### PR TITLE
Plumb Vote Certificate into BankingStage

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -119,7 +119,7 @@ solana-cost-model = { workspace = true, features = ["dev-context-only-utils"] }
 solana-ledger = { workspace = true, features = ["dev-context-only-utils"] }
 solana-logger = { workspace = true }
 solana-net-utils = { workspace = true, features = ["dev-context-only-utils"] }
-solana-poh = { workspace = true, features = ["dev-context-only-utils"] }
+solana-poh = { workspace = true, features = [ "dev-context-only-utils"] }
 solana-program-runtime = { workspace = true, features = ["metrics"] }
 solana-rpc = { workspace = true, features = ["dev-context-only-utils"] }
 solana-sdk = { workspace = true, features = ["dev-context-only-utils"] }
@@ -139,6 +139,9 @@ test-case = { workspace = true }
 sysctl = { workspace = true }
 
 [features]
+alpenglow = [
+    "solana-poh/alpenglow"
+]
 dev-context-only-utils = [
     "solana-perf/dev-context-only-utils",
     "solana-runtime/dev-context-only-utils",

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -119,7 +119,6 @@ impl Consumer {
         let mut consumed_buffered_packets_count = 0;
         let mut proc_start = Measure::start("consume_buffered_process");
         let num_packets_to_process = unprocessed_transaction_storage.len();
-
         let reached_end_of_slot = unprocessed_transaction_storage.process_packets(
             bank_start.working_bank.clone(),
             banking_stage_stats,

--- a/core/src/banking_stage/decision_maker.rs
+++ b/core/src/banking_stage/decision_maker.rs
@@ -42,6 +42,11 @@ impl DecisionMaker {
         }
     }
 
+    #[cfg(feature = "alpenglow")]
+    pub(crate) fn poh_recorder(&self) -> Arc<RwLock<PohRecorder>> {
+        self.poh_recorder.clone()
+    }
+
     pub(crate) fn make_consume_or_forward_decision(&self) -> BufferedPacketsDecision {
         let decision;
         {
@@ -132,6 +137,8 @@ mod tests {
     fn test_buffered_packet_decision_bank_start() {
         let bank = Arc::new(Bank::default_for_tests());
         let bank_start = BankStart {
+            #[cfg(feature = "alpenglow")]
+            vote_certificate: Arc::new(RwLock::new(None)),
             working_bank: bank,
             bank_creation_time: Arc::new(Instant::now()),
         };
@@ -221,6 +228,8 @@ mod tests {
         let my_pubkey1 = solana_pubkey::new_rand();
         let bank = Arc::new(Bank::default_for_tests());
         let bank_start = Some(BankStart {
+            #[cfg(feature = "alpenglow")]
+            vote_certificate: Arc::new(RwLock::new(None)),
             working_bank: bank,
             bank_creation_time: Arc::new(Instant::now()),
         });

--- a/core/src/banking_stage/leader_slot_metrics.rs
+++ b/core/src/banking_stage/leader_slot_metrics.rs
@@ -610,6 +610,10 @@ impl LeaderSlotMetricsTracker {
         }
     }
 
+    pub fn id(&self) -> u32 {
+        self.id
+    }
+
     // Check leader slot, return MetricsTrackerAction to be applied by apply_action()
     pub(crate) fn check_leader_slot_boundary(
         &mut self,
@@ -1088,6 +1092,9 @@ impl LeaderSlotMetricsTracker {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "alpenglow")]
+    use std::sync::RwLock;
+
     use {
         super::*,
         solana_pubkey::Pubkey,
@@ -1107,6 +1114,8 @@ mod tests {
         let genesis = create_genesis_config(10);
         let first_bank = Arc::new(Bank::new_for_tests(&genesis.genesis_config));
         let first_poh_recorder_bank = BankStart {
+            #[cfg(feature = "alpenglow")]
+            vote_certificate: Arc::new(RwLock::new(None)),
             working_bank: first_bank.clone(),
             bank_creation_time: Arc::new(Instant::now()),
         };
@@ -1118,6 +1127,8 @@ mod tests {
             first_bank.slot() + 1,
         ));
         let next_poh_recorder_bank = BankStart {
+            #[cfg(feature = "alpenglow")]
+            vote_certificate: Arc::new(RwLock::new(None)),
             working_bank: next_bank.clone(),
             bank_creation_time: Arc::new(Instant::now()),
         };

--- a/core/src/banking_stage/packet_deserializer.rs
+++ b/core/src/banking_stage/packet_deserializer.rs
@@ -98,7 +98,7 @@ impl PacketDeserializer {
 
     /// Deserialize packet batches, aggregates tracer packet stats, and collect
     /// them into ReceivePacketResults
-    fn deserialize_and_collect_packets(
+    pub(crate) fn deserialize_and_collect_packets(
         packet_count: usize,
         banking_batches: &[BankingPacketBatch],
         packet_filter: impl Fn(

--- a/poh/Cargo.toml
+++ b/poh/Cargo.toml
@@ -19,6 +19,7 @@ solana-hash = { workspace = true }
 solana-ledger = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
+solana-perf = { workspace = true }
 solana-poh-config = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-runtime = { workspace = true }

--- a/poh/src/poh_service.rs
+++ b/poh/src/poh_service.rs
@@ -107,6 +107,11 @@ impl PohService {
         let tick_producer = Builder::new()
             .name("solPohTickProd".to_string())
             .spawn(move || {
+                #[cfg(feature = "alpenglow")]
+                // Must be a low power tick producer which only waits for a single tick
+                assert!(
+                    poh_config.hashes_per_tick.is_none() && poh_config.target_tick_count.is_none()
+                );
                 if poh_config.hashes_per_tick.is_none() {
                     if poh_config.target_tick_count.is_none() {
                         Self::low_power_tick_producer(


### PR DESCRIPTION
#### Problem
Vote Certificate is missing from block creation in BankingStage

#### Summary of Changes
For the new consensus mechanism, every block X that descends from block Y needs a "certificate", essentially a vector of 67% of VoteTransaction included in block X for every block in the range [Y, X]

Otherwise block X is considered invalid

Now by the time the leader makes a block X, we can assume he has all the certificates sitting around, so he just needs to make sure BankingStage will include those Vec<VoteTransaction> in the block.

In this PR, starting from ReplayStage which holds these certificates:

1. In maybe_start_leader() when we set the block in PoH via poh_recorder.lock().unwrap().set_bank(&tpu_bank);, also pass along the necessary certificates
PohRecorder saves these certificates in BankStarthttps://github.com/anza-xyz/agave/blob/68536a665b97f80eb25c97360a9de1abdcf723dc/poh/src/poh_recorder.rs#L66-L69

2. PohRecorder saves these certificates in BankStarthttps://github.com/anza-xyz/agave/blob/68536a665b97f80eb25c97360a9de1abdcf723dc/poh/src/poh_recorder.rs#L66-L69
in the `WorkingBank`

3.  BankingStage main loop finds BankStart when it makes the block: [https://github.com/anza-xyz/agave/blob/68536a665b97f80eb25c97360a9de1abdcf723dc/core/src/banking_stage.rs#L688
consumer](https://github.com/anza-xyz/alpenglow/blob/8463a4323fdb604bee0208a9bc0e63f035656ef1/core/src/banking_stage.rs#L771-L789) For banking id  thread = 1 the tpu thread adds the certificate to the UnprocessedTransactionStorage::VoteStorage for votes.

5. Then when we drain from the vote storage we also drain from the vote_certificate to include in the block

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
