### PR TITLE
poh: always process record receiver

### DIFF
--- a/poh/src/poh_service.rs
+++ b/poh/src/poh_service.rs
@@ -231,6 +231,14 @@ impl PohService {
             }
 
             let Some(CurrentLeaderBank { bank, start }) = &current_leader_bank else {
+                // Even if the bank has been cleared, ensure that any leftover records are cleared
+                Self::read_record_receiver_and_process(
+                    &poh_recorder,
+                    &record_receiver,
+                    // Don't block
+                    Duration::from_millis(1),
+                );
+
                 continue;
             };
 


### PR DESCRIPTION
Split this from #118 

#### Problem
If the working bank is cleared while the certificate is being committed, we can deadlock as the `record_receiver` never clears the certificate records.

#### Summary of Changes
Even if the bank has been cleared, process the `record_receiver`

