### PR TITLE
replay: remove towerbft data structures from alpenglow set root

### DIFF
--- a/core/src/alpenglow_consensus/voting_loop.rs
+++ b/core/src/alpenglow_consensus/voting_loop.rs
@@ -13,14 +13,8 @@ use {
         commitment_service::{
             AlpenglowCommitmentAggregationData, AlpenglowCommitmentType, CommitmentAggregationData,
         },
-        consensus::{
-            heaviest_subtree_fork_choice::HeaviestSubtreeForkChoice, progress_map::ProgressMap,
-        },
-        repair::cluster_slot_state_verifier::{
-            DuplicateConfirmedSlots, DuplicateSlotsTracker, EpochSlotsFrozenSlots,
-        },
+        consensus::progress_map::ProgressMap,
         replay_stage::{Finalizer, ReplayStage, MAX_VOTE_SIGNATURES},
-        unfrozen_gossip_verified_vote_hashes::UnfrozenGossipVerifiedVoteHashes,
         voting_service::VoteOp,
     },
     alpenglow_vote::vote::Vote,
@@ -47,7 +41,6 @@ use {
     },
     solana_sdk::{
         clock::{Slot, NUM_CONSECUTIVE_LEADER_SLOTS},
-        hash::Hash,
         pubkey::Pubkey,
         signature::{Keypair, Signature, Signer},
         transaction::Transaction,
@@ -770,11 +763,9 @@ impl VotingLoop {
         vctx.vote_history.set_root(new_root);
         cert_pool.purge(new_root);
         ctx.cert_tracker.write().unwrap().set_root(new_root);
-        // TODO(ashwin): AG doesn't need this bank
-        let bank = ctx.bank_forks.read().unwrap().working_bank();
         if let Err(e) = ReplayStage::check_and_handle_new_root(
             &ctx.my_pubkey,
-            bank.as_ref(),
+            slot,
             new_root,
             ctx.bank_forks.as_ref(),
             &mut ctx.progress,
@@ -783,18 +774,11 @@ impl VotingLoop {
             accounts_background_request_sender,
             &ctx.rpc_subscriptions,
             Some(new_root),
-            // TODO(ashwin): AG doesn't need most of these
-            // we should stop populating them after the migration
-            // and remove them here
-            &mut HeaviestSubtreeForkChoice::new((0, Hash::default())),
             bank_notification_sender,
-            &mut DuplicateSlotsTracker::default(),
-            &mut DuplicateConfirmedSlots::default(),
-            &mut UnfrozenGossipVerifiedVoteHashes::default(),
             &mut vctx.has_new_vote_been_rooted,
             &mut vctx.voted_signatures,
-            &mut EpochSlotsFrozenSlots::default(),
             drop_bank_sender,
+            None,
         ) {
             error!("Unable to set root: {e:?}");
             return None;

--- a/core/tests/unified_scheduler.rs
+++ b/core/tests/unified_scheduler.rs
@@ -15,7 +15,7 @@ use {
         repair::cluster_slot_state_verifier::{
             DuplicateConfirmedSlots, DuplicateSlotsTracker, EpochSlotsFrozenSlots,
         },
-        replay_stage::ReplayStage,
+        replay_stage::{ReplayStage, TowerBFTStructures},
         unfrozen_gossip_verified_vote_hashes::UnfrozenGossipVerifiedVoteHashes,
     },
     solana_entry::entry::Entry,
@@ -162,20 +162,23 @@ fn test_scheduler_waited_by_drop_bank_service() {
             .into_iter()
             .map(|slot| (slot, Hash::default()))
             .collect();
+        let tbft_structs = TowerBFTStructures {
+            heaviest_subtree_fork_choice: &mut heaviest_subtree_fork_choice,
+            duplicate_slots_tracker: &mut duplicate_slots_tracker,
+            duplicate_confirmed_slots: &mut duplicate_confirmed_slots,
+            unfrozen_gossip_verified_vote_hashes: &mut unfrozen_gossip_verified_vote_hashes,
+            epoch_slots_frozen_slots: &mut epoch_slots_frozen_slots,
+        };
         ReplayStage::handle_new_root(
             root,
             &bank_forks,
             &mut progress,
             &AbsRequestSender::default(),
             None,
-            &mut heaviest_subtree_fork_choice,
-            &mut duplicate_slots_tracker,
-            &mut duplicate_confirmed_slots,
-            &mut unfrozen_gossip_verified_vote_hashes,
             &mut true,
             &mut Vec::new(),
-            &mut epoch_slots_frozen_slots,
             &drop_bank_sender1,
+            Some(tbft_structs),
         )
         .unwrap();
     }


### PR DESCRIPTION
#### Problem
We have a bunch of tower bft related data structures that are not needed in Alpenglow.


#### Summary of Changes
Remove them from set root, and instead manually clean them up when alpenglow is active

Fixes #65 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
