### PR TITLE
split out async block production loop, only need cert for first block

### DIFF
--- a/core/src/alpenglow_consensus.rs
+++ b/core/src/alpenglow_consensus.rs
@@ -60,14 +60,3 @@ pub const SAFE_TO_NOTAR_MIN_NOTARIZE_FOR_NOTARIZE_OR_SKIP: f64 = 0.2;
 pub const SAFE_TO_NOTAR_MIN_NOTARIZE_AND_SKIP: f64 = 0.6;
 
 pub const SAFE_TO_SKIP_THRESHOLD: f64 = 0.4;
-
-/// The amount of time a leader has to build their block in ms
-pub const BLOCKTIME: u128 = 400;
-
-/// The maximum message delay in ms
-pub const DELTA: u128 = 100;
-
-/// The Maximum delay a node can observe between entering the loop iteration
-/// for a window and receiving any shred of the first block of the leader.
-/// As a conservative global constant we set this to 3 * DELTA
-pub const DELTA_TIMEOUT: u128 = 300;

--- a/core/src/alpenglow_consensus/certificate_pool.rs
+++ b/core/src/alpenglow_consensus/certificate_pool.rs
@@ -501,7 +501,8 @@ impl CertificatePool {
         (voted_stake - top_notarized_stake) as f64 / total_stake as f64 >= SAFE_TO_SKIP_THRESHOLD
     }
 
-    /// Determines if the leader can start based on notarization and skip certificates.
+    /// Determines if we can produce `my_leader_slot` with parent `parent_slot`
+    /// based on the certificates in the pool.
     pub fn make_start_leader_decision(
         &self,
         my_leader_slot: Slot,

--- a/core/src/banking_simulation.rs
+++ b/core/src/banking_simulation.rs
@@ -744,12 +744,14 @@ impl BankingSimulator {
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
         let poh_service = PohService::new(
             poh_recorder.clone(),
+            bank_forks.clone(),
             &genesis_config.poh_config,
             exit.clone(),
             bank.ticks_per_slot(),
             DEFAULT_PINNED_CPU_CORE,
             DEFAULT_HASHES_PER_BATCH,
             record_receiver,
+            false,
         );
 
         // Enable BankingTracer to approximate the real environment as close as possible because

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -746,7 +746,7 @@ pub fn update_bank_forks_and_poh_recorder_for_new_tpu_bank(
     poh_recorder
         .write()
         .unwrap()
-        .set_bank(tpu_bank, track_transaction_indexes);
+        .set_bank(tpu_bank, track_transaction_indexes, None);
 }
 
 #[allow(dead_code)]

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1343,12 +1343,14 @@ impl Validator {
 
         let poh_service = PohService::new(
             poh_recorder.clone(),
+            bank_forks.clone(),
             &genesis_config.poh_config,
             exit.clone(),
             bank_forks.read().unwrap().root_bank().ticks_per_slot(),
             config.poh_pinned_cpu_core,
             config.poh_hashes_per_batch,
             record_receiver,
+            /* track_transaction_indexes */ transaction_status_sender.is_some(),
         );
         assert_eq!(
             blockstore.get_new_shred_signals_len(),

--- a/core/tests/unified_scheduler.rs
+++ b/core/tests/unified_scheduler.rs
@@ -276,7 +276,7 @@ fn test_scheduler_producing_blocks() {
     poh_recorder
         .write()
         .unwrap()
-        .set_bank(tpu_bank.clone_with_scheduler(), false);
+        .set_bank(tpu_bank.clone_with_scheduler(), false, None);
     let tpu_bank = bank_forks.read().unwrap().working_bank_with_scheduler();
     assert_eq!(tpu_bank.transaction_count(), 0);
 

--- a/local-cluster/src/integration_tests.rs
+++ b/local-cluster/src/integration_tests.rs
@@ -63,6 +63,9 @@ use {
 pub const RUST_LOG_FILTER: &str =
     "error,solana_core::replay_stage=warn,solana_local_cluster=info,local_cluster=info";
 
+pub const AG_DEBUG_LOG_FILTER: &str =
+    "error,solana_core::replay_stage=info,solana_core::alpenglow_consensus=trace,solana_local_cluster=info,local_cluster=info,solana_poh::poh_recorder=trace,solana_poh::poh_service=trace";
+
 pub const DEFAULT_NODE_STAKE: u64 = 10 * LAMPORTS_PER_SOL;
 
 pub fn last_vote_in_tower(tower_path: &Path, node_pubkey: &Pubkey) -> Option<(Slot, Hash)> {

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -42,7 +42,7 @@ use {
             run_cluster_partition, run_kill_partition_switch_threshold, save_tower,
             setup_snapshot_validator_config, test_faulty_node, wait_for_duplicate_proof,
             wait_for_last_vote_in_tower_to_land_in_ledger, SnapshotValidatorConfig,
-            ValidatorTestConfig, DEFAULT_NODE_STAKE, RUST_LOG_FILTER,
+            ValidatorTestConfig, AG_DEBUG_LOG_FILTER, DEFAULT_NODE_STAKE, RUST_LOG_FILTER,
         },
         local_cluster::{ClusterConfig, LocalCluster, DEFAULT_MINT_LAMPORTS},
         validator_configs::*,
@@ -137,7 +137,7 @@ fn test_local_cluster_start_and_exit_with_config() {
 }
 
 fn test_alpenglow_nodes_basic(num_nodes: usize, num_offline_nodes: usize, num_new_roots: usize) {
-    solana_logger::setup_with_default(RUST_LOG_FILTER);
+    solana_logger::setup_with_default(AG_DEBUG_LOG_FILTER);
     let validator_keys = (0..num_nodes)
         .map(|i| (Arc::new(keypair_from_seed(&[i as u8; 32]).unwrap()), true))
         .collect::<Vec<_>>();

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -143,6 +143,30 @@ impl BankForks {
         bank_forks
     }
 
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn new_empty_for_tests(root_bank: Arc<Bank>) -> Arc<RwLock<Self>> {
+        let root_slot = root_bank.slot();
+
+        let mut banks = HashMap::new();
+        banks.insert(
+            root_slot,
+            BankWithScheduler::new_without_scheduler(root_bank.clone()),
+        );
+
+        Arc::new(RwLock::new(Self {
+            root: Arc::new(AtomicSlot::new(root_slot)),
+            banks,
+            descendants: HashMap::default(),
+            snapshot_config: None,
+            accounts_hash_interval_slots: u64::MAX,
+            last_accounts_hash_slot: root_slot,
+            in_vote_only_mode: Arc::new(AtomicBool::new(false)),
+            highest_slot_at_startup: 0,
+            scheduler_pool: None,
+            dumped_slot_subscribers: vec![],
+        }))
+    }
+
     pub fn banks(&self) -> &HashMap<Slot, BankWithScheduler> {
         &self.banks
     }


### PR DESCRIPTION
#### Problem
The current voting loop produces each leader block only after the certificate is obtained for the previous block. It also maintains a separate timer to determine when the block should end. There is some inefficient lock contention with poh recorder/bank forks here as the voting loop is responsible for adding the next block once replay/banking stage is complete.

Only the first leader block needs a certificate so in fact the rest of the window should be built independent of the voting loop.

#### Summary of Changes
Instead, similar to the paper we spread responsibility in two threads, the voting loop and the block creation loop (lives in poh_service):

Voting loop:
- At the beginning of the leader window, block on replay until we can either insert our first empty leader bank or our slot ends up getting skipped
- This requires communication from replay, as we could have seen certificates for the previous leader through all-to-all, however our replay of the previous leader's blocks have not yet completed.
- We use a mutex/condvar here to avoid tight spin and minimal contention
- The voting loop then continues as normal, it is not responsible for inserting empty banks for the rest of the leader window.

Poh service:
- After the first leader block is produced, the poh service keeps track of the same skip timer as the voting loop
- It uses this timer to control when the leader block should end
- The remaining three leader blocks are inserted here after the previous leader block has been cleared, without waiting for any certificates

For comparison, the reference implementation does something similar https://github.com/qkniep/alpenglow/blob/90f15866d0e067fc87b515a986710e383ee20022/src/consensus/mod.rs#L196 the difference is that:
- The block production loop is entirely separate from the voting loop, they share the certificate pool but loop through slots separately.
- We opt to keep this in one loop so we don't have to make the certificate pool thread safe. We simply slot in the voting logic here https://github.com/qkniep/alpenglow/blob/90f15866d0e067fc87b515a986710e383ee20022/src/consensus/mod.rs#L270
- The reference implementation produces all 4 blocks synchronously since they are fake blocks, however we don't have the luxury. After creating the first empty bank in the voting loop, the rest of the window is handled asynchronously , filled in by banking stage and inserted/ cleared by poh service.


Fixes #133 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
