### PR TITLE
[core] Add `VoteSignature` trait

### DIFF
--- a/core/src/alpenglow_consensus.rs
+++ b/core/src/alpenglow_consensus.rs
@@ -4,6 +4,7 @@ pub mod utils;
 pub mod vote_certificate;
 pub mod vote_history;
 pub mod vote_history_storage;
+pub mod vote_signature;
 pub mod voting_loop;
 
 pub type Stake = u64;

--- a/core/src/alpenglow_consensus/vote_signature.rs
+++ b/core/src/alpenglow_consensus/vote_signature.rs
@@ -1,0 +1,51 @@
+use solana_sdk::transaction::VersionedTransaction;
+
+/// A trait for signature types used in vote transactions
+pub trait VoteSignature {
+    /// Type of an aggregate set of signatures
+    type Aggregate: Clone;
+
+    /// Extract signature from a transaction
+    fn from_transaction(transaction: VersionedTransaction) -> Self;
+
+    /// Create an empty aggregate set of signatures
+    fn empty_aggregate() -> Self::Aggregate;
+
+    /// Add a set of signatures to an aggregate set
+    fn aggregate_with<'a, I>(aggregate: &mut Self::Aggregate, signatures: I)
+    where
+        I: IntoIterator<Item = &'a Self>,
+        Self: 'a;
+
+    /// Aggregate a set of signatures
+    fn aggregate<'a, I>(signatures: I) -> Self::Aggregate
+    where
+        I: IntoIterator<Item = &'a Self>,
+        Self: 'a,
+    {
+        let mut aggregate = Self::empty_aggregate();
+        Self::aggregate_with(&mut aggregate, signatures);
+        aggregate
+    }
+}
+
+/// `VersionedTransaction`s can be used as vote signatures
+impl VoteSignature for VersionedTransaction {
+    type Aggregate = Vec<VersionedTransaction>;
+
+    fn from_transaction(transaction: VersionedTransaction) -> Self {
+        transaction
+    }
+
+    fn empty_aggregate() -> Self::Aggregate {
+        Vec::new()
+    }
+
+    fn aggregate_with<'a, I>(aggregate: &mut Self::Aggregate, signatures: I)
+    where
+        I: IntoIterator<Item = &'a Self>,
+        Self: 'a,
+    {
+        aggregate.extend(signatures.into_iter().cloned());
+    }
+}

--- a/core/src/alpenglow_consensus/voting_loop.rs
+++ b/core/src/alpenglow_consensus/voting_loop.rs
@@ -45,7 +45,7 @@ use {
         pubkey::Pubkey,
         signature::{Keypair, Signature, Signer},
         timing::timestamp,
-        transaction::Transaction,
+        transaction::{Transaction, VersionedTransaction},
     },
     std::{
         collections::{BTreeMap, BTreeSet},
@@ -486,7 +486,7 @@ impl VotingLoop {
     fn branch_notarized(
         my_pubkey: &Pubkey,
         slot: Slot,
-        cert_pool: &CertificatePool,
+        cert_pool: &CertificatePool<VersionedTransaction>,
         cert_tracker: &RwLock<ReplayCertificateTracker>,
     ) -> bool {
         if let Some(size) = cert_pool.is_notarization_certificate_complete(slot) {
@@ -511,7 +511,7 @@ impl VotingLoop {
         my_pubkey: &Pubkey,
         slot: Slot,
         root_bank_cache: &mut RootBankCache,
-        cert_pool: &mut CertificatePool,
+        cert_pool: &mut CertificatePool<VersionedTransaction>,
         cert_tracker: &RwLock<ReplayCertificateTracker>,
     ) -> bool {
         let root_bank = root_bank_cache.root_bank();
@@ -549,7 +549,7 @@ impl VotingLoop {
     fn maybe_start_leader(
         leader: &Option<Pubkey>,
         slot: Slot,
-        cert_pool: &mut CertificatePool,
+        cert_pool: &mut CertificatePool<VersionedTransaction>,
         slot_status_notifier: &Option<SlotStatusNotifier>,
         track_transaction_indexes: bool,
         ctx: &SharedContext,
@@ -745,7 +745,7 @@ impl VotingLoop {
     /// and return the root
     fn maybe_set_root(
         slot: Slot,
-        cert_pool: &mut CertificatePool,
+        cert_pool: &mut CertificatePool<VersionedTransaction>,
         accounts_background_request_sender: &AbsRequestSender,
         bank_notification_sender: &Option<BankNotificationSenderConfig>,
         drop_bank_sender: &Sender<Vec<BankWithScheduler>>,
@@ -807,7 +807,7 @@ impl VotingLoop {
         start: Slot,
         end: Slot,
         root_bank_cache: &mut RootBankCache,
-        cert_pool: &mut CertificatePool,
+        cert_pool: &mut CertificatePool<VersionedTransaction>,
         voting_context: &mut VotingContext,
     ) {
         // Extend the previous range if possible
@@ -829,7 +829,7 @@ impl VotingLoop {
     fn refresh_skip(
         my_pubkey: &Pubkey,
         root_bank_cache: &mut RootBankCache,
-        cert_pool: &mut CertificatePool,
+        cert_pool: &mut CertificatePool<VersionedTransaction>,
         voting_context: &mut VotingContext,
     ) {
         let Some(skip_vote) = voting_context.vote_history.skip_votes.last().copied() else {
@@ -858,7 +858,7 @@ impl VotingLoop {
         bank: &Bank,
         is_leader: bool,
         blockstore: &Blockstore,
-        cert_pool: &mut CertificatePool,
+        cert_pool: &mut CertificatePool<VersionedTransaction>,
         voting_context: &mut VotingContext,
     ) -> bool {
         debug_assert!(bank.is_frozen());
@@ -922,7 +922,7 @@ impl VotingLoop {
         vote: Vote,
         is_refresh: bool,
         bank: &Bank,
-        cert_pool: &mut CertificatePool,
+        cert_pool: &mut CertificatePool<VersionedTransaction>,
         context: &mut VotingContext,
     ) {
         let mut generate_time = Measure::start("generate_alpenglow_vote");
@@ -1065,7 +1065,7 @@ impl VotingLoop {
     fn ingest_votes_into_certificate_pool(
         my_pubkey: &Pubkey,
         vote_receiver: &VoteReceiver,
-        cert_pool: &mut CertificatePool,
+        cert_pool: &mut CertificatePool<VersionedTransaction>,
         bank_forks: &RwLock<BankForks>,
     ) -> Option<Slot> {
         let mut cached_root_bank = None;

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -85,7 +85,7 @@ use {
         saturating_add_assign,
         signature::{Keypair, Signature, Signer},
         timing::timestamp,
-        transaction::Transaction,
+        transaction::{Transaction, VersionedTransaction},
     },
     solana_timings::ExecuteTimings,
     solana_vote::vote_transaction::VoteTransaction,
@@ -3669,7 +3669,7 @@ impl ReplayStage {
         let parent_hash = parent_bank.hash();
         let mut notarization_stake = 0;
         let mut notarization_size = 0;
-        let mut skip_pool = SkipPool::new();
+        let mut skip_pool: SkipPool<VersionedTransaction> = SkipPool::new();
 
         let leader_slot_idx = leader_slot_index(bank.slot());
         if leader_slot_idx > 1 {
@@ -3711,7 +3711,7 @@ impl ReplayStage {
                         vote_state.latest_skip_start_slot(),
                         vote_state.latest_skip_end_slot(),
                     ),
-                    (),
+                    VersionedTransaction::default(),
                     *stake,
                 );
             });


### PR DESCRIPTION
#### Problem
I am looking into incorporating BLS signatures to certs. Since the signatures for ed25519 and bls logic is largely overlapping, I was thinking of organizing a signature as a trait and then work with generically for any signature type.

#### Summary of Changes
The main addition is the `VoteSignature` trait, which should represent either a ed25519 or a bls signature.

It has an associated type `Aggregate`, which should ultimately be the certificate type:
- for ed25519 (currently represented as `VersionedTransaction`), it should be `Vec<VersionedTransaction>`
- for bls signatures, it should be the batch aggregated signature, so just `BlsSignature`

This trait has the `from_transaction(transaction: VersionedTransaction)`, which extracts the signature from the transaction:
- for ed25519 (represented as `VersionedTransaction`), it should just be a copy of the transaction
- for BLS sig, we would look at instruction data and extract the signature from there

Finally, the trait has the `aggregate(signatures: ...)` function which creates aggregate signature type, which should ultimately be the signature(s) in the cert.

I implemented this trait for ed25519 (represented as `VersionedTransaction`). For BLS, I will add it in a follow-up PR (assuming that this PR is a right approach).

I updated the `VoteCertificate`, `CertificatePool`, and `SkipPool` to use this generic type in place of `VersionedTransaction`. For the functions in the voting loop, I just hard-coded the generic with `VersionedTransaction` for now, but we can make these functions generic too (assuming that this PR is a right approach).

Please let me know what you think about this general direction. I am less familiar with this side of the codebase, so please let me know if you think this is not the right approach. I can always revert and think of a another approach.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
