### PR TITLE
[bls] Add proof of possession proof for bls pubkeys

### DIFF
--- a/bls/src/proof_of_possession.rs
+++ b/bls/src/proof_of_possession.rs
@@ -1,0 +1,12 @@
+use {
+    crate::{keypair::BlsPubkey, Bls},
+    blstrs::G2Projective,
+};
+
+pub struct BlsProofOfPossession(pub G2Projective);
+impl BlsProofOfPossession {
+    /// Verify a proof of possession against a public key
+    pub fn verify(&self, public_key: &BlsPubkey) -> bool {
+        Bls::verify_proof_of_possession(public_key, self)
+    }
+}


### PR DESCRIPTION
#### Problem
The proof of possession (proof of knowledge) for proving that a BLS pubkey is valid is missing to prevent rogue attack.

#### Summary of Changes
Adding proof of possession functions following the specification in https://www.ietf.org/archive/id/draft-irtf-cfrg-bls-signature-05.html#name-proof-of-possession.

Part of https://github.com/anza-xyz/alpenglow/issues/48.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
