### PR TITLE
feat: support additional all-to-all listeners

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -8015,6 +8015,7 @@ pub(crate) mod tests {
             &vote_history_storage,
             vote_info,
             Arc::new(connection_cache),
+            None,
             &mut staked_validators_cache,
         );
 
@@ -8129,6 +8130,7 @@ pub(crate) mod tests {
             &vote_history_storage,
             vote_info,
             Arc::new(connection_cache),
+            None,
             &mut staked_validators_cache,
         );
 
@@ -8266,6 +8268,7 @@ pub(crate) mod tests {
             &vote_history_storage,
             vote_info,
             Arc::new(connection_cache),
+            None,
             &mut staked_validators_cache,
         );
 
@@ -8419,6 +8422,7 @@ pub(crate) mod tests {
             vote_history_storage,
             vote_info,
             Arc::new(connection_cache),
+            None,
             &mut staked_validators_cache,
         );
 

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -167,6 +167,7 @@ impl Tvu {
         wen_restart_repair_slots: Option<Arc<RwLock<Vec<Slot>>>>,
         slot_status_notifier: Option<SlotStatusNotifier>,
         vote_connection_cache: Arc<ConnectionCache>,
+        voting_service_additional_listeners: Option<&Vec<SocketAddr>>,
     ) -> Result<Self, String> {
         let in_wen_restart = wen_restart_repair_slots.is_some();
 
@@ -346,6 +347,7 @@ impl Tvu {
             vote_history_storage.clone(),
             vote_connection_cache.clone(),
             bank_forks.clone(),
+            voting_service_additional_listeners.cloned(),
         );
 
         let warm_quic_cache_service = create_cache_warmer_if_needed(
@@ -605,6 +607,7 @@ pub mod tests {
             wen_restart_repair_slots,
             None,
             Arc::new(connection_cache),
+            None,
         )
         .expect("assume success");
         if enable_wen_restart {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -317,6 +317,7 @@ pub struct ValidatorConfig {
     pub replay_transactions_threads: NonZeroUsize,
     pub tvu_shred_sigverify_threads: NonZeroUsize,
     pub delay_leader_block_for_pending_fork: bool,
+    pub voting_service_additional_listeners: Option<Vec<SocketAddr>>,
 }
 
 impl Default for ValidatorConfig {
@@ -391,6 +392,7 @@ impl Default for ValidatorConfig {
             replay_transactions_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
             tvu_shred_sigverify_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
             delay_leader_block_for_pending_fork: false,
+            voting_service_additional_listeners: None,
         }
     }
 }
@@ -1555,6 +1557,7 @@ impl Validator {
             wen_restart_repair_slots.clone(),
             slot_status_notifier,
             vote_connection_cache,
+            config.voting_service_additional_listeners.as_ref(),
         )
         .map_err(ValidatorError::Other)?;
 

--- a/core/src/voting_service.rs
+++ b/core/src/voting_service.rs
@@ -92,6 +92,7 @@ impl VotingService {
         vote_history_storage: Arc<dyn VoteHistoryStorage>,
         connection_cache: Arc<ConnectionCache>,
         bank_forks: Arc<RwLock<BankForks>>,
+        additional_listeners: Option<Vec<SocketAddr>>,
     ) -> Self {
         let thread_hdl = Builder::new()
             .name("solVoteService".to_string())
@@ -111,6 +112,7 @@ impl VotingService {
                         vote_history_storage.as_ref(),
                         vote_op,
                         connection_cache.clone(),
+                        additional_listeners.as_ref(),
                         &mut staked_validators_cache,
                     );
                 }
@@ -162,6 +164,7 @@ impl VotingService {
         cluster_info: &ClusterInfo,
         tx: &Transaction,
         connection_cache: Arc<ConnectionCache>,
+        additional_listeners: Option<&Vec<SocketAddr>>,
         staked_validators_cache: &mut StakedValidatorsCache,
     ) {
         let (staked_validator_tpu_sockets, _) = staked_validators_cache
@@ -170,7 +173,13 @@ impl VotingService {
         if staked_validator_tpu_sockets.is_empty() {
             let _ = send_vote_transaction(cluster_info, tx, None, &connection_cache);
         } else {
-            for tpu_vote_socket in staked_validator_tpu_sockets {
+            let sockets = additional_listeners
+                .map(|v| v.as_slice())
+                .unwrap_or(&[])
+                .iter()
+                .chain(staked_validator_tpu_sockets.iter());
+
+            for tpu_vote_socket in sockets {
                 let _ = send_vote_transaction(
                     cluster_info,
                     tx,
@@ -188,6 +197,7 @@ impl VotingService {
         vote_history_storage: &dyn VoteHistoryStorage,
         vote_op: VoteOp,
         connection_cache: Arc<ConnectionCache>,
+        additional_listeners: Option<&Vec<SocketAddr>>,
         staked_validators_cache: &mut StakedValidatorsCache,
     ) {
         match vote_op {
@@ -226,6 +236,7 @@ impl VotingService {
                     cluster_info,
                     &tx,
                     connection_cache,
+                    additional_listeners,
                     staked_validators_cache,
                 );
 

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -75,6 +75,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         replay_transactions_threads: config.replay_transactions_threads,
         tvu_shred_sigverify_threads: config.tvu_shred_sigverify_threads,
         delay_leader_block_for_pending_fork: config.delay_leader_block_for_pending_fork,
+        voting_service_additional_listeners: config.voting_service_additional_listeners.clone(),
     }
 }
 


### PR DESCRIPTION
Within all-to-all broadcasting in `voting_service.rs`, support the ability to broadcast votes to an extra list of sockets.