### PR TITLE
[bls] Implement `PodInOption` and `ZeroableInOption` for bls types

### DIFF
--- a/bls/src/pod.rs
+++ b/bls/src/pod.rs
@@ -1,5 +1,5 @@
 use {
-    bytemuck::{Pod, Zeroable},
+    bytemuck::{Pod, PodInOption, Zeroable, ZeroableInOption},
     serde::{Deserialize, Serialize},
     serde_with::serde_as,
 };
@@ -112,21 +112,33 @@ impl Default for Pubkey {
 // wrappers around byte arrays.
 unsafe impl Zeroable for PubkeyCompressed {}
 unsafe impl Pod for PubkeyCompressed {}
+unsafe impl ZeroableInOption for PubkeyCompressed {}
+unsafe impl PodInOption for PubkeyCompressed {}
 
 unsafe impl Zeroable for Pubkey {}
 unsafe impl Pod for Pubkey {}
+unsafe impl ZeroableInOption for Pubkey {}
+unsafe impl PodInOption for Pubkey {}
 
 unsafe impl Zeroable for Signature {}
 unsafe impl Pod for Signature {}
+unsafe impl ZeroableInOption for Signature {}
+unsafe impl PodInOption for Signature {}
 
 unsafe impl Zeroable for SignatureCompressed {}
 unsafe impl Pod for SignatureCompressed {}
+unsafe impl ZeroableInOption for SignatureCompressed {}
+unsafe impl PodInOption for SignatureCompressed {}
 
 unsafe impl Zeroable for ProofOfPossessionCompressed {}
 unsafe impl Pod for ProofOfPossessionCompressed {}
+unsafe impl ZeroableInOption for ProofOfPossessionCompressed {}
+unsafe impl PodInOption for ProofOfPossessionCompressed {}
 
 unsafe impl Zeroable for ProofOfPossession {}
 unsafe impl Pod for ProofOfPossession {}
+unsafe impl ZeroableInOption for ProofOfPossession {}
+unsafe impl PodInOption for ProofOfPossession {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
#### Problem
The bls types implement `Pod` and `Zeroable`, but `Option<...>` variants don't implement `Pod` and `Zeroable` by default. Before, we had to create custom types (e.g. [this](https://github.com/solana-program/libraries/blob/main/pod/src/optional_keys.rs#L26)) to cleanly handle optional types, but it seems that we can now just implement `PodInOption` and `ZeroableInOption` traits.

#### Summary of Changes
Implement `PodInOption` and `ZeroableInOption` traits for the bls types.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
