### PR TITLE
[zk-keygen] Add bls keypair support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,7 +1182,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
 dependencies = [
  "borsh-derive 0.10.3",
- "hashbrown 0.13.2",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -6697,7 +6697,7 @@ dependencies = [
 [[package]]
 name = "solana-bls"
 version = "0.1.1"
-source = "git+https://github.com/anza-xyz/solana-sdk?branch=bls#9e1431b3e83310bb118c47404265d905acea2dce"
+source = "git+https://github.com/anza-xyz/solana-sdk?branch=bls#ce5dd055f2c6e3adacae2e21827f79ee0d3804b5"
 dependencies = [
  "base64 0.22.1",
  "blst",
@@ -6708,6 +6708,7 @@ dependencies = [
  "group",
  "rand 0.8.5",
  "serde",
+ "serde_json",
  "serde_with",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
@@ -11186,6 +11187,7 @@ dependencies = [
  "bs58",
  "clap 3.2.23",
  "dirs-next",
+ "solana-bls",
  "solana-clap-v3-utils",
  "solana-pubkey",
  "solana-remote-wallet",

--- a/zk-keygen/Cargo.toml
+++ b/zk-keygen/Cargo.toml
@@ -19,6 +19,7 @@ edition = { workspace = true }
 bs58 = { workspace = true }
 clap = { version = "3.1.5", features = ["cargo", "derive"] }
 dirs-next = { workspace = true }
+solana-bls = { workspace = true }
 solana-clap-v3-utils = { workspace = true }
 solana-remote-wallet = { workspace = true, features = ["default"] }
 solana-seed-derivable = { workspace = true }


### PR DESCRIPTION
#### Problem
There is no CLI tool to generate BLS keypair files yet.

#### Summary of Changes
Not sure if we need a cli tool for tests yet, but I added BLS keypair support to zk-keygen, which is a cli tool intended to generate keys for token22 and other zk applications.

Go to the `zk-keygen` directory and do:
```
cargo run -- --help
```
to list the commands.

To generate a new BLS keypair
```
cargo run -- new bls -o ./bls_keypair.json
```

To recover a BLS public key from a BLS keypair file
```
cargo run -- pubkey bls ./bls_keypair.json
```
