### PR TITLE
voting_loop: add parent ready tracker, fix WFSM / snapshot hack

### DIFF
--- a/core/src/alpenglow_consensus.rs
+++ b/core/src/alpenglow_consensus.rs
@@ -44,14 +44,17 @@ impl CertificateId {
         matches!(self, Self::FinalizeFast(_, _, _))
     }
 
+    #[allow(dead_code)]
     pub(crate) fn is_finalization_variant(&self) -> bool {
         matches!(self, Self::Finalize(_) | Self::FinalizeFast(_, _, _))
     }
 
+    #[allow(dead_code)]
     pub(crate) fn is_notarize_fallback(&self) -> bool {
         matches!(self, Self::NotarizeFallback(_, _, _))
     }
 
+    #[allow(dead_code)]
     pub(crate) fn is_skip(&self) -> bool {
         matches!(self, Self::Skip(_))
     }

--- a/core/src/alpenglow_consensus.rs
+++ b/core/src/alpenglow_consensus.rs
@@ -6,6 +6,7 @@ use {
 
 pub mod block_creation_loop;
 pub mod certificate_pool;
+pub mod parent_ready_tracker;
 pub mod transaction;
 pub mod utils;
 pub mod vote_certificate;
@@ -51,6 +52,10 @@ impl CertificateId {
         matches!(self, Self::NotarizeFallback(_, _, _))
     }
 
+    pub(crate) fn is_skip(&self) -> bool {
+        matches!(self, Self::Skip(_))
+    }
+
     pub(crate) fn to_block(self) -> Option<Block> {
         match self {
             CertificateId::Finalize(_) | CertificateId::Skip(_) => None,
@@ -64,8 +69,7 @@ impl CertificateId {
 
     /// "Critical" certs are the certificates necessary to make progress
     /// We do not consider the next slot for voting until we've seen either
-    /// a Skip certificate (SkipCertified) or a NotarizeFallback certificate
-    /// (BranchCertified/ParentReady).
+    /// a Skip certificate or a NotarizeFallback certificate for ParentReady
     ///
     /// Note: Notarization certificates necessarily generate a
     /// NotarizeFallback certificate as well

--- a/core/src/alpenglow_consensus/block_creation_loop.rs
+++ b/core/src/alpenglow_consensus/block_creation_loop.rs
@@ -3,7 +3,7 @@
 //! within the block timeouts. Responsible for inserting empty banks for
 //! banking stage to fill, and clearing banks once the timeout has been reached.
 use {
-    super::block_timeout,
+    super::{block_timeout, Block},
     crate::{
         banking_trace::BankingTracer,
         replay_stage::{Finalizer, ReplayStage},
@@ -81,7 +81,7 @@ pub struct ReplayHighestFrozen {
 pub struct LeaderWindowInfo {
     pub start_slot: Slot,
     pub end_slot: Slot,
-    pub parent_slot: Slot,
+    pub parent_block: Block,
     pub skip_timer: Instant,
 }
 
@@ -161,7 +161,8 @@ pub fn start_loop(config: BlockCreationLoopConfig) {
         let LeaderWindowInfo {
             start_slot,
             end_slot,
-            parent_slot,
+            // TODO: handle duplicate blocks by using the hash here
+            parent_block: (parent_slot, _, _),
             skip_timer,
         } = {
             let window_info = leader_window_notifier.window_info.lock().unwrap();

--- a/core/src/alpenglow_consensus/certificate_pool.rs
+++ b/core/src/alpenglow_consensus/certificate_pool.rs
@@ -1,6 +1,7 @@
 use {
     super::{
         certificate_limits_and_vote_types,
+        parent_ready_tracker::ParentReadyTracker,
         vote_certificate::{CertificateError, LegacyVoteCertificate, VoteCertificate},
         vote_history::VoteHistory,
         vote_pool::{VoteKey, VotePool},
@@ -73,6 +74,8 @@ pub struct CertificatePool<VC: VoteCertificate> {
     vote_pools: BTreeMap<PoolId, VotePool<VC>>,
     /// Completed certificates
     completed_certificates: BTreeMap<CertificateId, VC>,
+    /// Parent ready tracker
+    pub(crate) parent_ready_tracker: ParentReadyTracker,
     /// Highest block that has a NotarizeFallback certificate, for use in producing our leader window
     highest_notarized_fallback: Option<(Slot, Hash, Hash)>,
     /// Highest slot that has a Finalized variant certificate, for use in notifying RPC
@@ -91,9 +94,19 @@ pub struct CertificatePool<VC: VoteCertificate> {
 
 impl<VC: VoteCertificate> CertificatePool<VC> {
     pub fn new_from_root_bank(
+        my_pubkey: Pubkey,
         bank: &Bank,
         certificate_sender: Option<Sender<(CertificateId, VC)>>,
     ) -> Self {
+        // To account for genesis and snapshots we allow default block id until
+        // block id can be serialized  as part of the snapshot
+        let root_block = (
+            bank.slot(),
+            bank.block_id().unwrap_or_default(),
+            bank.hash(),
+        );
+        let parent_ready_tracker = ParentReadyTracker::new(my_pubkey, root_block);
+
         let mut pool = Self {
             vote_pools: BTreeMap::new(),
             completed_certificates: BTreeMap::new(),
@@ -104,6 +117,7 @@ impl<VC: VoteCertificate> CertificatePool<VC> {
             root: bank.slot(),
             root_epoch: Epoch::default(),
             certificate_sender,
+            parent_ready_tracker,
         };
 
         // Update the epoch_stakes_map and root
@@ -221,6 +235,15 @@ impl<VC: VoteCertificate> CertificatePool<VC> {
                 {
                     self.highest_notarized_fallback =
                         Some((slot, block_id.unwrap(), bank_hash.unwrap()));
+                    self.parent_ready_tracker.add_new_notar_fallback((
+                        slot,
+                        block_id.unwrap(),
+                        bank_hash.unwrap(),
+                    ));
+                }
+
+                if cert_id.is_skip() {
+                    self.parent_ready_tracker.add_new_skip(slot);
                 }
 
                 if cert_id.is_finalization_variant()
@@ -254,6 +277,16 @@ impl<VC: VoteCertificate> CertificatePool<VC> {
 
     pub(crate) fn insert_certificate(&mut self, cert_id: CertificateId, cert: VC) {
         self.completed_certificates.insert(cert_id, cert);
+
+        match cert_id {
+            CertificateId::NotarizeFallback(slot, block_id, bank_hash) => self
+                .parent_ready_tracker
+                .add_new_notar_fallback((slot, block_id, bank_hash)),
+            CertificateId::Skip(slot) => self.parent_ready_tracker.add_new_skip(slot),
+            CertificateId::Finalize(_)
+            | CertificateId::FinalizeFast(_, _, _)
+            | CertificateId::Notarize(_, _, _) => (),
+        }
     }
 
     /// Adds the new vote the the certificate pool. If a new certificate is created
@@ -320,8 +353,6 @@ impl<VC: VoteCertificate> CertificatePool<VC> {
 
     /// The highest notarized fallback slot, for use as the parent slot in leader window
     pub fn highest_notarized_fallback(&self) -> Option<(Slot, Hash, Hash)> {
-        // TODO(ashwin): When updating voting loop for duplicate blocks, add parent tracker to
-        // make this the true "highest branchCertified block". For now this sufficies.
         self.highest_notarized_fallback
     }
 
@@ -362,8 +393,7 @@ impl<VC: VoteCertificate> CertificatePool<VC> {
             .unwrap_or(0)
     }
 
-    #[cfg(test)]
-    fn highest_finalized_slot(&self) -> Slot {
+    pub(crate) fn highest_finalized_slot(&self) -> Slot {
         self.completed_certificates
             .iter()
             .filter_map(|(cert_id, _)| match cert_id {
@@ -391,9 +421,8 @@ impl<VC: VoteCertificate> CertificatePool<VC> {
 
     /// Checks if the any block in slot `slot` has received a `NotarizeFallback` certificate, if so return
     /// the size of the certificate
+    #[cfg(test)]
     pub fn slot_notarized_fallback(&self, slot: Slot) -> Option<usize> {
-        // TODO(ashwin): when updating voting loop for duplicate blocks, add parent tracker to make this
-        // a true "branchCertified". For now this sufficies as branchCertified in the sequential loop
         self.completed_certificates
             .iter()
             .find_map(|(cert_id, cert)| {
@@ -511,8 +540,8 @@ impl<VC: VoteCertificate> CertificatePool<VC> {
         (voted_stake - top_notarized_stake) as f64 / total_stake as f64 >= SAFE_TO_SKIP_THRESHOLD
     }
 
-    /// Determines if the leader can start based on notarization and skip certificates.
-    pub fn make_start_leader_decision(
+    #[cfg(test)]
+    fn make_start_leader_decision(
         &self,
         my_leader_slot: Slot,
         parent_slot: Slot,
@@ -576,7 +605,8 @@ pub(crate) fn load_from_blockstore(
     blockstore: &Blockstore,
     certificate_sender: Option<Sender<(CertificateId, LegacyVoteCertificate)>>,
 ) -> CertificatePool<LegacyVoteCertificate> {
-    let mut cert_pool = CertificatePool::new_from_root_bank(root_bank, certificate_sender);
+    let mut cert_pool =
+        CertificatePool::new_from_root_bank(*my_pubkey, root_bank, certificate_sender);
     for (slot, slot_cert) in blockstore
         .slot_certificates_iterator(root_bank.slot())
         .unwrap()
@@ -669,7 +699,7 @@ mod tests {
         let root_bank = bank_forks.read().unwrap().root_bank();
         (
             validator_keypairs,
-            CertificatePool::new_from_root_bank(&root_bank.clone(), None),
+            CertificatePool::new_from_root_bank(Pubkey::new_unique(), &root_bank.clone(), None),
         )
     }
 
@@ -1612,7 +1642,7 @@ mod tests {
         let bank_forks = create_bank_forks(&validator_keypairs);
         let root_bank = bank_forks.read().unwrap().root_bank();
         let mut pool: CertificatePool<LegacyVoteCertificate> =
-            CertificatePool::new_from_root_bank(&root_bank.clone(), None);
+            CertificatePool::new_from_root_bank(Pubkey::new_unique(), &root_bank.clone(), None);
         assert_eq!(pool.root(), 0);
 
         let new_bank = Arc::new(create_bank(2, root_bank, &Pubkey::new_unique()));

--- a/core/src/alpenglow_consensus/parent_ready_tracker.rs
+++ b/core/src/alpenglow_consensus/parent_ready_tracker.rs
@@ -1,0 +1,265 @@
+//! Tracks the parent-ready condition
+//!
+//! The parent-ready condition pertains to a slot `s` and a block hash `hash(b)`,
+//! where `s` is the first slot of a leader window and `s > slot(b)`.
+//! Specifically, it is defined as the following:
+//!   - Block `b` is notarized or notarized-fallback, and
+//!   - slots `slot(b) + 1` (inclusive) to `s` (non-inclusive) are skip-certified.
+//!
+//! Additional restriction on notarization votes ensure that the parent-ready
+//! condition holds for a block `b` only if it also holds for all ancestors of `b`.
+//! Together this ensures that the block `b` is a valid parent for block
+//! production, i.e., under good network conditions an honest leader proposing
+//! a block with parent `b` in slot `s` will have their block finalized.
+
+use {super::Block, solana_pubkey::Pubkey, solana_sdk::clock::Slot, std::collections::HashMap};
+
+#[derive(Clone, Debug, Default)]
+pub struct ParentReadyTracker {
+    /// Our pubkey for logging
+    my_pubkey: Pubkey,
+
+    /// Parent ready status for each slot
+    slot_statuses: HashMap<Slot, ParentReadyStatus>,
+
+    /// Root
+    root: Slot,
+
+    /// Highest parent ready slot
+    // TODO: While the voting loop is sequential we track every slot (not just the first in window)
+    // However once we handle all slots concurrently we will update this to only count first leader
+    // slot in window
+    highest_parent_ready: Slot,
+}
+
+#[derive(Clone, Default, Debug)]
+struct ParentReadyStatus {
+    /// Whether this slot has a skip certificate
+    skip: bool,
+    /// The blocks that have been notar fallbacked in this slot
+    notar_fallbacks: Vec<Block>,
+    /// The parent blocks that achieve parent ready in this slot
+    parents_ready: Vec<Block>,
+}
+
+impl ParentReadyTracker {
+    /// Creates a new tracker with the root bank as implicitely notarized fallback
+    pub fn new(my_pubkey: Pubkey, root_block @ (root_slot, _, _): Block) -> Self {
+        let mut slot_statuses = HashMap::new();
+        slot_statuses.insert(
+            root_slot,
+            ParentReadyStatus {
+                skip: false,
+                notar_fallbacks: vec![root_block],
+                parents_ready: vec![],
+            },
+        );
+        slot_statuses.insert(
+            root_slot + 1,
+            ParentReadyStatus {
+                skip: false,
+                notar_fallbacks: vec![],
+                parents_ready: vec![root_block],
+            },
+        );
+        Self {
+            my_pubkey,
+            slot_statuses,
+            root: root_slot,
+            highest_parent_ready: root_slot + 1,
+        }
+    }
+
+    /// Adds a new notar-fallback certificate
+    pub fn add_new_notar_fallback(&mut self, block @ (slot, _, _): Block) {
+        if slot <= self.root {
+            return;
+        }
+
+        let status = self.slot_statuses.entry(slot).or_default();
+        if status.notar_fallbacks.contains(&block) {
+            return;
+        }
+        trace!(
+            "{}: Adding new notar fallback for {block:?}",
+            self.my_pubkey
+        );
+        status.notar_fallbacks.push(block);
+        assert!(status.notar_fallbacks.len() <= 3);
+
+        // Add this block as valid parent to skip connected future blocks
+        for s in slot + 1.. {
+            trace!(
+                "{}: Adding new parent ready for {s} parent {block:?}",
+                self.my_pubkey
+            );
+            let status = self.slot_statuses.entry(s).or_default();
+            status.parents_ready.push(block);
+
+            self.highest_parent_ready = s.max(self.highest_parent_ready);
+
+            if !status.skip {
+                break;
+            }
+        }
+    }
+
+    /// Adds a new skip certificate
+    pub fn add_new_skip(&mut self, slot: Slot) {
+        if slot <= self.root {
+            return;
+        }
+
+        trace!("{}: Adding new skip for {slot:?}", self.my_pubkey);
+        let status = self.slot_statuses.entry(slot).or_default();
+        status.skip = true;
+
+        // Get newly connected future slots
+        let mut future_slots = vec![];
+        for s in slot + 1.. {
+            future_slots.push(s);
+            if !self.slot_statuses.get(&s).is_some_and(|ss| ss.skip) {
+                break;
+            }
+        }
+
+        // Find possible parents using the previous slot
+        let mut potential_parents = vec![];
+        let Some(status) = self.slot_statuses.get(&(slot - 1)) else {
+            return;
+        };
+        for nf in &status.notar_fallbacks {
+            // If there's a notarize fallback certificate we can use the previous slot
+            // as a parent
+            potential_parents.push(*nf);
+        }
+        if status.skip {
+            // If there's a skip certificate we can use the parents of the previous slot
+            // as a parent
+            for parent in &status.parents_ready {
+                potential_parents.push(*parent);
+            }
+        }
+
+        // Add these as valid parents to the future slots
+        for s in future_slots {
+            trace!(
+                "{}: Adding new parent ready for {s} parents {potential_parents:?}",
+                self.my_pubkey,
+            );
+            let status = self.slot_statuses.entry(s).or_default();
+            status.parents_ready.extend_from_slice(&potential_parents);
+
+            self.highest_parent_ready = s.max(self.highest_parent_ready);
+        }
+    }
+
+    pub fn parent_ready(&self, slot: Slot, parent: Block) -> bool {
+        self.slot_statuses
+            .get(&slot)
+            .is_some_and(|ss| ss.parents_ready.contains(&parent))
+    }
+
+    /// For our leader slot `slot`, which block should we use as the parent
+    pub fn block_production_parent(&self, slot: Slot) -> Option<Block> {
+        // TODO: for duplicate blocks we should adjust this to choose the
+        // parent with the least amount of duplicate blocks if possible.
+        // Notice that each scenario with multiple NotarFallbacks also will eventually
+        // have a skip for that slot, so prefer the skip if we've received it
+        self.slot_statuses
+            .get(&slot)
+            .and_then(|ss| ss.parents_ready.iter().max().copied())
+    }
+
+    pub fn highest_parent_ready(&self) -> Slot {
+        self.highest_parent_ready
+    }
+
+    pub fn set_root(&mut self, root: Slot) {
+        self.root = root;
+        self.slot_statuses.retain(|&s, _| s >= root);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        solana_pubkey::Pubkey,
+        solana_sdk::{clock::NUM_CONSECUTIVE_LEADER_SLOTS, hash::Hash},
+    };
+
+    #[test]
+    fn basic() {
+        let genesis = Block::default();
+        let mut tracker = ParentReadyTracker::new(Pubkey::default(), genesis);
+
+        for i in 1..2 * NUM_CONSECUTIVE_LEADER_SLOTS {
+            let block = (i, Hash::new_unique(), Hash::new_unique());
+            tracker.add_new_notar_fallback(block);
+            assert_eq!(tracker.highest_parent_ready(), i + 1);
+            assert!(tracker.parent_ready(i + 1, block));
+        }
+    }
+
+    #[test]
+    fn skips() {
+        let genesis = Block::default();
+        let mut tracker = ParentReadyTracker::new(Pubkey::default(), genesis);
+        let block = (1, Hash::new_unique(), Hash::new_unique());
+
+        tracker.add_new_notar_fallback(block);
+        tracker.add_new_skip(1);
+        tracker.add_new_skip(2);
+        tracker.add_new_skip(3);
+
+        assert!(tracker.parent_ready(4, block));
+        assert!(tracker.parent_ready(4, genesis));
+        assert_eq!(tracker.highest_parent_ready(), 4);
+    }
+
+    #[test]
+    fn out_of_order() {
+        let genesis = Block::default();
+        let mut tracker = ParentReadyTracker::new(Pubkey::default(), genesis);
+        let block = (1, Hash::new_unique(), Hash::new_unique());
+
+        tracker.add_new_skip(3);
+        tracker.add_new_skip(2);
+
+        tracker.add_new_notar_fallback(block);
+        assert!(tracker.parent_ready(4, block));
+        assert!(!tracker.parent_ready(4, genesis));
+
+        tracker.add_new_skip(1);
+        assert!(tracker.parent_ready(4, block));
+        assert!(tracker.parent_ready(4, genesis));
+    }
+
+    #[test]
+    fn snapshot_wfsm() {
+        let root_slot = 2147;
+        let root_block = (root_slot, Hash::new_unique(), Hash::new_unique());
+        let mut tracker = ParentReadyTracker::new(Pubkey::default(), root_block);
+
+        assert!(tracker.parent_ready(root_slot + 1, root_block));
+        assert_eq!(tracker.highest_parent_ready(), root_slot + 1);
+
+        // Skipping root slot shouldn't do anything
+        tracker.add_new_skip(root_slot);
+        assert!(tracker.parent_ready(root_slot + 1, root_block));
+        assert_eq!(tracker.highest_parent_ready(), root_slot + 1);
+
+        // Adding new certs should work as root slot is implicitely notarized fallback
+        tracker.add_new_skip(root_slot + 1);
+        tracker.add_new_skip(root_slot + 2);
+        assert!(tracker.parent_ready(root_slot + 3, root_block));
+        assert_eq!(tracker.highest_parent_ready(), root_slot + 3);
+
+        let block = (root_slot + 4, Hash::new_unique(), Hash::new_unique());
+        tracker.add_new_notar_fallback(block);
+        assert!(tracker.parent_ready(root_slot + 3, root_block));
+        assert!(tracker.parent_ready(root_slot + 5, block));
+        assert_eq!(tracker.highest_parent_ready(), root_slot + 5);
+    }
+}

--- a/core/src/alpenglow_consensus/voting_loop.rs
+++ b/core/src/alpenglow_consensus/voting_loop.rs
@@ -5,7 +5,7 @@ use {
         block_creation_loop::{LeaderWindowInfo, LeaderWindowNotifier},
         certificate_pool::{self, AddVoteError},
         vote_history_storage::VoteHistoryStorage,
-        CertificateId,
+        Block, CertificateId,
     },
     crate::{
         alpenglow_consensus::{
@@ -28,7 +28,9 @@ use {
     solana_ledger::{
         blockstore::Blockstore,
         leader_schedule_cache::LeaderScheduleCache,
-        leader_schedule_utils::{last_of_consecutive_leader_slots, leader_slot_index},
+        leader_schedule_utils::{
+            first_of_consecutive_leader_slots, last_of_consecutive_leader_slots, leader_slot_index,
+        },
     },
     solana_measure::measure::Measure,
     solana_rpc::{
@@ -42,6 +44,7 @@ use {
     },
     solana_sdk::{
         clock::{Slot, NUM_CONSECUTIVE_LEADER_SLOTS},
+        hash::Hash,
         pubkey::Pubkey,
         signature::{Keypair, Signature, Signer},
         timing::timestamp,
@@ -255,20 +258,17 @@ impl VotingLoop {
 
             if is_leader {
                 // Let the block creation loop know it is time for it to produce the window
-                // TODO: We max with root here, as the snapshot slot might not have a certificate.
-                // Think about this more and fix if necessary.
-                let parent_slot = cert_pool
-                    .highest_notarized_fallback()
-                    // TODO(ashwin): Check hash when dealing with duplicate blocks
-                    .map_or(0, |(s, _, _)| s)
-                    .max(root_bank_cache.root_bank().slot());
+                let parent_block = cert_pool
+                    .parent_ready_tracker
+                    .block_production_parent(current_slot)
+                    .expect("Must have a block production parent in sequential voting loop");
                 Self::notify_block_creation_loop_of_leader_window(
                     &my_pubkey,
                     &cert_pool,
                     &leader_window_notifier,
-                    current_slot,
+                    first_of_consecutive_leader_slots(current_slot),
                     leader_end_slot,
-                    parent_slot,
+                    parent_block,
                     skip_timer,
                 );
             }
@@ -280,7 +280,6 @@ impl VotingLoop {
                 &leader_pubkey,
             );
 
-            let mut fast_forward = None;
             while current_slot <= leader_end_slot {
                 let leader_slot_index = leader_slot_index(current_slot);
                 let timeout = timeouts[leader_slot_index];
@@ -323,7 +322,6 @@ impl VotingLoop {
                     if Self::try_notar(
                         &my_pubkey,
                         bank.as_ref(),
-                        is_leader,
                         &blockstore,
                         &mut cert_pool,
                         &mut voting_context,
@@ -333,11 +331,9 @@ impl VotingLoop {
                     }
                 }
 
-                // Wait for certificate
+                // Wait for certificates to indicate we can move to the next slot
                 let mut refresh_timer = Instant::now();
-                while !Self::branch_certified(&my_pubkey, current_slot, &cert_pool)
-                    && !Self::skip_certified(&my_pubkey, current_slot, &cert_pool)
-                {
+                while cert_pool.parent_ready_tracker.highest_parent_ready() <= current_slot {
                     if exit.load(Ordering::Relaxed) {
                         return;
                     }
@@ -382,26 +378,6 @@ impl VotingLoop {
                         );
                         refresh_timer = Instant::now();
                     }
-
-                    // Check if we can fast forward
-                    // TODO(ashwin): for duplicate blocks, ensure that we have the correct chain up to this
-                    let Some((slot, _, _)) = cert_pool.highest_fast_finalized() else {
-                        continue;
-                    };
-                    if slot > current_slot {
-                        fast_forward = Some(slot);
-                        break;
-                    }
-                }
-
-                if let Some(slot) = fast_forward {
-                    info!(
-                        "{my_pubkey}: While waiting for certificate on {current_slot} we observed fast finalization certificate for {slot}. \
-                        Fast forwarding to {}",
-                        slot + 1,
-                    );
-                    current_slot = slot + 1;
-                    break;
                 }
 
                 info!(
@@ -421,13 +397,6 @@ impl VotingLoop {
                 current_slot += 1;
             }
 
-            // We intentionally do not set root if we were fast forwarding, we could
-            // end up rooting a slot that has not yet been considered for voting by the above loop
-            // causing the bank to be removed from bank forks.
-            if fast_forward.is_some() {
-                continue;
-            }
-
             // Set new root
             Self::maybe_set_root(
                 leader_end_slot,
@@ -442,39 +411,6 @@ impl VotingLoop {
             // TODO(ashwin): If we were the leader for `current_slot` and the bank has not completed,
             // we can abandon the bank now
         }
-    }
-
-    fn branch_certified(
-        my_pubkey: &Pubkey,
-        slot: Slot,
-        cert_pool: &CertificatePool<LegacyVoteCertificate>,
-    ) -> bool {
-        // TODO(ashwin): For non duplicate blocks, `notarize fallback` is sufficient to imply
-        // that we have seen branch certified in the sequential loop, when implementing duplicate
-        // logic, update to May 2nd paper for simplicity
-        if let Some(size) = cert_pool.slot_notarized_fallback(slot) {
-            info!(
-                "{my_pubkey}: Branch Certified: Slot {} from {} validators",
-                slot, size
-            );
-            return true;
-        };
-
-        false
-    }
-
-    fn skip_certified(
-        my_pubkey: &Pubkey,
-        slot: Slot,
-        cert_pool: &CertificatePool<LegacyVoteCertificate>,
-    ) -> bool {
-        // TODO(ashwin): can include cert size for debugging
-        if cert_pool.skip_certified(slot) {
-            info!("{my_pubkey}: Skip Certified: Slot {}", slot,);
-            return true;
-        }
-
-        false
     }
 
     /// Checks if any slots between `vote_history`'s current root
@@ -536,6 +472,51 @@ impl VotingLoop {
         }
 
         Some(new_root)
+    }
+
+    /// Gets the block id of a bank. If this is a leader bank,
+    /// shredding might not be complete when initially set, so update
+    /// the bank for children checks later
+    fn get_set_block_id(my_pubkey: &Pubkey, bank: &Bank, blockstore: &Blockstore) -> Option<Hash> {
+        let is_leader = bank.collector_id() == my_pubkey;
+
+        if bank.slot() == 0 {
+            // Genesis does not have a block id
+            return Some(Hash::default());
+        }
+        if bank.block_id().is_some() {
+            return bank.block_id();
+        }
+
+        if !is_leader {
+            warn!(
+                "{my_pubkey}: Unable to retrieve block id or duplicate block checks have failed
+                for non leader slot {} {}",
+                bank.slot(),
+                bank.hash()
+            );
+            return None;
+        }
+
+        // We are leader attempt to retrieve from blockstore
+        // TODO:(ashwin) We are leader ignore duplicate block checks and just get from last shred?
+        let block_id = blockstore
+            .check_last_fec_set_and_get_block_id(
+                bank.slot(),
+                bank.hash(),
+                is_leader,
+                &FeatureSet::all_enabled(),
+            )
+            .unwrap_or(None);
+
+        if block_id.is_some() {
+            // Prior to asynchronous execution, the leader's blocks could be frozen before shredded
+            // As such we choose to set the block id here, so that future parent block id lookups
+            // succeed. Since the scope of parent block id lookups is the voting loop, doing it here
+            // suffices, but if the scope expands we could consider moving this to replay.
+            bank.set_block_id(block_id);
+        }
+        block_id
     }
 
     /// Attempts to create and send a skip vote for all unvoted slots in `[start, end]`
@@ -608,7 +589,6 @@ impl VotingLoop {
     fn try_notar(
         my_pubkey: &Pubkey,
         bank: &Bank,
-        is_leader: bool,
         blockstore: &Blockstore,
         cert_pool: &mut CertificatePool<LegacyVoteCertificate>,
         voting_context: &mut VotingContext,
@@ -618,33 +598,33 @@ impl VotingLoop {
         let leader_slot_index = leader_slot_index(slot);
 
         let parent_slot = bank.parent_slot();
+        let parent_bank_hash = bank.parent_hash();
+        let parent_block_id = Self::get_set_block_id(
+            my_pubkey,
+            bank.parent().expect("Cannot vote on genesis").as_ref(),
+            blockstore,
+        )
+        // To account for child of genesis and snapshots we allow default block id
+        .unwrap_or_default();
 
         // Check if the certificates are valid for us to vote notarize.
-        // TODO: fix WFSM hack
         // - If this is the first leader slot (leader index = 0 or slot = 1) check
-        //      - The parent is branch certified
+        //   that we are parent ready:
+        //      - The parent is notarized fallback
         //      - OR the parent is genesis / slot 1 (WFSM hack)
         //      - All slots between the parent and this slot are skip certified
         // - If this is not the first leader slot check
         //      - The slot is consecutive to the parent slot
         //      - We voted notarize on the parent block
         if leader_slot_index == 0 || slot == 1 {
-            // TODO(ashwin): track by hash,
-            if cert_pool.slot_notarized_fallback(parent_slot).is_none() && parent_slot > 1 {
-                // Need to ingest more votes
-                return false;
-            }
-
-            if !(parent_slot + 1..slot).all(|s| cert_pool.skip_certified(s)) {
+            if !cert_pool
+                .parent_ready_tracker
+                .parent_ready(slot, (parent_slot, parent_block_id, parent_bank_hash))
+            {
                 // Need to ingest more votes
                 return false;
             }
         } else {
-            let parent_bank_hash = bank.parent_hash();
-            let parent_block_id = bank
-                .parent_block_id()
-                .expect("Synchronous replay cannot have a missing parent block id");
-
             if parent_slot + 1 != slot {
                 // Non consecutive
                 return false;
@@ -658,14 +638,7 @@ impl VotingLoop {
         }
 
         // Broadcast notarize vote
-        let voted = Self::vote_notarize(
-            my_pubkey,
-            bank,
-            is_leader,
-            blockstore,
-            cert_pool,
-            voting_context,
-        );
+        let voted = Self::vote_notarize(my_pubkey, bank, blockstore, cert_pool, voting_context);
 
         // Try to finalize
         Self::try_final(my_pubkey, slot, bank, cert_pool, voting_context);
@@ -680,7 +653,6 @@ impl VotingLoop {
     fn vote_notarize(
         my_pubkey: &Pubkey,
         bank: &Bank,
-        is_leader: bool,
         blockstore: &Blockstore,
         cert_pool: &mut CertificatePool<LegacyVoteCertificate>,
         voting_context: &mut VotingContext,
@@ -688,41 +660,9 @@ impl VotingLoop {
         debug_assert!(bank.is_frozen());
         let slot = bank.slot();
         let hash = bank.hash();
-        let Some(block_id) = blockstore
-            .check_last_fec_set_and_get_block_id(
-                slot,
-                hash,
-                is_leader,
-                // TODO:(ashwin) ignore duplicate block checks (?)
-                &FeatureSet::all_enabled(),
-            ).unwrap_or_else(|e| {
-                if !is_leader {
-                    warn!("Unable to retrieve block_id, failed last fec set checks for slot {slot} hash {hash}: {e:?}")
-                }
-                None
-            }
-        ) else {
-            if is_leader {
-                // For leader slots, shredding is asynchronous so block_id might not yet
-                // be available. In this case we want to retry our vote later
-                return false;
-            }
-            // At this point we could mark the bank as dead similar to TowerBFT, however
-            // for alpenglow this is not necessary
-            warn!(
-                "Unable to retrieve block id or duplicate block checks have failed
-                for non leader slot {slot} {hash}, not voting notarize"
-            );
-            return true;
+        let Some(block_id) = Self::get_set_block_id(my_pubkey, bank, blockstore) else {
+            return false;
         };
-
-        if is_leader && bank.block_id().is_none() {
-            // Prior to asynchronous execution, the leader's blocks could be frozen before shredded
-            // As such we choose to set the block id here, so that future parent block id lookups
-            // succeed. Since the scope of parent block id lookups is the voting loop, doing it here
-            // suffices, but if the scope expands we could consider moving this to replay.
-            bank.set_block_id(Some(block_id));
-        }
 
         info!("{my_pubkey}: Voting notarize for slot {slot} hash {hash} block_id {block_id}");
         let vote = Vote::new_notarization_vote(slot, block_id, hash);
@@ -737,8 +677,8 @@ impl VotingLoop {
     }
 
     /// Consider voting notarize fallback for this slot
-    /// if b' = safeToNotar(slot)
-    /// then try to skip the window, vote notarize fallback and skip the window
+    /// for each b' = safeToNotar(slot)
+    /// try to skip the window, and vote notarize fallback b'
     fn try_notar_fallback(
         my_pubkey: &Pubkey,
         slot: Slot,
@@ -775,7 +715,7 @@ impl VotingLoop {
 
     /// Consider voting skip fallback for this slot
     /// if safeToSkip(slot)
-    /// then try to skip the window, vote notarize fallback and skip the window
+    /// then try to skip the window, and vote skip fallback
     fn try_skip_fallback(
         my_pubkey: &Pubkey,
         slot: Slot,
@@ -808,7 +748,7 @@ impl VotingLoop {
     }
 
     /// Refresh the highest recent finalization certificate
-    /// For each slot past this, refresh our votes
+    /// For each slot past this up to our current slot `slot`, refresh our votes
     fn refresh_votes_and_cert(
         my_pubkey: &Pubkey,
         slot: Slot,
@@ -816,13 +756,13 @@ impl VotingLoop {
         cert_pool: &mut CertificatePool<LegacyVoteCertificate>,
         voting_context: &mut VotingContext,
     ) {
-        // TODO: handle slow finalization after cert pool refactor
-        let highest_finalization_slot = if let Some(block) = cert_pool.highest_fast_finalized() {
-            // TODO: rebroadcast cert for block once we have BLS
-            block.0
-        } else {
-            0
-        };
+        let highest_finalization_slot = cert_pool
+            .highest_finalized_slot()
+            .max(root_bank_cache.root_bank().slot());
+        // TODO: rebroadcast finalization cert for block once we have BLS
+        // This includes the notarized fallback cert if it was a slow finalization
+
+        // Refresh votes for all slots up to our current slot
         for s in highest_finalization_slot..=slot {
             for vote in voting_context.vote_history.votes_cast(s) {
                 info!("{my_pubkey}: Refreshing vote {vote:?}");
@@ -1038,7 +978,7 @@ impl VotingLoop {
         leader_window_notifier: &LeaderWindowNotifier,
         start_slot: Slot,
         end_slot: Slot,
-        parent_slot: Slot,
+        parent_block @ (parent_slot, _, _): Block,
         skip_timer: Instant,
     ) -> bool {
         // Check if we missed our window
@@ -1057,14 +997,6 @@ impl VotingLoop {
             return false;
         }
 
-        // Sanity check for certificates
-        if !cert_pool.make_start_leader_decision(start_slot, parent_slot, 0) {
-            panic!(
-                "{my_pubkey}: Missing leader block certificates something has gone wrong with the voting loop \
-                while producing {start_slot} parent {parent_slot}"
-            );
-        }
-
         // Notify the block creation loop.
         let mut l_window_info = leader_window_notifier.window_info.lock().unwrap();
         if let Some(window_info) = l_window_info.as_ref() {
@@ -1079,7 +1011,7 @@ impl VotingLoop {
         *l_window_info = Some(LeaderWindowInfo {
             start_slot,
             end_slot,
-            parent_slot,
+            parent_block,
             skip_timer,
         });
         leader_window_notifier.window_notification.notify_one();

--- a/core/src/consensus/progress_map.rs
+++ b/core/src/consensus/progress_map.rs
@@ -5,7 +5,7 @@ use {
         consensus::{Stake, ThresholdDecision, VotedStakes},
         replay_stage::SUPERMINORITY_THRESHOLD,
     },
-    solana_ledger::blockstore_processor::{self, ConfirmationProgress, ReplaySlotStats},
+    solana_ledger::blockstore_processor::{ConfirmationProgress, ReplaySlotStats},
     solana_runtime::{bank::Bank, bank_forks::BankForks},
     solana_sdk::{clock::Slot, hash::Hash, pubkey::Pubkey},
     solana_vote::vote_account::VoteAccountsHashMap,
@@ -167,11 +167,6 @@ impl ForkProgress {
             num_blocks_on_fork,
             num_dropped_blocks_on_fork,
         );
-
-        // Don't need set ticks for our own leader banks, poh service will do that
-        if bank.collector_id() != validator_identity {
-            blockstore_processor::set_alpenglow_ticks(bank);
-        }
 
         if bank.is_frozen() {
             new_progress.fork_stats.bank_hash = Some(bank.hash());

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -4494,6 +4494,8 @@ impl ReplayStage {
                     slot_status_notifier,
                     NewBankOptions::default(),
                 );
+                // Set ticks for received banks, block creation loop will take care of leader banks
+                blockstore_processor::set_alpenglow_ticks(&child_bank);
                 let empty: Vec<Pubkey> = vec![];
                 Self::update_fork_propagated_threshold_from_votes(
                     progress,


### PR DESCRIPTION
Reuploaded from #198 

### Problem
We still use the branch certified / skip certified naming from an earlier draft of the paper. Additionally we don't actually verify the hash for notarize fallback certificates.
Finally we hack in slot 1 for WFSM to enable GCE tests.

### Summary of Changes

- Add parent ready tracker to explicitly track notarize fallback / skip certificates by block hashes
- Update voting loop to use parent ready instead of old checks (Note this shouldn't actually change any behavior at the moment, but will once we have duplicate blocks)
- Instead of hacking in WFSM / snapshot slots, implicitely notarize fallback the root bank used in startup

Fixes https://github.com/anza-xyz/alpenglow/issues/155