### PR TITLE
Add option to push BLS message to Alpenglow sockets in voting service.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7486,6 +7486,7 @@ dependencies = [
  "solana-net-utils",
  "solana-perf",
  "solana-poh",
+ "solana-poh-config",
  "solana-program-runtime",
  "solana-pubkey",
  "solana-quic-client",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -123,8 +123,8 @@ solana-cost-model = { workspace = true, features = ["dev-context-only-utils"] }
 solana-ledger = { workspace = true, features = ["dev-context-only-utils"] }
 solana-logger = { workspace = true }
 solana-net-utils = { workspace = true, features = ["dev-context-only-utils"] }
-solana-poh-config = { workspace = true }
 solana-poh = { workspace = true, features = ["dev-context-only-utils"] }
+solana-poh-config = { workspace = true }
 solana-program-runtime = { workspace = true, features = ["metrics"] }
 solana-rpc = { workspace = true, features = ["dev-context-only-utils"] }
 solana-sdk = { workspace = true, features = ["dev-context-only-utils"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -123,6 +123,7 @@ solana-cost-model = { workspace = true, features = ["dev-context-only-utils"] }
 solana-ledger = { workspace = true, features = ["dev-context-only-utils"] }
 solana-logger = { workspace = true }
 solana-net-utils = { workspace = true, features = ["dev-context-only-utils"] }
+solana-poh-config = { workspace = true }
 solana-poh = { workspace = true, features = ["dev-context-only-utils"] }
 solana-program-runtime = { workspace = true, features = ["metrics"] }
 solana-rpc = { workspace = true, features = ["dev-context-only-utils"] }

--- a/core/src/staked_validators_cache.rs
+++ b/core/src/staked_validators_cache.rs
@@ -240,7 +240,7 @@ mod tests {
             sync::{Arc, RwLock},
             time::{Duration, Instant},
         },
-        test_case::test_case,
+        test_case::{test_case, test_matrix},
     };
 
     fn new_rand_vote_account<R: rand::Rng>(
@@ -616,7 +616,7 @@ mod tests {
         assert!(refreshed);
     }
 
-#[test_matrix(
+    #[test_matrix(
     [1_usize, 10_usize],
     [Protocol::UDP, Protocol::QUIC],
     [false, true]

--- a/core/src/staked_validators_cache.rs
+++ b/core/src/staked_validators_cache.rs
@@ -405,87 +405,23 @@ mod tests {
         (node_keypair_map, vahm)
     }
 
-    #[test_case(
-        325_000_000_u64,
-        1_usize,
-        0_usize,
-        10_usize,
-        123_u64,
-        Protocol::UDP,
-        false
-    )]
-    #[test_case(
-        325_000_000_u64,
-        1_usize,
-        0_usize,
-        10_usize,
-        123_u64,
-        Protocol::UDP,
-        true
-    )]
-    #[test_case(
-        325_000_000_u64,
-        3_usize,
-        0_usize,
-        10_usize,
-        123_u64,
-        Protocol::QUIC,
-        false
-    )]
-    #[test_case(
-        325_000_000_u64,
-        10_usize,
-        2_usize,
-        10_usize,
-        123_u64,
-        Protocol::UDP,
-        false
-    )]
-    #[test_case(
-        325_000_000_u64,
-        10_usize,
-        2_usize,
-        10_usize,
-        123_u64,
-        Protocol::UDP,
-        true
-    )]
-    #[test_case(
-        325_000_000_u64,
-        10_usize,
-        10_usize,
-        10_usize,
-        123_u64,
-        Protocol::QUIC,
-        false
-    )]
-    #[test_case(
-        325_000_000_u64,
-        50_usize,
-        7_usize,
-        60_usize,
-        123_u64,
-        Protocol::UDP,
-        false
-    )]
-    #[test_case(
-        325_000_000_u64,
-        50_usize,
-        7_usize,
-        60_usize,
-        123_u64,
-        Protocol::UDP,
-        true
-    )]
+    #[test_case(1_usize, 0_usize, 10_usize, Protocol::UDP, false)]
+    #[test_case(1_usize, 0_usize, 10_usize, Protocol::UDP, true)]
+    #[test_case(3_usize, 0_usize, 10_usize, Protocol::QUIC, false)]
+    #[test_case(10_usize, 2_usize, 10_usize, Protocol::UDP, false)]
+    #[test_case(10_usize, 2_usize, 10_usize, Protocol::UDP, true)]
+    #[test_case(10_usize, 10_usize, 10_usize, Protocol::QUIC, false)]
+    #[test_case(50_usize, 7_usize, 60_usize, Protocol::UDP, false)]
+    #[test_case(50_usize, 7_usize, 60_usize, Protocol::UDP, true)]
     fn test_detect_only_staked_nodes_and_refresh_after_ttl(
-        slot_num: u64,
         num_nodes: usize,
         num_zero_stake_nodes: usize,
         num_vote_accounts: usize,
-        genesis_lamports: u64,
         protocol: Protocol,
         use_alpenglow_socket: bool,
     ) {
+        let slot_num = 325_000_000_u64;
+        let genesis_lamports = 123_u64;
         // Create our harness
         let (keypair_map, vahm) =
             build_epoch_stakes(num_nodes, num_zero_stake_nodes, num_vote_accounts);

--- a/core/src/staked_validators_cache.rs
+++ b/core/src/staked_validators_cache.rs
@@ -680,12 +680,11 @@ mod tests {
         assert!(refreshed);
     }
 
-    #[test_case(1_usize, Protocol::UDP, false)]
-    #[test_case(1_usize, Protocol::UDP, true)]
-    #[test_case(1_usize, Protocol::QUIC, false)]
-    #[test_case(10_usize, Protocol::UDP, false)]
-    #[test_case(10_usize, Protocol::UDP, true)]
-    #[test_case(10_usize, Protocol::QUIC, false)]
+#[test_matrix(
+    [1_usize, 10_usize],
+    [Protocol::UDP, Protocol::QUIC],
+    [false, true]
+)]
     fn test_exclude_self_from_cache(
         num_nodes: usize,
         protocol: Protocol,

--- a/core/src/staked_validators_cache.rs
+++ b/core/src/staked_validators_cache.rs
@@ -709,8 +709,14 @@ mod tests {
                 .with_vote_accounts(slot_num, keypair_map, vahm, protocol)
                 .bank_forks();
 
-        let my_tpu_vote_socket_addr = cluster_info
-            .lookup_contact_info(&keypair.pubkey(), |node| node.tpu_vote(protocol).unwrap())
+        let my_socket_addr = cluster_info
+            .lookup_contact_info(&keypair.pubkey(), |node| {
+                if use_alpenglow_socket {
+                    node.alpenglow().unwrap()
+                } else {
+                    node.tpu_vote(protocol).unwrap()
+                }
+            })
             .unwrap();
 
         // Create our staked validators cache - set include_self to true
@@ -729,7 +735,7 @@ mod tests {
             use_alpenglow_socket,
         );
         assert_eq!(sockets.len(), num_nodes);
-        assert!(sockets.contains(&my_tpu_vote_socket_addr));
+        assert!(sockets.contains(&my_socket_addr));
 
         // Create our staked validators cache - set include_self to false
         let mut svc = StakedValidatorsCache::new(
@@ -747,6 +753,6 @@ mod tests {
             use_alpenglow_socket,
         );
         assert_eq!(sockets.len(), num_nodes - 1);
-        assert!(!sockets.contains(&my_tpu_vote_socket_addr));
+        assert!(!sockets.contains(&my_socket_addr));
     }
 }

--- a/core/src/staked_validators_cache.rs
+++ b/core/src/staked_validators_cache.rs
@@ -124,16 +124,15 @@ impl StakedValidatorsCache {
         nodes.dedup_by_key(|node| node.tpu_socket);
         nodes.sort_unstable_by(|a, b| a.stake.cmp(&b.stake));
 
-        let (validator_sockets, alpenglow_sockets) = nodes.into_iter().fold(
-            (Vec::new(), Vec::new()),
-            |(mut validator_sockets, mut alpenglow_sockets), node| {
-                validator_sockets.push(node.tpu_socket);
-                if let Some(alpenglow_socket) = node.alpenglow_socket {
-                    alpenglow_sockets.push(alpenglow_socket);
-                }
-                (validator_sockets, alpenglow_sockets)
-            },
-        );
+        let mut validator_sockets = Vec::new();
+        let mut alpenglow_sockets = Vec::new();
+
+        for node in nodes {
+            validator_sockets.push(node.tpu_socket);
+            if let Some(alpenglow_socket) = node.alpenglow_socket {
+                alpenglow_sockets.push(alpenglow_socket);
+            }
+        }
 
         self.cache.push(
             epoch,

--- a/core/src/voting_service.rs
+++ b/core/src/voting_service.rs
@@ -5,6 +5,7 @@ use {
         next_leader::upcoming_leader_tpu_vote_sockets,
         staked_validators_cache::StakedValidatorsCache,
     },
+    alpenglow_vote::bls_message::BLSMessage,
     bincode::serialize,
     crossbeam_channel::Receiver,
     solana_client::connection_cache::ConnectionCache,
@@ -36,8 +37,14 @@ pub enum VoteOp {
         tower_slots: Vec<Slot>,
         saved_tower: SavedTowerVersions,
     },
+    //TODO(wen): remove PushAlpenglowVote when BLS all to all is submmitted.
     PushAlpenglowVote {
         tx: Transaction,
+        slot: Slot,
+        saved_vote_history: SavedVoteHistoryVersions,
+    },
+    PushAlpenglowBLSMessage {
+        bls_message: BLSMessage,
         slot: Slot,
         saved_vote_history: SavedVoteHistoryVersions,
     },
@@ -55,6 +62,16 @@ enum SendVoteError {
     InvalidTpuAddress,
     #[error(transparent)]
     TransportError(#[from] TransportError),
+}
+
+fn send_message(
+    buf: Vec<u8>,
+    socket: &SocketAddr,
+    connection_cache: &Arc<ConnectionCache>,
+) -> Result<(), TransportError> {
+    let client = connection_cache.get_connection(socket);
+
+    client.send_data_async(buf)
 }
 
 fn send_vote_transaction(
@@ -160,6 +177,8 @@ impl VotingService {
         }
     }
 
+    // TODO(wen): broadcast_alpenglow_vote should be removed when all Alpenglow
+    // votes are sent through BLS messages.
     fn broadcast_alpenglow_vote(
         slot: Slot,
         cluster_info: &ClusterInfo,
@@ -169,7 +188,7 @@ impl VotingService {
         staked_validators_cache: &mut StakedValidatorsCache,
     ) {
         let (staked_validator_tpu_sockets, _) = staked_validators_cache
-            .get_staked_validators_by_slot(slot, cluster_info, Instant::now());
+            .get_staked_validators_by_slot(slot, cluster_info, Instant::now(), false);
 
         if staked_validator_tpu_sockets.is_empty() {
             let _ = send_vote_transaction(cluster_info, tx, None, &connection_cache);
@@ -187,6 +206,39 @@ impl VotingService {
                     Some(*tpu_vote_socket),
                     &connection_cache,
                 );
+            }
+        }
+    }
+
+    fn broadcast_alpenglow_message(
+        slot: Slot,
+        cluster_info: &ClusterInfo,
+        bls_message: &BLSMessage,
+        connection_cache: Arc<ConnectionCache>,
+        additional_listeners: Option<&Vec<SocketAddr>>,
+        staked_validators_cache: &mut StakedValidatorsCache,
+    ) {
+        let (staked_validator_alpenglow_sockets, _) = staked_validators_cache
+            .get_staked_validators_by_slot(slot, cluster_info, Instant::now(), true);
+
+        let sockets = additional_listeners
+            .map(|v| v.as_slice())
+            .unwrap_or(&[])
+            .iter()
+            .chain(staked_validator_alpenglow_sockets.iter());
+        match serialize(bls_message) {
+            Ok(buf) => {
+                for alpenglow_socket in sockets {
+                    if let Err(e) = send_message(buf.clone(), alpenglow_socket, &connection_cache) {
+                        warn!(
+                            "Failed to send alpenglow message to {}: {:?}",
+                            alpenglow_socket, e
+                        );
+                    }
+                }
+            }
+            Err(err) => {
+                error!("Failed to serialize alpenglow message: {:?}", err);
             }
         }
     }
@@ -244,6 +296,28 @@ impl VotingService {
                 // TODO: Test that no important votes are overwritten
                 cluster_info.push_alpenglow_vote(tx);
             }
+            VoteOp::PushAlpenglowBLSMessage {
+                bls_message,
+                slot,
+                saved_vote_history,
+            } => {
+                let mut measure = Measure::start("alpenglow vote history save");
+                if let Err(err) = vote_history_storage.store(&saved_vote_history) {
+                    error!("Unable to save vote history to storage: {:?}", err);
+                    std::process::exit(1);
+                }
+                measure.stop();
+                trace!("{measure}");
+
+                Self::broadcast_alpenglow_message(
+                    slot,
+                    cluster_info,
+                    &bls_message,
+                    connection_cache,
+                    additional_listeners,
+                    staked_validators_cache,
+                );
+            }
             VoteOp::RefreshVote {
                 tx,
                 last_voted_slot,
@@ -255,5 +329,150 @@ impl VotingService {
 
     pub fn join(self) -> thread::Result<()> {
         self.thread_hdl.join()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::{
+            alpenglow_consensus::vote_history_storage::{NullVoteHistoryStorage, SavedVoteHistory},
+            consensus::tower_storage::NullTowerStorage,
+        },
+        alpenglow_vote::{
+            bls_message::{BLSMessage, VoteMessage},
+            vote::Vote,
+        },
+        solana_bls::Signature as BLSSignature,
+        solana_gossip::{cluster_info::ClusterInfo, contact_info::ContactInfo},
+        solana_ledger::{
+            blockstore::Blockstore, get_tmp_ledger_path_auto_delete,
+            leader_schedule_cache::LeaderScheduleCache,
+        },
+        solana_poh_config::PohConfig,
+        solana_runtime::{
+            bank::Bank,
+            bank_forks::BankForks,
+            genesis_utils::{
+                create_genesis_config_with_alpenglow_vote_accounts_no_program,
+                ValidatorVoteKeypairs,
+            },
+        },
+        solana_sdk::{
+            hash::Hash,
+            signer::{keypair::Keypair, Signer},
+        },
+        solana_streamer::{
+            packet::{Packet, PacketBatch},
+            recvmmsg::recv_mmsg,
+            socket::SocketAddrSpace,
+        },
+        std::{
+            net::{SocketAddr, UdpSocket},
+            sync::{atomic::AtomicBool, Arc, RwLock},
+        },
+    };
+
+    fn create_voting_service(
+        vote_receiver: Receiver<VoteOp>,
+        listener: SocketAddr,
+    ) -> VotingService {
+        // Create 10 node validatorvotekeypairs vec
+        let validator_keypairs = (0..10)
+            .map(|_| ValidatorVoteKeypairs::new_rand())
+            .collect::<Vec<_>>();
+        let genesis = create_genesis_config_with_alpenglow_vote_accounts_no_program(
+            1_000_000_000,
+            &validator_keypairs,
+            vec![100; validator_keypairs.len()],
+        );
+        let bank0 = Bank::new_for_tests(&genesis.genesis_config);
+        let bank_forks = BankForks::new_rw_arc(bank0);
+        let keypair = Keypair::new();
+        let contact_info = ContactInfo::new_localhost(&keypair.pubkey(), 0);
+        let cluster_info = ClusterInfo::new(
+            contact_info,
+            Arc::new(keypair),
+            SocketAddrSpace::Unspecified,
+        );
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path())
+            .expect("Expected to be able to open database ledger");
+        let working_bank = bank_forks.read().unwrap().working_bank();
+        let poh_recorder = PohRecorder::new(
+            working_bank.tick_height(),
+            working_bank.last_blockhash(),
+            working_bank.clone(),
+            None,
+            working_bank.ticks_per_slot(),
+            Arc::new(blockstore),
+            &Arc::new(LeaderScheduleCache::new_from_bank(&working_bank)),
+            &PohConfig::default(),
+            Arc::new(AtomicBool::new(false)),
+        )
+        .0;
+
+        VotingService::new(
+            vote_receiver,
+            Arc::new(cluster_info),
+            Arc::new(RwLock::new(poh_recorder)),
+            Arc::new(NullTowerStorage::default()),
+            Arc::new(NullVoteHistoryStorage::default()),
+            Arc::new(ConnectionCache::with_udp("TestConnectionCache", 10)),
+            bank_forks,
+            Some(vec![listener]),
+        )
+    }
+
+    #[allow(clippy::disallowed_methods)]
+    #[test]
+    fn test_send_bls_message() {
+        solana_logger::setup();
+        let (vote_sender, vote_receiver) = crossbeam_channel::unbounded();
+        // Create listener thread on a random port we allocated and return SocketAddr to create VotingService
+
+        // Bind to a random UDP port
+        let socket = UdpSocket::bind("127.0.0.1:0").expect("Failed to bind UDP socket");
+        let listener_addr = socket.local_addr().unwrap();
+
+        // Create VotingService with the listener address
+        let _ = create_voting_service(vote_receiver, listener_addr);
+
+        // Send a BLS message via the VotingService
+        let bls_message = BLSMessage::Vote(VoteMessage {
+            vote: Vote::new_notarization_vote(5, Hash::new_unique(), Hash::new_unique()),
+            signature: BLSSignature::default(),
+            rank: 1,
+        });
+        let saved_vote_history = SavedVoteHistoryVersions::Current(SavedVoteHistory::default());
+        assert!(vote_sender
+            .send(VoteOp::PushAlpenglowBLSMessage {
+                bls_message: bls_message.clone(),
+                slot: 5,
+                saved_vote_history,
+            })
+            .is_ok());
+
+        // Wait for the listener to receive the message
+        let mut packet_batch = PacketBatch::new(vec![Packet::default()]);
+        socket
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .unwrap();
+        assert!(recv_mmsg(&socket, &mut packet_batch[..]).is_ok());
+        if let Some(packet) = packet_batch.iter().next() {
+            match packet.deserialize_slice::<BLSMessage, _>(..) {
+                Ok(received_bls_message) => {
+                    assert_eq!(received_bls_message, bls_message);
+                }
+                Err(err) => panic!(
+                    "Failed to deserialize BLSMessage: {:?} {:?}",
+                    size_of::<BLSMessage>(),
+                    err
+                ),
+            }
+        } else {
+            panic!("No packets received");
+        }
     }
 }

--- a/core/src/voting_service.rs
+++ b/core/src/voting_service.rs
@@ -370,7 +370,7 @@ mod tests {
             socket::SocketAddrSpace,
         },
         std::{
-            net::{SocketAddr, UdpSocket},
+            net::SocketAddr,
             sync::{atomic::AtomicBool, Arc, RwLock},
         },
     };
@@ -434,7 +434,7 @@ mod tests {
         // Create listener thread on a random port we allocated and return SocketAddr to create VotingService
 
         // Bind to a random UDP port
-        let socket = solana_net_utils::bind_to_localhost();
+        let socket = solana_net_utils::bind_to_localhost().unwrap();
         let listener_addr = socket.local_addr().unwrap();
 
         // Create VotingService with the listener address

--- a/core/src/voting_service.rs
+++ b/core/src/voting_service.rs
@@ -226,19 +226,20 @@ impl VotingService {
             .unwrap_or(&[])
             .iter()
             .chain(staked_validator_alpenglow_sockets.iter());
-        match serialize(bls_message) {
-            Ok(buf) => {
-                for alpenglow_socket in sockets {
-                    if let Err(e) = send_message(buf.clone(), alpenglow_socket, &connection_cache) {
-                        warn!(
-                            "Failed to send alpenglow message to {}: {:?}",
-                            alpenglow_socket, e
-                        );
-                    }
-                }
-            }
+        let buf = match serialize(bls_message) {
+            Ok(buf) => buf,
             Err(err) => {
                 error!("Failed to serialize alpenglow message: {:?}", err);
+                return;
+            }
+        };
+
+        for alpenglow_socket in sockets {
+            if let Err(e) = send_message(buf.clone(), alpenglow_socket, &connection_cache) {
+                warn!(
+                    "Failed to send alpenglow message to {}: {:?}",
+                    alpenglow_socket, e
+                );
             }
         }
     }

--- a/core/src/voting_service.rs
+++ b/core/src/voting_service.rs
@@ -433,7 +433,7 @@ mod tests {
         // Create listener thread on a random port we allocated and return SocketAddr to create VotingService
 
         // Bind to a random UDP port
-        let socket = UdpSocket::bind("127.0.0.1:0").expect("Failed to bind UDP socket");
+        let socket = solana_net_utils::bind_to_localhost();
         let listener_addr = socket.local_addr().unwrap();
 
         // Create VotingService with the listener address

--- a/core/src/voting_service.rs
+++ b/core/src/voting_service.rs
@@ -460,19 +460,16 @@ mod tests {
             .set_read_timeout(Some(Duration::from_secs(2)))
             .unwrap();
         assert!(recv_mmsg(&socket, &mut packet_batch[..]).is_ok());
-        if let Some(packet) = packet_batch.iter().next() {
-            match packet.deserialize_slice::<BLSMessage, _>(..) {
-                Ok(received_bls_message) => {
-                    assert_eq!(received_bls_message, bls_message);
-                }
-                Err(err) => panic!(
+        let packet = packet_batch.iter().next().expect("No packets received");
+        let received_bls_message = packet
+            .deserialize_slice::<BLSMessage, _>(..)
+            .unwrap_or_else(|err| {
+                panic!(
                     "Failed to deserialize BLSMessage: {:?} {:?}",
                     size_of::<BLSMessage>(),
                     err
-                ),
-            }
-        } else {
-            panic!("No packets received");
-        }
+                )
+            });
+        assert_eq!(received_bls_message, bls_message);
     }
 }


### PR DESCRIPTION
Cache Alpenglow sockets and use them when pushing BLS messages in voting service.

- We will switch to QUIC or SNP in a later PR, this is just using UDP for the prototype testing
- Actually switching to BLS messages will happen in later PRs
- Once we switch to BLS messages, the original pushAlpenglowVote which sends vote transactions can be decommed