### PR TITLE
feat: support u64 metrics

### DIFF
--- a/metrics/src/datapoint.rs
+++ b/metrics/src/datapoint.rs
@@ -113,7 +113,7 @@ macro_rules! create_datapoint {
     (@field $point:ident $name:expr, $value:expr, i64) => {
         $point.add_field_i64($name, $value as i64);
     };
-    (@field $point:ident $name:expr, $value:expr, i64) => {
+    (@field $point:ident $name:expr, $value:expr, u64) => {
         $point.add_field_u64($name, $value as u64);
     };
     (@field $point:ident $name:expr, $value:expr, f64) => {


### PR DESCRIPTION
#### Problem
We only signed metrics with signed integer types. Some integers should really be positive.

#### Summary of Changes
Support `u64` as a valid metric type.