### PR TITLE
gossip fallback

### DIFF
--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -1138,7 +1138,7 @@ pub fn execute(
                         )
                 })
             } else {
-                Some(IpAddr::V4(Ipv4Addr::LOCALHOST))
+                Some(bind_address)
             }
         })
         .ok_or_else(|| "unable to determine the validator's public IP address".to_string())?;

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -71,7 +71,7 @@ use {
     std::{
         collections::HashSet,
         fs::{self, File},
-        net::{IpAddr, Ipv4Addr, SocketAddr},
+        net::{IpAddr, SocketAddr},
         num::NonZeroUsize,
         path::{Path, PathBuf},
         process::exit,


### PR DESCRIPTION
#### Problem
When starting a boostrap node (no `entrypoint` args set) without `gossip_host` set, we will fall back to localhost IP. This causes contact info to be filtered out, and other nodes cannot join the cluster. `gossip_host` has been deprecated upstream.

This was discovered when trying to spin up Alpenglow repo on invalidator cluster (it has removed `gossip_host` arg inline with the upstream deprecation).

Note: This was fixed upstream with https://github.com/anza-xyz/agave/pull/6519

#### Summary of Changes
Fallback to the `bind_address` (presumably external facing IP) instead of localhost.