### PR TITLE
Vote Fetch Dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,7 +472,7 @@ checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 [[package]]
 name = "alpenglow-vote"
 version = "0.1.0"
-source = "git+ssh://git@github.com/solana-program/alpenglow-vote.git?rev=e4f33e5#e4f33e57647f8ca15789d347e763d28478823b5d"
+source = "git+https://github.com/solana-program/alpenglow-vote.git?rev=e4f33e5#e4f33e57647f8ca15789d347e763d28478823b5d"
 dependencies = [
  "bincode",
  "bitflags 2.9.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,7 +174,7 @@ check-cfg = [
 
 [workspace.dependencies]
 Inflector = "0.11.4"
-alpenglow-vote = { git = "ssh://git@github.com/solana-program/alpenglow-vote.git", rev = "e4f33e5" }
+alpenglow-vote = { git = "https://github.com/solana-program/alpenglow-vote.git", rev = "e4f33e5" }
 axum = "0.7.9"
 agave-banking-stage-ingress-types = { path = "banking-stage-ingress-types", version = "=2.3.0" }
 agave-transaction-view = { path = "transaction-view", version = "=2.3.0" }

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -1138,7 +1138,7 @@ pub fn execute(
                         )
                 })
             } else {
-                Some(bind_address)
+                Some(IpAddr::V4(Ipv4Addr::LOCALHOST))
             }
         })
         .ok_or_else(|| "unable to determine the validator's public IP address".to_string())?;

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -1138,7 +1138,7 @@ pub fn execute(
                         )
                 })
             } else {
-                Some(IpAddr::V4(Ipv4Addr::LOCALHOST))
+                Some(bind_address)
             }
         })
         .ok_or_else(|| "unable to determine the validator's public IP address".to_string())?;

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -71,7 +71,7 @@ use {
     std::{
         collections::HashSet,
         fs::{self, File},
-        net::{IpAddr, SocketAddr},
+        net::{IpAddr, Ipv4Addr, SocketAddr},
         num::NonZeroUsize,
         path::{Path, PathBuf},
         process::exit,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -71,7 +71,7 @@ use {
     std::{
         collections::HashSet,
         fs::{self, File},
-        net::{IpAddr, Ipv4Addr, SocketAddr},
+        net::{IpAddr, SocketAddr},
         num::NonZeroUsize,
         path::{Path, PathBuf},
         process::exit,


### PR DESCRIPTION
Builds on #212 

#### Problem
Invalidator buildkite pipeline failing to fetch the `alpenglow-vote` program repo with ssh credentials.

Example of failure for invalidator pipeline:
https://buildkite.com/anza/infra-invalidator/builds/2026#01977ffa-7548-4e91-84b9-0f58257a47bd
![image](https://github.com/user-attachments/assets/530ee932-fe1e-4569-b260-3eae060cbae2)

#### Summary of Changes
Switch to https. This repo is public now