### PR TITLE
parent_ready: only update highest parent ready if a parent was added

### DIFF
--- a/core/src/alpenglow_consensus/parent_ready_tracker.rs
+++ b/core/src/alpenglow_consensus/parent_ready_tracker.rs
@@ -145,6 +145,10 @@ impl ParentReadyTracker {
             }
         }
 
+        if potential_parents.is_empty() {
+            return;
+        }
+
         // Add these as valid parents to the future slots
         for s in future_slots {
             trace!(
@@ -265,5 +269,23 @@ mod tests {
         assert!(tracker.parent_ready(root_slot + 3, root_block));
         assert!(tracker.parent_ready(root_slot + 5, block));
         assert_eq!(tracker.highest_parent_ready(), root_slot + 5);
+    }
+
+    #[test]
+    fn highest_parent_ready_out_of_order() {
+        let genesis = Block::default();
+        let mut tracker = ParentReadyTracker::new(Pubkey::default(), genesis);
+        assert_eq!(tracker.highest_parent_ready(), 1);
+
+        tracker.add_new_skip(2);
+        assert_eq!(tracker.highest_parent_ready(), 1);
+
+        tracker.add_new_skip(3);
+        assert_eq!(tracker.highest_parent_ready(), 1);
+
+        tracker.add_new_skip(1);
+        assert!(tracker.parent_ready(4, genesis));
+        assert_eq!(tracker.highest_parent_ready(), 4);
+        assert_eq!(tracker.block_production_parent(4), Some(genesis));
     }
 }


### PR DESCRIPTION
#### Problem
We update the `highest_with_parent_ready` regardless of whether we actually inserted a new parent.
This causes the `voting_loop` to progress even if there isn't actually a proper chain of notarize fallback / skip certificates up to the `highest_with_parent_ready` slot.

Although usually this isn't a problem because the certificates will eventually come in, if the node is a leader for the next window, and the certificates are coming in out of order, we could end up calling `block_production_parent` and failing:
```
thread 'solVotingLoop' panicked at core/src/alpenglow_consensus/voting_loop.rs:272:22:
Must have a block production parent in sequential voting loop
```

#### Summary of Changes
Only update `highest_with_parent_ready` if a higher slot actually reached `parent_ready` status, and add a test for this out of order certificate condition
