### PR TITLE
Gossip host upstream

### DIFF
--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -28,7 +28,7 @@ while [[ -n $1 ]]; do
     if [[ $1 = --init-complete-file ]]; then
       args+=("$1" "$2")
       shift 2
-    elif [[ $1 = --gossip-host ]]; then
+    elif [[ $1 = --bind-address ]]; then
       args+=("$1" "$2")
       shift 2
     elif [[ $1 = --gossip-port ]]; then

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -279,7 +279,7 @@ EOF
       fi
     fi
     args=(
-      --gossip-host "$entrypointIp"
+      --bind-address "$entrypointIp"
       --gossip-port 8001
       --init-complete-file "$initCompleteFile"
     )

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -173,11 +173,14 @@ fn main() {
             exit(1);
         })
     });
-    let bind_address = matches.value_of("bind_address").map(|bind_address| {
-        solana_net_utils::parse_host(bind_address).unwrap_or_else(|err| {
-            eprintln!("Failed to parse --bind-address: {err}");
-            exit(1);
-        })
+    let bind_address = solana_net_utils::parse_host(
+        matches
+            .value_of("bind_address")
+            .expect("Bind address has default value"),
+    )
+    .unwrap_or_else(|err| {
+        eprintln!("Failed to parse --bind-address: {err}");
+        exit(1);
     });
 
     let advertised_ip = if let Some(ip) = gossip_host {
@@ -560,9 +563,7 @@ fn main() {
         genesis.port_range(dynamic_port_range);
     }
 
-    if let Some(bind_address) = bind_address {
-        genesis.bind_ip_addr(bind_address);
-    }
+    genesis.bind_ip_addr(bind_address);
 
     if matches.is_present("geyser_plugin_config") {
         genesis.geyser_plugin_config_files = Some(

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -160,6 +160,7 @@ fn main() {
     let ticks_per_slot = value_t!(matches, "ticks_per_slot", u64).ok();
     let slots_per_epoch = value_t!(matches, "slots_per_epoch", Slot).ok();
     let gossip_host = matches.value_of("gossip_host").map(|gossip_host| {
+        warn!("--gossip-host is deprecated. Use --bind-address instead.");
         solana_net_utils::parse_host(gossip_host).unwrap_or_else(|err| {
             eprintln!("Failed to parse --gossip-host: {err}");
             exit(1);
@@ -178,6 +179,15 @@ fn main() {
             exit(1);
         })
     });
+
+    let advertised_ip = if let Some(ip) = gossip_host {
+        ip
+    } else if !bind_address.is_unspecified() && !bind_address.is_loopback() {
+        bind_address
+    } else {
+        IpAddr::V4(Ipv4Addr::LOCALHOST)
+    };
+
     let compute_unit_limit = value_t!(matches, "compute_unit_limit", u64).ok();
 
     let faucet_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), faucet_port);
@@ -540,9 +550,7 @@ fn main() {
         genesis.rent = Rent::with_slots_per_epoch(slots_per_epoch);
     }
 
-    if let Some(gossip_host) = gossip_host {
-        genesis.gossip_host(gossip_host);
-    }
+    genesis.gossip_host(advertised_ip);
 
     if let Some(gossip_port) = gossip_port {
         genesis.gossip_port(gossip_port);

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -867,8 +867,8 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .value_name("HOST")
                 .takes_value(true)
                 .validator(solana_net_utils::is_host)
-                .default_value("0.0.0.0")
-                .help("IP address to bind the validator ports [default: 0.0.0.0]"),
+                .default_value("127.0.0.1")
+                .help("IP address to bind the validator ports [default: 127.0.0.1]"),
         )
         .arg(
             Arg::with_name("clone_account")

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -850,10 +850,8 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .value_name("HOST")
                 .takes_value(true)
                 .validator(solana_net_utils::is_host)
-                .help(
-                    "Gossip DNS name or IP address for the validator to advertise in gossip \
-                     [default: 127.0.0.1]",
-                ),
+                .hidden(hidden_unless_forced())
+                .help("DEPRECATED: Use --bind-address instead."),
         )
         .arg(
             Arg::with_name("dynamic_port_range")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -344,10 +344,8 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .value_name("HOST")
             .takes_value(true)
             .validator(solana_net_utils::is_host)
-            .help(
-                "Gossip DNS name or IP address for the validator to advertise in gossip \
-                 [default: ask --entrypoint, or 127.0.0.1 when --entrypoint is not provided]",
-            ),
+            .hidden(hidden_unless_forced())
+            .help("DEPRECATED: Use --bind-address instead."),
     )
     .arg(
         Arg::with_name("public_tpu_addr")

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -1108,45 +1108,49 @@ pub fn execute(
         },
     );
 
-    let gossip_host: IpAddr = matches
+    let gossip_host = matches
         .value_of("gossip_host")
         .map(|gossip_host| {
+            warn!("--gossip-host is deprecated. Use --bind-address or rely on automatic public IP discovery instead.");
             solana_net_utils::parse_host(gossip_host)
                 .map_err(|err| format!("failed to parse --gossip-host: {err}"))
         })
-        .transpose()?
-        .or_else(|| {
-            if !entrypoint_addrs.is_empty() {
-                let mut order: Vec<_> = (0..entrypoint_addrs.len()).collect();
-                order.shuffle(&mut thread_rng());
-                // Return once we determine our IP from an entrypoint
-                order.into_iter().find_map(|i| {
-                    let entrypoint_addr = &entrypoint_addrs[i];
-                    info!(
-                        "Contacting {} to determine the validator's public IP address",
-                        entrypoint_addr
-                    );
-                    solana_net_utils::get_public_ip_addr_with_binding(entrypoint_addr, bind_address)
-                        .map_or_else(
-                            |err| {
-                                warn!(
-                                    "Failed to contact cluster entrypoint {entrypoint_addr}: {err}"
-                                );
-                                None
-                            },
-                            Some,
-                        )
-                })
-            } else {
-                Some(IpAddr::V4(Ipv4Addr::LOCALHOST))
-            }
-        })
-        .ok_or_else(|| "unable to determine the validator's public IP address".to_string())?;
+        .transpose()?;
+
+    let advertised_ip = if let Some(ip) = gossip_host {
+        ip
+    } else if !bind_address.is_unspecified() && !bind_address.is_loopback() {
+        bind_address
+    } else if !entrypoint_addrs.is_empty() {
+        let mut order: Vec<_> = (0..entrypoint_addrs.len()).collect();
+        order.shuffle(&mut thread_rng());
+
+        order
+            .into_iter()
+            .find_map(|i| {
+                let entrypoint_addr = &entrypoint_addrs[i];
+                info!(
+                    "Contacting {} to determine the validator's public IP address",
+                    entrypoint_addr
+                );
+                solana_net_utils::get_public_ip_addr_with_binding(entrypoint_addr, bind_address)
+                    .map_or_else(
+                        |err| {
+                            warn!("Failed to contact cluster entrypoint {entrypoint_addr}: {err}");
+                            None
+                        },
+                        Some,
+                    )
+            })
+            .ok_or_else(|| "unable to determine the validator's public IP address".to_string())?
+    } else {
+        IpAddr::V4(Ipv4Addr::LOCALHOST)
+    };
     let gossip_port = value_t!(matches, "gossip_port", u16).or_else(|_| {
         solana_net_utils::find_available_port_in_range(bind_address, (0, 1))
             .map_err(|err| format!("unable to find an available gossip port: {err}"))
     })?;
-    let gossip_addr = SocketAddr::new(gossip_host, gossip_port);
+    let gossip_addr = SocketAddr::new(advertised_ip, gossip_port);
 
     let public_tpu_addr = matches
         .value_of("public_tpu_addr")


### PR DESCRIPTION
#### Problem
When starting a boostrap node (no entrypoint args set) without `gossip_host` set, we will fall back to localhost IP. This causes contact info to be filtered out, and other nodes cannot join the cluster. `gossip_host` has been deprecated upstream.

This was discovered when trying to spin up Alpenglow repo on invalidator cluster (it has removed `gossip_host` arg, inline with the upstream deprecation).

#### Summary of Changes
Cherry pick 2 upstream fixes related to this:
https://github.com/anza-xyz/agave/commit/e218d961a14115fa09dccf5a21f10a1e1b272275
https://github.com/anza-xyz/agave/commit/de672d2a81175a866e3a947b7dbede21fe2c054d