### PR TITLE
block_creation_loop: adjust blocktime to always be 400ms

### DIFF
--- a/core/src/alpenglow_consensus.rs
+++ b/core/src/alpenglow_consensus.rs
@@ -182,7 +182,6 @@ pub fn skip_timeout(leader_block_index: usize) -> Duration {
 /// within the leader window
 #[inline]
 pub fn block_timeout(leader_block_index: usize) -> Duration {
-    // TODO: What should be a reasonable buffer for this?
-    // Release the final shred `DELTA`ms before the skip timeout
-    skip_timeout(leader_block_index).saturating_sub(DELTA)
+    // TODO: based on testing, perhaps adjust this
+    BLOCKTIME * (leader_block_index as u32 + 1)
 }


### PR DESCRIPTION
#### Problem
Block time is dynamic at the moment, based  on the skip timeout.
This leads to a longer leader transition.

#### Summary of Changes
Instead as specified in the paper, fix this to the block time
