### PR TITLE
free parent ready tracker

### DIFF
--- a/core/src/alpenglow_consensus/certificate_pool.rs
+++ b/core/src/alpenglow_consensus/certificate_pool.rs
@@ -578,7 +578,8 @@ impl<VC: VoteCertificate> CertificatePool<VC> {
 
     /// Cleanup any old slots from the certificate pool
     pub fn handle_new_root(&mut self, bank: Arc<Bank>) {
-        self.root = bank.slot();
+        let new_root = bank.slot();
+        self.root = new_root;
         // `completed_certificates`` now only contains entries >= `slot`
         self.completed_certificates
             .retain(|cert_id, _| match cert_id {
@@ -588,9 +589,8 @@ impl<VC: VoteCertificate> CertificatePool<VC> {
                 | CertificateId::NotarizeFallback(s, _, _)
                 | CertificateId::Skip(s) => *s >= self.root,
             });
-        self.vote_pools = self
-            .vote_pools
-            .split_off(&(bank.slot(), VoteType::Finalize));
+        self.vote_pools = self.vote_pools.split_off(&(new_root, VoteType::Finalize));
+        self.parent_ready_tracker.set_root(new_root);
         self.update_epoch_stakes_map(&bank);
     }
 }


### PR DESCRIPTION
#### Problem
Parent ready tracker is growing `slot_statuses` indefinitely. Forgot to hook up the `set_root` function, which is where we are supposed to purge stale statuses

#### Summary of Changes

- Call `set_root` from `handle_new_root`
- while in the area, make local variable `new_root` and use that in `handle_new_root`