### PR TITLE
pending blocks orphaning

### DIFF
--- a/core/src/alpenglow_consensus/voting_loop.rs
+++ b/core/src/alpenglow_consensus/voting_loop.rs
@@ -475,7 +475,7 @@ impl VotingLoop {
         trace!("{}: Attempting to set new root {new_root}", ctx.my_pubkey);
         vctx.vote_history.set_root(new_root);
         cert_pool.handle_new_root(ctx.bank_forks.read().unwrap().get(new_root).unwrap());
-        pending_blocks.split_off(&new_root);
+        *pending_blocks = pending_blocks.split_off(&new_root);
         if let Err(e) = ReplayStage::check_and_handle_new_root(
             &ctx.my_pubkey,
             slot,


### PR DESCRIPTION
#### Problem
We're keeping the wrong set of pending blocks in the voting loop, which can lead to holding old banks indefinitely and leaking mem

#### Summary of Changes
Keep only the pending banks ahead of the root