### PR TITLE
replay: stop sending to tower bft related crossbeam channels

### DIFF
--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -672,6 +672,12 @@ impl ClusterInfoVoteListener {
                     }
                 }
                 ParsedVoteTransaction::Tower(vote) => {
+                    if root_bank
+                        .feature_set
+                        .is_active(&solana_feature_set::secp256k1_program_enabled::id())
+                    {
+                        continue;
+                    }
                     let is_gossip_vote = transaction.is_some();
                     Self::track_new_votes_and_notify_confirmations(
                         vote,

--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -629,6 +629,16 @@ impl AncestorHashesService {
                 if exit.load(Ordering::Relaxed) {
                     return;
                 }
+                if repair_info
+                    .bank_forks
+                    .read()
+                    .unwrap()
+                    .root_bank()
+                    .feature_set
+                    .is_active(&solana_feature_set::secp256k1_program_enabled::id())
+                {
+                    return;
+                }
                 Self::manage_ancestor_requests(
                     &ancestor_hashes_request_statuses,
                     &ancestor_hashes_request_socket,

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -721,13 +721,18 @@ impl RepairService {
             repair_metrics,
         );
 
-        Self::handle_popular_pruned_forks(
-            root_bank.clone(),
-            repair_weight,
-            popular_pruned_forks_requests,
-            popular_pruned_forks_sender,
-            repair_metrics,
-        );
+        if !root_bank
+            .feature_set
+            .is_active(&solana_feature_set::secp256k1_program_enabled::id())
+        {
+            Self::handle_popular_pruned_forks(
+                root_bank.clone(),
+                repair_weight,
+                popular_pruned_forks_requests,
+                popular_pruned_forks_sender,
+                repair_metrics,
+            );
+        }
 
         Self::build_and_send_repair_batch(
             serve_repair,

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -167,6 +167,13 @@ fn run_check_duplicate(
             }
         };
 
+        if root_bank
+            .feature_set
+            .is_active(&solana_feature_set::secp256k1_program_enabled::id())
+        {
+            return Ok(());
+        }
+
         // Propagate duplicate proof through gossip
         cluster_info.push_duplicate_shred(&shred1, &shred2)?;
         // Notify duplicate consensus state machine


### PR DESCRIPTION
#### Problem
Unlikely that this is the cause of the memory leak, but these crossbeam channels are no longer received from once the feature flag is active. Since they are `unbounded` this could lead to memory growth:
```
ancestor_duplicate_slots_receiver
duplicate_confirmed_slots_receiver
gossip_verified_vote_hash_receiver
popular_pruned_forks_receiver
duplicate_slots_receiver
```

#### Summary of Changes
Stop sending on these channels when the feature flag is active. Later we can retire these services completely
