### PR TITLE
replay: remove reentrant locking in prune program cache

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -952,6 +952,10 @@ impl<FG: ForkGraph> ProgramCache<FG> {
             error!("Failed to lock fork graph for reading.");
             return;
         };
+        self.prune_locked(new_root_slot, new_root_epoch, &fork_graph);
+    }
+
+    pub fn prune_locked(&mut self, new_root_slot: Slot, new_root_epoch: Epoch, fork_graph: &FG) {
         let mut preparation_phase_ends = false;
         if self.latest_root_epoch != new_root_epoch {
             self.latest_root_epoch = new_root_epoch;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1543,6 +1543,19 @@ impl Bank {
             .prune(new_root_slot, new_root_epoch);
     }
 
+    pub fn prune_program_cache_locked(
+        &self,
+        new_root_slot: Slot,
+        new_root_epoch: Epoch,
+        bank_forks: &BankForks,
+    ) {
+        self.transaction_processor
+            .program_cache
+            .write()
+            .unwrap()
+            .prune_locked(new_root_slot, new_root_epoch, bank_forks);
+    }
+
     pub fn prune_program_cache_by_deployment_slot(&self, deployment_slot: Slot) {
         self.transaction_processor
             .program_cache

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -542,7 +542,7 @@ impl BankForks {
 
     pub fn prune_program_cache(&self, root: Slot) {
         if let Some(root_bank) = self.banks.get(&root) {
-            root_bank.prune_program_cache(root, root_bank.epoch());
+            root_bank.prune_program_cache_locked(root, root_bank.epoch(), self);
         }
     }
 


### PR DESCRIPTION
#### Problem
We grab the bank forks read lock in order to call `prune_program_cache()` , which in turn grabs the read lock again. This can cause a deadlock if a writer requests the lock in between:
1) `handle_new_root` acquires the read lock in order to call prune_program_cache
2) `generate_new_bank_forks` asks for the write lock
3) `prune_program_cache` tries to acquire the read lock again during `fork_graph.read()`
4) Deadlock, as (3) will never complete due to the presence of (2)

#### Summary of Changes
Have `prune_program_cache` pass in `BankForks` to avoid the reentrant locking
