### PR TITLE
blockstore: purge slot_certificates column

### DIFF
--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -315,6 +315,10 @@ impl Blockstore {
             & self
                 .merkle_root_meta_cf
                 .delete_range_in_batch(write_batch, from_slot, to_slot)
+                .is_ok()
+            & self
+                .slot_certificates_cf
+                .delete_range_in_batch(write_batch, from_slot, to_slot)
                 .is_ok();
 
         match purge_type {
@@ -394,6 +398,10 @@ impl Blockstore {
                 .is_ok()
             & self
                 .merkle_root_meta_cf
+                .delete_file_in_range(from_slot, to_slot)
+                .is_ok()
+            & self
+                .slot_certificates_cf
                 .delete_file_in_range(from_slot, to_slot)
                 .is_ok()
     }


### PR DESCRIPTION
#### Problem
The `SlotCertificates` column is never purged as part of the blockstore cleanup process.

Still don't think this is the cause of the memory leak as it shouldn't be correlated to # txs and all in disk. Forgot to do this in #178 🤦 .

#### Summary of Changes
Add it to the `blockstore_purge` list.