### PR TITLE
replay: handle set_root of progress map in replay

### DIFF
--- a/core/src/alpenglow_consensus/voting_loop.rs
+++ b/core/src/alpenglow_consensus/voting_loop.rs
@@ -18,7 +18,6 @@ use {
         commitment_service::{
             AlpenglowCommitmentAggregationData, AlpenglowCommitmentType, CommitmentAggregationData,
         },
-        consensus::progress_map::ProgressMap,
         replay_stage::{
             CompletedBlock, CompletedBlockReceiver, Finalizer, ReplayStage, MAX_VOTE_SIGNATURES,
         },
@@ -119,8 +118,6 @@ struct SharedContext {
     bank_forks: Arc<RwLock<BankForks>>,
     rpc_subscriptions: Arc<RpcSubscriptions>,
     vote_receiver: VoteReceiver,
-    // TODO(ashwin): share this with replay (currently empty)
-    progress: ProgressMap,
     // TODO(ashwin): integrate with gossip set-identity
     my_pubkey: Pubkey,
 }
@@ -244,7 +241,6 @@ impl VotingLoop {
             bank_forks: bank_forks.clone(),
             rpc_subscriptions: rpc_subscriptions.clone(),
             vote_receiver,
-            progress: ProgressMap::default(),
             my_pubkey,
         };
 
@@ -481,7 +477,7 @@ impl VotingLoop {
             slot,
             new_root,
             ctx.bank_forks.as_ref(),
-            &mut ctx.progress,
+            None,
             ctx.blockstore.as_ref(),
             &ctx.leader_schedule_cache,
             accounts_background_request_sender,

--- a/core/src/vote_simulator.rs
+++ b/core/src/vote_simulator.rs
@@ -242,7 +242,7 @@ impl VoteSimulator {
         ReplayStage::handle_new_root(
             new_root,
             &self.bank_forks,
-            &mut self.progress,
+            Some(&mut self.progress),
             &AbsRequestSender::default(),
             None,
             &mut true,

--- a/core/tests/unified_scheduler.rs
+++ b/core/tests/unified_scheduler.rs
@@ -167,7 +167,7 @@ fn test_scheduler_waited_by_drop_bank_service() {
         ReplayStage::handle_new_root(
             root,
             &bank_forks,
-            &mut progress,
+            Some(&mut progress),
             &AbsRequestSender::default(),
             None,
             &mut true,


### PR DESCRIPTION
#### Problem
Scrapping the initial plan of pruning progress from the voting loop, most of the fields are obsolete with alpenglow and the remaining ones are only useful in replay so no need to share this between both threads.

#### Summary of Changes
Prune progress map in replay on successful bank completion.

There's still some fields being populated like the PropagatedStats within progress map that are no longer used, but we can take care of removing them during cleanup post alpenglow. 