### PR TITLE
Handle set-identity in voting loop

### DIFF
--- a/core/src/alpenglow_consensus/block_creation_loop.rs
+++ b/core/src/alpenglow_consensus/block_creation_loop.rs
@@ -166,11 +166,11 @@ pub fn start_loop(config: BlockCreationLoopConfig) {
     // Similar to the voting loop, if this loop dies kill the validator
     let _exit = Finalizer::new(exit.clone());
 
-    // TODO: set-identity
-    let my_pubkey = cluster_info.id();
+    // get latest identity pubkey during startup
+    let mut my_pubkey = cluster_info.id();
     let leader_bank_notifier = poh_recorder.read().unwrap().new_leader_bank_notifier();
 
-    let ctx = LeaderContext {
+    let mut ctx = LeaderContext {
         my_pubkey,
         blockstore,
         poh_recorder: poh_recorder.clone(),
@@ -194,6 +194,16 @@ pub fn start_loop(config: BlockCreationLoopConfig) {
     });
 
     while !exit.load(Ordering::Relaxed) {
+        // Check if set-identity was called at each leader window start
+        if my_pubkey != cluster_info.id() {
+            // set-identity cli has been called during runtime
+            let my_old_pubkey = my_pubkey;
+            my_pubkey = cluster_info.id();
+            ctx.my_pubkey = my_pubkey;
+            
+            warn!("Identity changed from {} to {} during block creation loop", my_old_pubkey, my_pubkey);
+        }
+        
         // Wait for the voting loop to notify us
         let LeaderWindowInfo {
             start_slot,

--- a/core/src/alpenglow_consensus/block_creation_loop.rs
+++ b/core/src/alpenglow_consensus/block_creation_loop.rs
@@ -200,10 +200,13 @@ pub fn start_loop(config: BlockCreationLoopConfig) {
             let my_old_pubkey = my_pubkey;
             my_pubkey = cluster_info.id();
             ctx.my_pubkey = my_pubkey;
-            
-            warn!("Identity changed from {} to {} during block creation loop", my_old_pubkey, my_pubkey);
+
+            warn!(
+                "Identity changed from {} to {} during block creation loop",
+                my_old_pubkey, my_pubkey
+            );
         }
-        
+
         // Wait for the voting loop to notify us
         let LeaderWindowInfo {
             start_slot,

--- a/core/src/alpenglow_consensus/certificate_pool.rs
+++ b/core/src/alpenglow_consensus/certificate_pool.rs
@@ -593,6 +593,13 @@ impl<VC: VoteCertificate> CertificatePool<VC> {
         self.parent_ready_tracker.set_root(new_root);
         self.update_epoch_stakes_map(&bank);
     }
+
+    /// Updates the pubkey used for logging purposes only.
+    /// This avoids the need to recreate the entire certificate pool since it's
+    /// not distinguished by the pubkey.
+    pub fn update_pubkey(&mut self, new_pubkey: Pubkey) {
+        self.parent_ready_tracker.update_pubkey(new_pubkey);
+    }
 }
 
 pub(crate) fn load_from_blockstore(

--- a/core/src/alpenglow_consensus/parent_ready_tracker.rs
+++ b/core/src/alpenglow_consensus/parent_ready_tracker.rs
@@ -206,6 +206,11 @@ impl ParentReadyTracker {
         self.root = root;
         self.slot_statuses.retain(|&s, _| s >= root);
     }
+
+    /// Updates the pubkey. Note that the pubkey is used for logging purposes only.
+    pub fn update_pubkey(&mut self, new_pubkey: Pubkey) {
+        self.my_pubkey = new_pubkey;
+    }
 }
 
 #[cfg(test)]

--- a/core/src/alpenglow_consensus/voting_loop.rs
+++ b/core/src/alpenglow_consensus/voting_loop.rs
@@ -275,7 +275,7 @@ impl VotingLoop {
                     Err(err) => {
                         error!(
                                 "Unable to load new vote history when attempting to change identity from {} \
-                                 to {} on VotingLoop startup, Exiting: {}",
+                                 to {} in voting loop, Exiting: {}",
                                 my_old_pubkey, my_pubkey, err
                             );
                         return;

--- a/core/src/alpenglow_consensus/voting_loop.rs
+++ b/core/src/alpenglow_consensus/voting_loop.rs
@@ -118,7 +118,6 @@ struct SharedContext {
     bank_forks: Arc<RwLock<BankForks>>,
     rpc_subscriptions: Arc<RpcSubscriptions>,
     vote_receiver: VoteReceiver,
-    // TODO(ashwin): integrate with gossip set-identity
     my_pubkey: Pubkey,
 }
 
@@ -284,13 +283,8 @@ impl VotingLoop {
                 voting_context.identity_keypair = identity_keypair.clone();
                 shared_context.my_pubkey = my_pubkey;
                 
-                // Recreate certificate pool with new identity
-                cert_pool = certificate_pool::load_from_blockstore(
-                    &my_pubkey,
-                    &root_bank_cache.root_bank(),
-                    blockstore.as_ref(),
-                    Some(certificate_sender),
-                );
+                // Update the certificate pool's pubkey (which is used for logging purposes)
+                cert_pool.update_pubkey(my_pubkey);
                 
                 warn!("{my_pubkey}: Identity changed from {my_old_pubkey} to {my_pubkey}");
             }

--- a/core/src/alpenglow_consensus/voting_loop.rs
+++ b/core/src/alpenglow_consensus/voting_loop.rs
@@ -199,14 +199,14 @@ impl VotingLoop {
             let my_old_pubkey = vote_history.node_pubkey;
             vote_history = match VoteHistory::restore(vote_history_storage.as_ref(), &my_pubkey) {
                 Ok(vote_history) => vote_history,
-                    Err(err) => {
-                        error!(
+                Err(err) => {
+                    error!(
                             "Unable to load new vote history when attempting to change identity from {} \
                              to {} on VotingLoop startup, Exiting: {}",
                             my_old_pubkey, my_pubkey, err
                         );
-                        return;
-                    }
+                    return;
+                }
             };
             warn!(
                 "Identity changed during startup from {} to {}",
@@ -267,25 +267,28 @@ impl VotingLoop {
                 let my_old_pubkey = my_pubkey;
                 my_pubkey = identity_keypair.pubkey();
 
-                voting_context.vote_history = match VoteHistory::restore(vote_history_storage.as_ref(), &my_pubkey) {
+                voting_context.vote_history = match VoteHistory::restore(
+                    vote_history_storage.as_ref(),
+                    &my_pubkey,
+                ) {
                     Ok(vote_history) => vote_history,
-                        Err(err) => {
-                            error!(
+                    Err(err) => {
+                        error!(
                                 "Unable to load new vote history when attempting to change identity from {} \
                                  to {} on VotingLoop startup, Exiting: {}",
                                 my_old_pubkey, my_pubkey, err
                             );
-                            return;
-                        }
+                        return;
+                    }
                 };
-                
+
                 // Update contexts with new identity
                 voting_context.identity_keypair = identity_keypair.clone();
                 shared_context.my_pubkey = my_pubkey;
-                
+
                 // Update the certificate pool's pubkey (which is used for logging purposes)
                 cert_pool.update_pubkey(my_pubkey);
-                
+
                 warn!("{my_pubkey}: Identity changed from {my_old_pubkey} to {my_pubkey}");
             }
 

--- a/core/src/alpenglow_consensus/voting_loop.rs
+++ b/core/src/alpenglow_consensus/voting_loop.rs
@@ -168,8 +168,8 @@ impl VotingLoop {
             vote_account,
             wait_to_vote_slot,
             wait_for_vote_to_start_leader,
-            vote_history,
-            vote_history_storage: _, // TODO: set-identity
+            mut vote_history,
+            vote_history_storage,
             authorized_voter_keypairs,
             blockstore,
             bank_forks,
@@ -190,13 +190,29 @@ impl VotingLoop {
         let _exit = Finalizer::new(exit.clone());
         let mut root_bank_cache = RootBankCache::new(bank_forks.clone());
 
-        let identity_keypair = cluster_info.keypair().clone();
-        let my_pubkey = identity_keypair.pubkey();
+        let mut identity_keypair = cluster_info.keypair().clone();
+        let mut my_pubkey = identity_keypair.pubkey();
         let has_new_vote_been_rooted = !wait_for_vote_to_start_leader;
         // TODO(ashwin): handle set identity here and in loop
         // reminder prev 3 need to be mutable
         if my_pubkey != vote_history.node_pubkey {
-            todo!();
+            // set-identity has been called during startup
+            let my_old_pubkey = vote_history.node_pubkey;
+            vote_history = match VoteHistory::restore(vote_history_storage.as_ref(), &my_pubkey) {
+                Ok(vote_history) => vote_history,
+                    Err(err) => {
+                        error!(
+                            "Unable to load new vote history when attempting to change identity from {} \
+                             to {} on VotingLoop startup, Exiting: {}",
+                            my_old_pubkey, my_pubkey, err
+                        );
+                        return;
+                    }
+            };
+            warn!(
+                "Identity changed during startup from {} to {}",
+                my_old_pubkey, my_pubkey
+            );
         }
 
         let mut current_leader = None;
@@ -227,7 +243,7 @@ impl VotingLoop {
         let mut voting_context = VotingContext {
             vote_history,
             vote_account_pubkey: vote_account,
-            identity_keypair,
+            identity_keypair: identity_keypair.clone(),
             authorized_voter_keypairs,
             has_new_vote_been_rooted,
             voting_sender,
@@ -246,6 +262,39 @@ impl VotingLoop {
 
         // TODO(ashwin): Start loop once migration is complete current_slot from vote history
         loop {
+            // Check if set-identity was called during runtime. Do this before the `is_leader` check.
+            if my_pubkey != cluster_info.id() {
+                identity_keypair = cluster_info.keypair().clone();
+                let my_old_pubkey = my_pubkey;
+                my_pubkey = identity_keypair.pubkey();
+
+                voting_context.vote_history = match VoteHistory::restore(vote_history_storage.as_ref(), &my_pubkey) {
+                    Ok(vote_history) => vote_history,
+                        Err(err) => {
+                            error!(
+                                "Unable to load new vote history when attempting to change identity from {} \
+                                 to {} on VotingLoop startup, Exiting: {}",
+                                my_old_pubkey, my_pubkey, err
+                            );
+                            return;
+                        }
+                };
+                
+                // Update contexts with new identity
+                voting_context.identity_keypair = identity_keypair.clone();
+                shared_context.my_pubkey = my_pubkey;
+                
+                // Recreate certificate pool with new identity
+                cert_pool = certificate_pool::load_from_blockstore(
+                    &my_pubkey,
+                    &root_bank_cache.root_bank(),
+                    blockstore.as_ref(),
+                    Some(certificate_sender),
+                );
+                
+                warn!("{my_pubkey}: Identity changed from {my_old_pubkey} to {my_pubkey}");
+            }
+
             let leader_end_slot = last_of_consecutive_leader_slots(current_slot);
 
             let Some(leader_pubkey) = leader_schedule_cache

--- a/core/src/alpenglow_consensus/voting_loop.rs
+++ b/core/src/alpenglow_consensus/voting_loop.rs
@@ -202,7 +202,7 @@ impl VotingLoop {
                 Err(err) => {
                     error!(
                             "Unable to load new vote history when attempting to change identity from {} \
-                             to {} on VotingLoop startup, Exiting: {}",
+                             to {} on voting loop startup, Exiting: {}",
                             my_old_pubkey, my_pubkey, err
                         );
                     return;


### PR DESCRIPTION
#### Problem
Implements #121

#### Summary of Changes
For the voting loop, I've added code that fetches the vote history for the new pubkey, if the `set-identity` was called during startup. If it was called during the main loop, I update the pubkey and fetch the vote history for the new pubkey, and update related contexts & certificate pool where the pubkey is used in.
* For the main loop, I check this before the pubkey is used, such as in the `is_leader` boolean.

For the block creation loop, I update the pubkey if `set-identity` was called during the main loop.
* For the startup of the block creation loop, the original issue mentions "If set-identity has been called during startup, update pubkey in block creation loop". I'm unsure if I'm misunderstanding, but isn't this already implemented in [line 170](https://github.com/anza-xyz/alpenglow/blob/34d86a1c8651b3455b440915a9b510e56126720d/core/src/alpenglow_consensus/block_creation_loop.rs#L170) where it fetches the latest pubkey during the function's startup?
