### PR TITLE
voting_loop: send optimistically confirmed BankNotification

### DIFF
--- a/core/src/alpenglow_consensus/voting_loop.rs
+++ b/core/src/alpenglow_consensus/voting_loop.rs
@@ -504,6 +504,10 @@ impl VotingLoop {
                 new_root, &e
             );
         }
+        // It is critical to send the OC notification in order to keep compatibility with
+        // the RPC API. Additionally the PrioritizationFeeCache relies on this notification
+        // in order to perform cleanup. In the future we will look to deprecate OC and remove
+        // these code paths.
         if let Some(config) = bank_notification_sender {
             config
                 .sender


### PR DESCRIPTION
#### Problem
We no longer send the optimistically confirmed notification as Alpenglow has no notion of OC.
This breaks RPC and most importantly the prioritization fee cache, as it relies on the RPC notification in order to perform cleanup. See https://github.com/anza-xyz/alpenglow/issues/240.

#### Summary of Changes
Similar to inserting the new highest finalized slot as an OC slot in blockstore, also send the `BankNotification::OptimisticallyConfirmed`

In the future we can deprecate and look to remove the OC notifications/commitment level across the board.

Fixes #240 