### PR TITLE
voting_loop: only block on pending blocks if bank is not present

### DIFF
--- a/core/src/alpenglow_consensus/voting_loop.rs
+++ b/core/src/alpenglow_consensus/voting_loop.rs
@@ -394,17 +394,17 @@ impl VotingLoop {
                             pending_blocks.remove(&current_slot);
                             break;
                         }
-                    }
-
-                    // Ingest replayed blocks
-                    match completed_block_receiver
-                        .recv_timeout(timeout.saturating_sub(skip_timer.elapsed()))
-                    {
-                        Ok(CompletedBlock { slot, bank }) => {
-                            pending_blocks.insert(slot, bank);
+                    } else {
+                        // Ingest replayed blocks
+                        match completed_block_receiver
+                            .recv_timeout(timeout.saturating_sub(skip_timer.elapsed()))
+                        {
+                            Ok(CompletedBlock { slot, bank }) => {
+                                pending_blocks.insert(slot, bank);
+                            }
+                            Err(RecvTimeoutError::Timeout) => (),
+                            Err(RecvTimeoutError::Disconnected) => return,
                         }
-                        Err(RecvTimeoutError::Timeout) => (),
-                        Err(RecvTimeoutError::Disconnected) => return,
                     }
                 }
 


### PR DESCRIPTION
## Problem
A transient error such as block id not present due to broadcast stage being slow causes us to block on another pending block.

## Summary of Changes
Only block on pending blocks if we have not yet finished replay

This should look a lot cleaner once we refactor into an event driven approach. Also missing the certificate pool ingestion in this loop in case the leader picks a different parent ready, will need that once we have more involved testing.