### PR TITLE
only send block to voting loop once block_id is available

### DIFF
--- a/core/src/alpenglow_consensus/voting_loop.rs
+++ b/core/src/alpenglow_consensus/voting_loop.rs
@@ -377,8 +377,6 @@ impl VotingLoop {
 
                     // Check if replay has successfully completed
                     if let Some(bank) = pending_blocks.get(&current_slot) {
-                        debug_assert!(bank.is_frozen());
-                        debug_assert!(bank.block_id().is_some());
                         // Vote notarize
                         if Self::try_notar(
                             &my_pubkey,

--- a/core/src/alpenglow_consensus/voting_loop.rs
+++ b/core/src/alpenglow_consensus/voting_loop.rs
@@ -18,17 +18,14 @@ use {
         commitment_service::{
             AlpenglowCommitmentAggregationData, AlpenglowCommitmentType, CommitmentAggregationData,
         },
-        replay_stage::{
-            CompletedBlock, CompletedBlockReceiver, Finalizer, ReplayStage, MAX_VOTE_SIGNATURES,
-        },
+        replay_stage::{Finalizer, ReplayStage, MAX_VOTE_SIGNATURES},
         voting_service::VoteOp,
     },
     alpenglow_vote::vote::Vote,
     crossbeam_channel::{RecvTimeoutError, Sender},
-    solana_feature_set::FeatureSet,
     solana_gossip::cluster_info::ClusterInfo,
     solana_ledger::{
-        blockstore::Blockstore,
+        blockstore::{Blockstore, CompletedBlock, CompletedBlockReceiver},
         leader_schedule_cache::LeaderScheduleCache,
         leader_schedule_utils::{
             first_of_consecutive_leader_slots, last_of_consecutive_leader_slots, leader_slot_index,
@@ -46,7 +43,6 @@ use {
     },
     solana_sdk::{
         clock::{Slot, NUM_CONSECUTIVE_LEADER_SLOTS},
-        hash::Hash,
         pubkey::Pubkey,
         signature::{Keypair, Signature, Signer},
         timing::timestamp,
@@ -382,11 +378,11 @@ impl VotingLoop {
                     // Check if replay has successfully completed
                     if let Some(bank) = pending_blocks.get(&current_slot) {
                         debug_assert!(bank.is_frozen());
+                        debug_assert!(bank.block_id().is_some());
                         // Vote notarize
                         if Self::try_notar(
                             &my_pubkey,
                             bank.as_ref(),
-                            &blockstore,
                             &mut cert_pool,
                             &mut voting_context,
                         ) {
@@ -394,17 +390,32 @@ impl VotingLoop {
                             pending_blocks.remove(&current_slot);
                             break;
                         }
+                    } else {
+                        // Block on replay ingest
+                        match completed_block_receiver
+                            .recv_timeout(timeout.saturating_sub(skip_timer.elapsed()))
+                        {
+                            Ok(CompletedBlock { slot, bank }) => {
+                                pending_blocks.insert(slot, bank);
+                                // Reassess if we can vote
+                                continue;
+                            }
+                            Err(RecvTimeoutError::Timeout) => continue,
+                            Err(RecvTimeoutError::Disconnected) => return,
+                        }
                     }
 
-                    // Ingest replayed blocks
-                    match completed_block_receiver
-                        .recv_timeout(timeout.saturating_sub(skip_timer.elapsed()))
-                    {
-                        Ok(CompletedBlock { slot, bank }) => {
-                            pending_blocks.insert(slot, bank);
-                        }
-                        Err(RecvTimeoutError::Timeout) => (),
-                        Err(RecvTimeoutError::Disconnected) => return,
+                    // Block on certificate ingest
+                    if let Err(e) = Self::ingest_votes_into_certificate_pool(
+                        &my_pubkey,
+                        &shared_context.vote_receiver,
+                        &mut cert_pool,
+                        &voting_context.commitment_sender,
+                        timeout.saturating_sub(skip_timer.elapsed()),
+                    ) {
+                        error!("{my_pubkey}: error ingesting votes into certificate pool, exiting: {e:?}");
+                        // Finalizer will set exit flag
+                        return;
                     }
                 }
 
@@ -420,6 +431,8 @@ impl VotingLoop {
                         &shared_context.vote_receiver,
                         &mut cert_pool,
                         &voting_context.commitment_sender,
+                        // Need to provide a timeout to check exit flag
+                        Duration::from_secs(1),
                     ) {
                         error!("{my_pubkey}: error ingesting votes into certificate pool, exiting: {e:?}");
                         // Finalizer will set exit flag
@@ -564,51 +577,6 @@ impl VotingLoop {
         Some(new_root)
     }
 
-    /// Gets the block id of a bank. If this is a leader bank,
-    /// shredding might not be complete when initially set, so update
-    /// the bank for children checks later
-    fn get_set_block_id(my_pubkey: &Pubkey, bank: &Bank, blockstore: &Blockstore) -> Option<Hash> {
-        let is_leader = bank.collector_id() == my_pubkey;
-
-        if bank.slot() == 0 {
-            // Genesis does not have a block id
-            return Some(Hash::default());
-        }
-        if bank.block_id().is_some() {
-            return bank.block_id();
-        }
-
-        if !is_leader {
-            warn!(
-                "{my_pubkey}: Unable to retrieve block id or duplicate block checks have failed
-                for non leader slot {} {}",
-                bank.slot(),
-                bank.hash()
-            );
-            return None;
-        }
-
-        // We are leader attempt to retrieve from blockstore
-        // TODO:(ashwin) We are leader ignore duplicate block checks and just get from last shred?
-        let block_id = blockstore
-            .check_last_fec_set_and_get_block_id(
-                bank.slot(),
-                bank.hash(),
-                is_leader,
-                &FeatureSet::all_enabled(),
-            )
-            .unwrap_or(None);
-
-        if block_id.is_some() {
-            // Prior to asynchronous execution, the leader's blocks could be frozen before shredded
-            // As such we choose to set the block id here, so that future parent block id lookups
-            // succeed. Since the scope of parent block id lookups is the voting loop, doing it here
-            // suffices, but if the scope expands we could consider moving this to replay.
-            bank.set_block_id(block_id);
-        }
-        block_id
-    }
-
     /// Attempts to create and send a skip vote for all unvoted slots in `[start, end]`
     fn try_skip_window(
         my_pubkey: &Pubkey,
@@ -675,11 +643,11 @@ impl VotingLoop {
     /// The conditions are:
     /// - If this is the first leader block of this window, check for notarization and skip certificates
     /// - Else ensure that this is a consecutive slot and that we have voted notarize on the parent
-    /// - Finally check if the block id for `bank` is present and passes the duplicate checks
+    ///
+    /// Returns false if these conditions fail
     fn try_notar(
         my_pubkey: &Pubkey,
         bank: &Bank,
-        blockstore: &Blockstore,
         cert_pool: &mut CertificatePool<LegacyVoteCertificate>,
         voting_context: &mut VotingContext,
     ) -> bool {
@@ -689,13 +657,10 @@ impl VotingLoop {
 
         let parent_slot = bank.parent_slot();
         let parent_bank_hash = bank.parent_hash();
-        let parent_block_id = Self::get_set_block_id(
-            my_pubkey,
-            bank.parent().expect("Cannot vote on genesis").as_ref(),
-            blockstore,
-        )
-        // To account for child of genesis and snapshots we allow default block id
-        .unwrap_or_default();
+        let parent_block_id = bank
+            .parent_block_id()
+            // To account for child of genesis and snapshots we allow default block id
+            .unwrap_or_default();
 
         // Check if the certificates are valid for us to vote notarize.
         // - If this is the first leader slot (leader index = 0 or slot = 1) check
@@ -728,7 +693,7 @@ impl VotingLoop {
         }
 
         // Broadcast notarize vote
-        let voted = Self::vote_notarize(my_pubkey, bank, blockstore, cert_pool, voting_context);
+        let voted = Self::vote_notarize(my_pubkey, bank, cert_pool, voting_context);
 
         // Try to finalize
         Self::try_final(my_pubkey, slot, bank, cert_pool, voting_context);
@@ -736,23 +701,19 @@ impl VotingLoop {
     }
 
     /// Create and send a Notarization or Finalization vote
-    /// Attempts to retrieve the block id from blockstore.
-    ///
-    /// Returns false if we should attempt to retry this vote later
-    /// because the block_id/bank hash is not yet populated.
     fn vote_notarize(
         my_pubkey: &Pubkey,
         bank: &Bank,
-        blockstore: &Blockstore,
         cert_pool: &mut CertificatePool<LegacyVoteCertificate>,
         voting_context: &mut VotingContext,
     ) -> bool {
         debug_assert!(bank.is_frozen());
+        debug_assert!(bank.block_id().is_some());
         let slot = bank.slot();
         let hash = bank.hash();
-        let Some(block_id) = Self::get_set_block_id(my_pubkey, bank, blockstore) else {
-            return false;
-        };
+        let block_id = bank
+            .block_id()
+            .expect("Block id must be present for all banks in pending_blocks");
 
         info!("{my_pubkey}: Voting notarize for slot {slot} hash {hash} block_id {block_id}");
         let vote = Vote::new_notarization_vote(slot, block_id, hash);
@@ -1028,6 +989,7 @@ impl VotingLoop {
         vote_receiver: &VoteReceiver,
         cert_pool: &mut CertificatePool<LegacyVoteCertificate>,
         commitment_sender: &Sender<CommitmentAggregationData>,
+        timeout: Duration,
     ) -> Result<(), AddVoteError> {
         let add_to_cert_pool =
             |(vote, vote_account_pubkey, tx): (Vote, Pubkey, VersionedTransaction)| {
@@ -1049,7 +1011,7 @@ impl VotingLoop {
                 }
             };
 
-        let Ok(first) = vote_receiver.recv_timeout(Duration::from_secs(1)) else {
+        let Ok(first) = vote_receiver.recv_timeout(timeout) else {
             // Either timeout or sender disconnected, return so we can check exit
             return Ok(());
         };

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -41,7 +41,7 @@ use {
         voting_service::VoteOp,
         window_service::DuplicateSlotReceiver,
     },
-    crossbeam_channel::{unbounded, Receiver, RecvTimeoutError, Sender},
+    crossbeam_channel::{Receiver, RecvTimeoutError, Sender},
     rayon::{
         iter::{IntoParallelIterator, ParallelIterator},
         ThreadPool,
@@ -52,7 +52,7 @@ use {
     solana_gossip::cluster_info::ClusterInfo,
     solana_ledger::{
         block_error::BlockError,
-        blockstore::Blockstore,
+        blockstore::{Blockstore, CompletedBlock, CompletedBlockReceiver, CompletedBlockSender},
         blockstore_processor::{
             self, BlockstoreProcessorError, ConfirmationProgress, ExecuteBatchesInternalMetrics,
             ReplaySlotStats, TransactionStatusSender,
@@ -112,15 +112,6 @@ pub const DUPLICATE_THRESHOLD: f64 = 1.0 - SWITCH_FORK_THRESHOLD - DUPLICATE_LIV
 pub(crate) const MAX_VOTE_SIGNATURES: usize = 200;
 const MAX_VOTE_REFRESH_INTERVAL_MILLIS: usize = 5000;
 const MAX_REPAIR_RETRY_LOOP_ATTEMPTS: usize = 10;
-
-pub struct CompletedBlock {
-    pub slot: Slot,
-    // TODO: once we have the async execution changes this can be (block_id, parent_block_id) instead
-    pub bank: Arc<Bank>,
-}
-
-pub type CompletedBlockSender = Sender<CompletedBlock>;
-pub type CompletedBlockReceiver = Receiver<CompletedBlock>;
 
 #[cfg(test)]
 static_assertions::const_assert!(REFRESH_VOTE_BLOCKHEIGHT < solana_sdk::clock::MAX_PROCESSING_AGE);
@@ -308,6 +299,7 @@ pub struct ReplaySenders {
     pub dumped_slots_sender: Sender<Vec<(u64, Hash)>>,
     pub alpenglow_vote_sender: AlpenglowVoteSender,
     pub certificate_sender: Sender<(CertificateId, LegacyVoteCertificate)>,
+    pub completed_block_sender: CompletedBlockSender,
 }
 
 pub struct ReplayReceivers {
@@ -318,6 +310,7 @@ pub struct ReplayReceivers {
     pub gossip_verified_vote_hash_receiver: Receiver<(Pubkey, u64, Hash)>,
     pub popular_pruned_forks_receiver: Receiver<Vec<u64>>,
     pub alpenglow_vote_receiver: AlpenglowVoteReceiver,
+    pub completed_block_receiver: CompletedBlockReceiver,
 }
 
 /// Timing information for the ReplayStage main processing loop
@@ -612,6 +605,7 @@ impl ReplayStage {
             dumped_slots_sender,
             alpenglow_vote_sender,
             certificate_sender,
+            completed_block_sender,
         } = senders;
 
         let ReplayReceivers {
@@ -622,6 +616,7 @@ impl ReplayStage {
             gossip_verified_vote_hash_receiver,
             popular_pruned_forks_receiver,
             alpenglow_vote_receiver,
+            completed_block_receiver,
         } = receivers;
 
         trace!("replay stage");
@@ -663,7 +658,6 @@ impl ReplayStage {
             .highest_frozen_bank()
             .map_or(0, |hfs| hfs.slot());
         *replay_highest_frozen.highest_frozen_slot.lock().unwrap() = highest_frozen_slot;
-        let (completed_block_sender, completed_block_receiver) = unbounded();
 
         let voting_loop = if is_alpenglow_migration_complete {
             info!("Starting alpenglow voting loop");
@@ -687,7 +681,7 @@ impl ReplayStage {
                 bank_notification_sender: bank_notification_sender.clone(),
                 leader_window_notifier,
                 certificate_sender,
-                completed_block_receiver,
+                completed_block_receiver: completed_block_receiver.clone(),
                 vote_receiver: alpenglow_vote_receiver,
             };
             Some(VotingLoop::new(voting_loop_config))
@@ -883,6 +877,10 @@ impl ReplayStage {
 
                 let forks_root = bank_forks.read().unwrap().root();
                 let start_leader_time = if !is_alpenglow_migration_complete {
+                    // TODO(ashwin): This will be moved to the event coordinator once we figure out
+                    // migration
+                    for _ in completed_block_receiver.try_iter() {}
+
                     // Process cluster-agreed versions of duplicate slots for which we potentially
                     // have the wrong version. Our version was dead or pruned.
                     // Signalled by ancestor_hashes_service.
@@ -3607,7 +3605,9 @@ impl ReplayStage {
                     }
                 }
 
-                if *is_alpenglow_migration_complete {
+                if *is_alpenglow_migration_complete && bank.block_id().is_some() {
+                    // Leader blocks will not have a block id, broadcast stage will
+                    // take care of notifying the voting loop
                     let _ = completed_block_sender.send(CompletedBlock {
                         slot: bank.slot(),
                         bank: bank.clone_without_scheduler(),

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -31,7 +31,8 @@ use {
     solana_client::connection_cache::ConnectionCache,
     solana_gossip::cluster_info::ClusterInfo,
     solana_ledger::{
-        blockstore::Blockstore, blockstore_processor::TransactionStatusSender,
+        blockstore::{Blockstore, CompletedBlockSender},
+        blockstore_processor::TransactionStatusSender,
         entry_notifier_service::EntryNotifierSender,
     },
     solana_perf::data_budget::DataBudget,
@@ -120,6 +121,7 @@ impl Tpu {
         alpenglow_vote_sender: AlpenglowVoteSender,
         connection_cache: &Arc<ConnectionCache>,
         turbine_quic_endpoint_sender: AsyncSender<(SocketAddr, Bytes)>,
+        completed_block_sender: CompletedBlockSender,
         keypair: &Keypair,
         log_messages_bytes_limit: Option<usize>,
         staked_nodes: &Arc<RwLock<StakedNodes>>,
@@ -333,6 +335,7 @@ impl Tpu {
             bank_forks,
             shred_version,
             turbine_quic_endpoint_sender,
+            completed_block_sender,
         );
 
         (

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1539,6 +1539,7 @@ impl Validator {
             Arc::<RwLock<repair::repair_service::OutstandingShredRepairs>>::default();
         let cluster_slots =
             Arc::new(crate::cluster_slots_service::cluster_slots::ClusterSlots::default());
+        let (completed_block_sender, completed_block_receiver) = bounded(1000);
 
         let tvu = Tvu::new(
             vote_account,
@@ -1608,6 +1609,8 @@ impl Validator {
             replay_highest_frozen,
             leader_window_notifier,
             config.voting_service_additional_listeners.as_ref(),
+            completed_block_sender.clone(),
+            completed_block_receiver,
         )
         .map_err(ValidatorError::Other)?;
 
@@ -1666,6 +1669,7 @@ impl Validator {
             alpenglow_vote_sender,
             &connection_cache,
             turbine_quic_endpoint_sender,
+            completed_block_sender,
             &identity_keypair,
             config.runtime_config.log_messages_bytes_limit,
             &staked_nodes,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1539,6 +1539,8 @@ impl Validator {
             Arc::<RwLock<repair::repair_service::OutstandingShredRepairs>>::default();
         let cluster_slots =
             Arc::new(crate::cluster_slots_service::cluster_slots::ClusterSlots::default());
+        // This channel backing up indicates a serious problem in the voting loop
+        // Capping at 1000 for now, TODO: add metrics for channel len
         let (completed_block_sender, completed_block_receiver) = bounded(1000);
 
         let tvu = Tvu::new(

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -192,6 +192,14 @@ impl<T> AsRef<T> for WorkingEntry<T> {
     }
 }
 
+pub struct CompletedBlock {
+    pub slot: Slot,
+    // TODO: once we have the async execution changes this can be (block_id, parent_block_id) instead
+    pub bank: Arc<Bank>,
+}
+pub type CompletedBlockSender = Sender<CompletedBlock>;
+pub type CompletedBlockReceiver = Receiver<CompletedBlock>;
+
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct LastFECSetCheckResults {
     last_fec_set_merkle_root: Option<Hash>,

--- a/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
@@ -4,7 +4,10 @@ use {
     crossbeam_channel::Sender,
     itertools::Itertools,
     solana_entry::entry::Entry,
-    solana_ledger::shred::{ProcessShredsStats, ReedSolomonCache, Shredder},
+    solana_ledger::{
+        blockstore::CompletedBlockSender,
+        shred::{ProcessShredsStats, ReedSolomonCache, Shredder},
+    },
     solana_sdk::{
         hash::Hash,
         signature::{Keypair, Signature, Signer},
@@ -82,6 +85,7 @@ impl BroadcastRun for BroadcastDuplicatesRun {
         receiver: &Receiver<WorkingBankEntry>,
         socket_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
         blockstore_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
+        _completed_block_sender: &CompletedBlockSender,
     ) -> Result<()> {
         // 1) Pull entries from banking stage
         let mut receive_results = broadcast_utils::recv_slot_entries(receiver)?;

--- a/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
@@ -2,7 +2,10 @@ use {
     super::*,
     solana_entry::entry::Entry,
     solana_gossip::contact_info::ContactInfo,
-    solana_ledger::shred::{self, ProcessShredsStats, ReedSolomonCache, Shredder},
+    solana_ledger::{
+        blockstore::CompletedBlockSender,
+        shred::{self, ProcessShredsStats, ReedSolomonCache, Shredder},
+    },
     solana_sdk::{hash::Hash, signature::Keypair},
 };
 
@@ -35,6 +38,7 @@ impl BroadcastRun for BroadcastFakeShredsRun {
         receiver: &Receiver<WorkingBankEntry>,
         socket_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
         blockstore_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
+        _completed_block_sender: &CompletedBlockSender,
     ) -> Result<()> {
         // 1) Pull entries from banking stage
         let receive_results = broadcast_utils::recv_slot_entries(receiver)?;

--- a/turbine/src/broadcast_stage/broadcast_utils.rs
+++ b/turbine/src/broadcast_stage/broadcast_utils.rs
@@ -4,7 +4,7 @@ use {
     crossbeam_channel::Receiver,
     solana_entry::entry::Entry,
     solana_ledger::{
-        blockstore::Blockstore,
+        blockstore::{Blockstore, CompletedBlock, CompletedBlockSender},
         shred::{self, ShredData},
     },
     solana_poh::poh_recorder::WorkingBankEntry,
@@ -117,6 +117,20 @@ pub(super) fn get_chained_merkle_root_from_parent(
         slot: parent,
         index,
     })
+}
+
+/// Set the block id on the bank and send it for consideration in voting
+pub(super) fn set_block_id_and_send(
+    completed_block_sender: &CompletedBlockSender,
+    bank: Arc<Bank>,
+    block_id: Hash,
+) -> Result<()> {
+    bank.set_block_id(Some(block_id));
+    completed_block_sender.send(CompletedBlock {
+        slot: bank.slot(),
+        bank,
+    })?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
@@ -1,7 +1,10 @@
 use {
     super::*,
     crate::cluster_nodes::ClusterNodesCache,
-    solana_ledger::shred::{ProcessShredsStats, ReedSolomonCache, Shredder},
+    solana_ledger::{
+        blockstore::CompletedBlockSender,
+        shred::{ProcessShredsStats, ReedSolomonCache, Shredder},
+    },
     solana_sdk::{hash::Hash, signature::Keypair},
     std::{thread::sleep, time::Duration},
     tokio::sync::mpsc::Sender as AsyncSender,
@@ -49,6 +52,7 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
         receiver: &Receiver<WorkingBankEntry>,
         socket_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
         blockstore_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
+        _completed_block_sender: &CompletedBlockSender,
     ) -> Result<()> {
         // 1) Pull entries from banking stage
         let mut receive_results = broadcast_utils::recv_slot_entries(receiver)?;


### PR DESCRIPTION
#### Problem
We send all replayed blocks to the voting loop. Since shredding is asynchronous, replayed leader blocks might not be eligible for voting yet as the block id is missing.

This adds complexity to the voting loop which has to check blockstore and potentially update the bank with the block_id. Additionally the voting loop doesn't handle this transient condition properly , see #249 for example.

#### Summary of Changes
Instead we:
1. For non leader blocks, in replay we set the block id and send the completed bank to the voting loop
2. For leader blocks, instead broadcast stage will set the block id and send the completed bank
3. The voting loop now will always have the block id for any incoming banks, the blockstore fetch can be removed.
4. `try_notar` can only fail transiently for certificate checks now, refactor the blocking in the initial loop to address this

Part of #250 