### PR TITLE
certificate pool: fix conflicting vote check for notarize fallback

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,7 +174,7 @@ check-cfg = [
 
 [workspace.dependencies]
 Inflector = "0.11.4"
-alpenglow-vote = { git = "https://github.com/solana-program/alpenglow-vote.git", rev = "e5df52d" }
+alpenglow-vote = { git = "https://github.com/solana-program/alpenglow-vote.git", rev = "e5df52d", features = ["serde"] }
 axum = "0.7.9"
 agave-banking-stage-ingress-types = { path = "banking-stage-ingress-types", version = "=2.3.0" }
 agave-transaction-view = { path = "transaction-view", version = "=2.3.0" }

--- a/core/src/alpenglow_consensus.rs
+++ b/core/src/alpenglow_consensus.rs
@@ -90,6 +90,12 @@ pub enum VoteType {
     SkipFallback,
 }
 
+impl VoteType {
+    fn is_block_type(&self) -> bool {
+        matches!(self, Self::Notarize | Self::NotarizeFallback)
+    }
+}
+
 pub const fn conflicting_types(vote_type: VoteType) -> &'static [VoteType] {
     match vote_type {
         VoteType::Finalize => &[VoteType::NotarizeFallback, VoteType::Skip],

--- a/core/src/alpenglow_consensus.rs
+++ b/core/src/alpenglow_consensus.rs
@@ -91,7 +91,7 @@ pub enum VoteType {
 }
 
 impl VoteType {
-    fn is_block_type(&self) -> bool {
+    fn is_notarize_type(&self) -> bool {
         matches!(self, Self::Notarize | Self::NotarizeFallback)
     }
 }

--- a/core/src/alpenglow_consensus/certificate_pool.rs
+++ b/core/src/alpenglow_consensus/certificate_pool.rs
@@ -267,7 +267,7 @@ impl<VC: VoteCertificate> CertificatePool<VC> {
                 if pool.has_prev_vote(
                     validator_vote_key,
                     conflicting_type
-                        .is_block_type()
+                        .is_notarize_type()
                         .then_some(vote_key.as_ref())
                         .flatten(),
                 ) {
@@ -330,7 +330,7 @@ impl<VC: VoteCertificate> CertificatePool<VC> {
             }
             _ => (None, None),
         };
-        let vote_key = (block_id.is_some()).then_some(VoteKey {
+        let vote_key = block_id.map(|_| VoteKey {
             block_id,
             bank_hash,
         });

--- a/core/src/alpenglow_consensus/certificate_pool.rs
+++ b/core/src/alpenglow_consensus/certificate_pool.rs
@@ -260,10 +260,17 @@ impl<VC: VoteCertificate> CertificatePool<VC> {
         slot: Slot,
         vote_type: VoteType,
         validator_vote_key: &Pubkey,
+        vote_key: Option<VoteKey>,
     ) -> Option<VoteType> {
         for conflicting_type in conflicting_types(vote_type) {
             if let Some(pool) = self.vote_pools.get(&(slot, *conflicting_type)) {
-                if pool.has_prev_vote(validator_vote_key) {
+                if pool.has_prev_vote(
+                    validator_vote_key,
+                    conflicting_type
+                        .is_block_type()
+                        .then_some(vote_key.as_ref())
+                        .flatten(),
+                ) {
                     return Some(*conflicting_type);
                 }
             }
@@ -323,8 +330,12 @@ impl<VC: VoteCertificate> CertificatePool<VC> {
             }
             _ => (None, None),
         };
+        let vote_key = (block_id.is_some()).then_some(VoteKey {
+            block_id,
+            bank_hash,
+        });
         if let Some(conflicting_type) =
-            self.has_conflicting_vote(slot, vote_type, validator_vote_key)
+            self.has_conflicting_vote(slot, vote_type, validator_vote_key, vote_key)
         {
             return Err(AddVoteError::ConflictingVoteType(
                 vote_type,

--- a/core/src/alpenglow_consensus/vote_pool.rs
+++ b/core/src/alpenglow_consensus/vote_pool.rs
@@ -116,12 +116,12 @@ impl<VC: VoteCertificate> VotePool<VC> {
     }
 
     pub(crate) fn has_prev_vote(&self, validator_key: &Pubkey, vote_key: Option<&VoteKey>) -> bool {
-        if let Some(vote_key) = vote_key {
-            self.prev_votes
+        match vote_key {
+            Some(vote_key) => self
+                .prev_votes
                 .get(validator_key)
-                .is_some_and(|vs| vs.contains(vote_key))
-        } else {
-            self.prev_votes.contains_key(validator_key)
+                .is_some_and(|vs| vs.contains(vote_key)),
+            None => self.prev_votes.contains_key(validator_key),
         }
     }
 }

--- a/core/src/alpenglow_consensus/vote_pool.rs
+++ b/core/src/alpenglow_consensus/vote_pool.rs
@@ -115,8 +115,14 @@ impl<VC: VoteCertificate> VotePool<VC> {
         Ok(())
     }
 
-    pub fn has_prev_vote(&self, validator_key: &Pubkey) -> bool {
-        self.prev_votes.contains_key(validator_key)
+    pub(crate) fn has_prev_vote(&self, validator_key: &Pubkey, vote_key: Option<&VoteKey>) -> bool {
+        if let Some(vote_key) = vote_key {
+            self.prev_votes
+                .get(validator_key)
+                .is_some_and(|vs| vs.contains(vote_key))
+        } else {
+            self.prev_votes.contains_key(validator_key)
+        }
     }
 }
 


### PR DESCRIPTION
#### Problem
Certificate pool doesn't allow a notarize for block b and then a notarize fallback for block b'

#### Summary of Changes
Update the conflicting vote check to compare block id / bank hash when dealing with 2 block based vote types