### PR TITLE
voting_loop: remove commitment and block creation dependency

### DIFF
--- a/core/src/alpenglow_consensus/block_creation_loop.rs
+++ b/core/src/alpenglow_consensus/block_creation_loop.rs
@@ -3,7 +3,10 @@
 //! within the block timeouts. Responsible for inserting empty banks for
 //! banking stage to fill, and clearing banks once the timeout has been reached.
 use {
-    super::{block_timeout, Block},
+    super::{
+        block_timeout,
+        voting_loop::{LeaderWindowInfo, LeaderWindowNotifier},
+    },
     crate::{
         banking_trace::BankingTracer,
         replay_stage::{Finalizer, ReplayStage},
@@ -73,20 +76,6 @@ struct LeaderContext {
 pub struct ReplayHighestFrozen {
     pub highest_frozen_slot: Mutex<Slot>,
     pub freeze_notification: Condvar,
-}
-
-#[derive(Copy, Clone, Debug)]
-pub struct LeaderWindowInfo {
-    pub start_slot: Slot,
-    pub end_slot: Slot,
-    pub parent_block: Block,
-    pub skip_timer: Instant,
-}
-
-#[derive(Default)]
-pub struct LeaderWindowNotifier {
-    pub window_info: Mutex<Option<LeaderWindowInfo>>,
-    pub window_notification: Condvar,
 }
 
 #[derive(Debug, Error)]

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2,10 +2,12 @@
 use {
     crate::{
         alpenglow_consensus::{
-            block_creation_loop::{LeaderWindowNotifier, ReplayHighestFrozen},
+            block_creation_loop::ReplayHighestFrozen,
             vote_history::VoteHistory,
             vote_history_storage::VoteHistoryStorage,
-            voting_loop::{GenerateVoteTxResult, VotingLoop, VotingLoopConfig},
+            voting_loop::{
+                GenerateVoteTxResult, LeaderWindowNotifier, VotingLoop, VotingLoopConfig,
+            },
             CertificateId,
         },
         banking_stage::update_bank_forks_and_poh_recorder_for_new_tpu_bank,
@@ -14,9 +16,7 @@ use {
             DuplicateConfirmedSlotsReceiver, GossipVerifiedVoteHashReceiver, VoteTracker,
         },
         cluster_slots_service::{cluster_slots::ClusterSlots, ClusterSlotsUpdateSender},
-        commitment_service::{
-            AggregateCommitmentService, CommitmentAggregationData, TowerCommitmentAggregationData,
-        },
+        commitment_service::{AggregateCommitmentService, TowerCommitmentAggregationData},
         consensus::{
             fork_choice::{select_vote_and_reset_forks, ForkChoice, SelectVoteAndResetForkResult},
             heaviest_subtree_fork_choice::HeaviestSubtreeForkChoice,
@@ -622,11 +622,12 @@ impl ReplayStage {
         trace!("replay stage");
 
         // Start the replay stage loop
-        let (lockouts_sender, commitment_service) = AggregateCommitmentService::new(
-            exit.clone(),
-            block_commitment_cache.clone(),
-            rpc_subscriptions.clone(),
-        );
+        let (lockouts_sender, commitment_sender, commitment_service) =
+            AggregateCommitmentService::new(
+                exit.clone(),
+                block_commitment_cache.clone(),
+                rpc_subscriptions.clone(),
+            );
 
         // Alpenglow specific objects
         let mut first_alpenglow_slot = bank_forks
@@ -676,7 +677,7 @@ impl ReplayStage {
                 rpc_subscriptions: rpc_subscriptions.clone(),
                 accounts_background_request_sender: accounts_background_request_sender.clone(),
                 voting_sender: voting_sender.clone(),
-                commitment_sender: lockouts_sender.clone(),
+                commitment_sender,
                 drop_bank_sender: drop_bank_sender.clone(),
                 bank_notification_sender: bank_notification_sender.clone(),
                 leader_window_notifier,
@@ -2650,7 +2651,7 @@ impl ReplayStage {
         authorized_voter_keypairs: &[Arc<Keypair>],
         blockstore: &Blockstore,
         leader_schedule_cache: &Arc<LeaderScheduleCache>,
-        lockouts_sender: &Sender<CommitmentAggregationData>,
+        lockouts_sender: &Sender<TowerCommitmentAggregationData>,
         accounts_background_request_sender: &AbsRequestSender,
         rpc_subscriptions: &Arc<RpcSubscriptions>,
         block_commitment_cache: &Arc<RwLock<BlockCommitmentCache>>,
@@ -3102,13 +3103,14 @@ impl ReplayStage {
         root: Slot,
         total_stake: Stake,
         node_vote_state: (Pubkey, TowerVoteState),
-        lockouts_sender: &Sender<CommitmentAggregationData>,
+        lockouts_sender: &Sender<TowerCommitmentAggregationData>,
     ) {
-        if let Err(e) =
-            lockouts_sender.send(CommitmentAggregationData::TowerCommitmentAggregationData(
-                TowerCommitmentAggregationData::new(bank, root, total_stake, node_vote_state),
-            ))
-        {
+        if let Err(e) = lockouts_sender.send(TowerCommitmentAggregationData::new(
+            bank,
+            root,
+            total_stake,
+            node_vote_state,
+        )) {
             trace!("lockouts_sender failed: {:?}", e);
         }
     }
@@ -5552,7 +5554,7 @@ pub(crate) mod tests {
             block_commitment_cache.clone(),
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks),
         ));
-        let (lockouts_sender, _) = AggregateCommitmentService::new(
+        let (lockouts_sender, _, _) = AggregateCommitmentService::new(
             exit,
             block_commitment_cache.clone(),
             rpc_subscriptions,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -4,9 +4,8 @@
 use {
     crate::{
         alpenglow_consensus::{
-            block_creation_loop::{LeaderWindowNotifier, ReplayHighestFrozen},
-            vote_history::VoteHistory,
-            vote_history_storage::VoteHistoryStorage,
+            block_creation_loop::ReplayHighestFrozen, vote_history::VoteHistory,
+            vote_history_storage::VoteHistoryStorage, voting_loop::LeaderWindowNotifier,
         },
         banking_trace::BankingTracer,
         cluster_info_vote_listener::{

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -6,11 +6,10 @@ use {
         accounts_hash_verifier::AccountsHashVerifier,
         admin_rpc_post_init::AdminRpcRequestMetadataPostInit,
         alpenglow_consensus::{
-            block_creation_loop::{
-                self, BlockCreationLoopConfig, LeaderWindowNotifier, ReplayHighestFrozen,
-            },
+            block_creation_loop::{self, BlockCreationLoopConfig, ReplayHighestFrozen},
             vote_history::{VoteHistory, VoteHistoryError},
             vote_history_storage::{NullVoteHistoryStorage, VoteHistoryStorage},
+            voting_loop::LeaderWindowNotifier,
         },
         banking_trace::{self, BankingTracer, TraceError},
         cluster_info_vote_listener::VoteTracker,


### PR DESCRIPTION
In preparation for creating the `solana-votor` crate I am untangling core dependencies from the `voting_loop` over the course of a couple PRs