### PR TITLE
Statically type vote pools 

### DIFF
--- a/votor/src/certificate_pool.rs
+++ b/votor/src/certificate_pool.rs
@@ -4,7 +4,9 @@ use {
         certificate_pool::{
             parent_ready_tracker::ParentReadyTracker,
             vote_certificate::{CertificateError, VoteCertificate},
-            vote_pool::{VoteKey, VotePool},
+            vote_pool::{
+                DuplicateBlockVotePool, SimpleVotePool, VotePool, VotePoolType, VotedBlockKey,
+            },
         },
         conflicting_types, vote_to_certificate_ids, CertificateId, Stake, VoteType,
         MAX_ENTRIES_PER_PUBKEY_FOR_NOTARIZE_LITE, MAX_ENTRIES_PER_PUBKEY_FOR_OTHER_TYPES,
@@ -80,7 +82,7 @@ pub enum AddVoteError {
 #[derive(Default)]
 pub struct CertificatePool {
     // Vote pools to do bean counting for votes.
-    vote_pools: BTreeMap<PoolId, VotePool>,
+    vote_pools: BTreeMap<PoolId, VotePoolType>,
     /// Completed certificates
     completed_certificates: BTreeMap<CertificateId, VoteCertificate>,
     /// Tracks slots which have reached the parent ready condition:
@@ -151,10 +153,15 @@ impl CertificatePool {
         }
     }
 
-    fn new_vote_pool(vote_type: VoteType) -> VotePool {
+    fn new_vote_pool(vote_type: VoteType) -> VotePoolType {
         match vote_type {
-            VoteType::NotarizeFallback => VotePool::new(MAX_ENTRIES_PER_PUBKEY_FOR_NOTARIZE_LITE),
-            _ => VotePool::new(MAX_ENTRIES_PER_PUBKEY_FOR_OTHER_TYPES),
+            VoteType::NotarizeFallback => VotePoolType::DuplicateBlockVotePool(
+                DuplicateBlockVotePool::new(MAX_ENTRIES_PER_PUBKEY_FOR_NOTARIZE_LITE),
+            ),
+            VoteType::Notarize => VotePoolType::DuplicateBlockVotePool(
+                DuplicateBlockVotePool::new(MAX_ENTRIES_PER_PUBKEY_FOR_OTHER_TYPES),
+            ),
+            _ => VotePoolType::SimpleVotePool(SimpleVotePool::new()),
         }
     }
 
@@ -162,8 +169,7 @@ impl CertificatePool {
         &mut self,
         slot: Slot,
         vote_type: VoteType,
-        bank_hash: Option<Hash>,
-        block_id: Option<Hash>,
+        voted_block_key: Option<VotedBlockKey>,
         transaction: &VoteMessage,
         validator_vote_key: &Pubkey,
         validator_stake: Stake,
@@ -172,13 +178,17 @@ impl CertificatePool {
             .vote_pools
             .entry((slot, vote_type))
             .or_insert_with(|| Self::new_vote_pool(vote_type));
-        pool.add_vote(
-            validator_vote_key,
-            bank_hash,
-            block_id,
-            transaction,
-            validator_stake,
-        )
+        match pool {
+            VotePoolType::SimpleVotePool(pool) => {
+                pool.add_vote(validator_vote_key, validator_stake, transaction)
+            }
+            VotePoolType::DuplicateBlockVotePool(pool) => pool.add_vote(
+                validator_vote_key,
+                voted_block_key.expect("Duplicate block pool expects a voted block key"),
+                transaction,
+                validator_stake,
+            ),
+        }
     }
 
     /// For a new vote `slot` , `vote_type` checks if any
@@ -192,8 +202,7 @@ impl CertificatePool {
     fn update_certificates(
         &mut self,
         vote: &Vote,
-        block_id: Option<Hash>,
-        bank_hash: Option<Hash>,
+        voted_block_key: Option<VotedBlockKey>,
         total_stake: Stake,
     ) -> Result<Option<Slot>, AddVoteError> {
         let slot = vote.slot();
@@ -209,11 +218,11 @@ impl CertificatePool {
                 let accumulated_stake = vote_types
                     .iter()
                     .filter_map(|vote_type| {
-                        Some(
-                            self.vote_pools
-                                .get(&(slot, *vote_type))?
-                                .total_stake_by_key(bank_hash, block_id),
-                        )
+                        Some(match self.vote_pools
+                            .get(&(slot, *vote_type))? {
+                                VotePoolType::SimpleVotePool(pool) => pool.total_stake(),
+                                VotePoolType::DuplicateBlockVotePool(pool) => pool.total_stake_by_voted_block_key(voted_block_key.as_ref().expect("Duplicate block pool for {vote_type:?} expects a voted block key for certificate {cert_id:?}")),
+                            })
                     })
                     .sum::<Stake>();
                 if accumulated_stake as f64 / (total_stake as f64) < limit {
@@ -224,9 +233,10 @@ impl CertificatePool {
                     let Some(vote_pool) = self.vote_pools.get(&(slot, *vote_type)) else {
                         continue;
                     };
-                    vote_pool
-                        .add_to_certificate(bank_hash, block_id, &mut vote_certificate)
-                        .map_err(AddVoteError::Certificate)?;
+                    match vote_pool {
+                        VotePoolType::SimpleVotePool(pool) => pool.add_to_certificate(&mut vote_certificate),
+                        VotePoolType::DuplicateBlockVotePool(pool) => pool.add_to_certificate(voted_block_key.as_ref().expect("Duplicate block pool for {vote_type:?} expects a voted block key for certificate {cert_id:?}"), &mut vote_certificate),
+                    }.map_err(AddVoteError::Certificate)?;
                 }
                 self.completed_certificates
                     .insert(cert_id, vote_certificate.clone());
@@ -271,17 +281,33 @@ impl CertificatePool {
         slot: Slot,
         vote_type: VoteType,
         validator_vote_key: &Pubkey,
-        vote_key: Option<VoteKey>,
+        voted_block_key: &Option<VotedBlockKey>,
     ) -> Option<VoteType> {
         for conflicting_type in conflicting_types(vote_type) {
             if let Some(pool) = self.vote_pools.get(&(slot, *conflicting_type)) {
-                if pool.has_prev_vote(
-                    validator_vote_key,
-                    conflicting_type
-                        .is_notarize_type()
-                        .then_some(vote_key.as_ref())
-                        .flatten(),
-                ) {
+                let is_conflicting = match pool {
+                    // In a simple vote pool, just check if the validator previously voted at all. If so, that's a conflict
+                    VotePoolType::SimpleVotePool(pool) => {
+                        pool.has_prev_validator_vote(validator_vote_key)
+                    }
+                    // In a duplicate block vote pool, because some conflicts between things like Notarize and NotarizeFallback
+                    // for different blocks are allowed, we need a more specific check.
+                    // TODO: This can be made much cleaner/safer if VoteType carried the bank hash, block id so we
+                    // could check which exact VoteType(blockid, bankhash) was the source of the conflict.
+                    VotePoolType::DuplicateBlockVotePool(pool) => {
+                        if let Some(voted_block_key) = &voted_block_key {
+                            // Reject votes for the same block with a conflicting type, i.e.
+                            // a NotarizeFallback vote for the same block as a Notarize vote.
+                            pool.has_prev_validator_vote_for_block(
+                                validator_vote_key,
+                                voted_block_key,
+                            )
+                        } else {
+                            pool.has_prev_validator_vote(validator_vote_key)
+                        }
+                    }
+                };
+                if is_conflicting {
                     return Some(*conflicting_type);
                 }
             }
@@ -357,20 +383,21 @@ impl CertificatePool {
         if slot > self.root.saturating_add(MAX_SLOT_AGE) {
             return Err(AddVoteError::SlotInFuture);
         }
-        let vote_type = VoteType::get_type(vote);
-        let (bank_hash, block_id) = match vote {
-            Vote::Notarize(vote) => (Some(*vote.replayed_bank_hash()), Some(*vote.block_id())),
-            Vote::NotarizeFallback(vote) => {
-                (Some(*vote.replayed_bank_hash()), Some(*vote.block_id()))
+
+        let voted_block_key = vote.block_id().map(|block_id| {
+            if !matches!(vote, Vote::Notarize(_) | Vote::NotarizeFallback(_)) {
+                panic!("expected Notarize or NotarizeFallback vote");
             }
-            _ => (None, None),
-        };
-        let vote_key = block_id.map(|_| VoteKey {
-            block_id,
-            bank_hash,
+            VotedBlockKey {
+                block_id: *block_id,
+                bank_hash: *vote
+                    .replayed_bank_hash()
+                    .expect("replayed_bank_hash should be Some for Notarize and NotarizeFallback"),
+            }
         });
+        let vote_type = VoteType::get_type(vote);
         if let Some(conflicting_type) =
-            self.has_conflicting_vote(slot, vote_type, &validator_vote_key, vote_key)
+            self.has_conflicting_vote(slot, vote_type, &validator_vote_key, &voted_block_key)
         {
             return Err(AddVoteError::ConflictingVoteType(
                 vote_type,
@@ -382,15 +409,14 @@ impl CertificatePool {
         if !self.update_vote_pool(
             slot,
             vote_type,
-            bank_hash,
-            block_id,
+            voted_block_key.clone(),
             vote_message,
             &validator_vote_key,
             validator_stake,
         ) {
             return Ok(None);
         }
-        self.update_certificates(vote, block_id, bank_hash, total_stake)
+        self.update_certificates(vote, voted_block_key, total_stake)
     }
 
     /// The highest notarized fallback slot, for use as the parent slot in leader window
@@ -497,34 +523,35 @@ impl CertificatePool {
         let skip_ratio = self
             .vote_pools
             .get(&(slot, VoteType::Skip))
-            .map_or(0, |pool| pool.total_stake_by_key(None, None)) as f64
+            .map_or(0, |pool| pool.total_stake()) as f64
             / total_stake as f64;
 
         let voted_skip = self
             .vote_pools
             .get(&(slot, VoteType::Skip))
-            .is_some_and(|pool| pool.has_prev_vote(my_vote_pubkey, None));
+            .is_some_and(|pool| pool.has_prev_validator_vote(my_vote_pubkey));
 
         let Some(notarize_pool) = self.vote_pools.get(&(slot, VoteType::Notarize)) else {
             return vec![];
         };
-        let my_prev_notarize_vote = notarize_pool.get_prev_notarize_vote(my_vote_pubkey);
+        let notarize_pool = notarize_pool.unwrap_duplicate_block_vote_pool(
+            "Notarize vote pool should be a DuplicateBlockVotePool",
+        );
+        let my_prev_notarize_vote = notarize_pool.get_prev_vote(my_vote_pubkey);
 
         let mut safe_to_notar = vec![];
         for (
-            VoteKey {
+            VotedBlockKey {
                 bank_hash,
                 block_id,
             },
             votes,
         ) in notarize_pool.votes.iter()
         {
-            let b_block_id = block_id.unwrap();
-            let b_bank_hash = bank_hash.unwrap();
-
             if !voted_skip
                 && my_prev_notarize_vote
-                    .is_none_or(|(prev_block_id, _)| prev_block_id == b_block_id)
+                    .as_ref()
+                    .is_none_or(|prev_vote| prev_vote.block_id == *block_id)
             {
                 // We either have not voted for the slot or we voted notarize on this block.
                 // Not eligble for safe to notar
@@ -540,7 +567,7 @@ impl CertificatePool {
                     && notarized_ratio + skip_ratio >= SAFE_TO_NOTAR_MIN_NOTARIZE_AND_SKIP);
 
             if qualifies {
-                safe_to_notar.push((b_block_id, b_bank_hash));
+                safe_to_notar.push((*block_id, *bank_hash));
             }
         }
         safe_to_notar
@@ -560,11 +587,12 @@ impl CertificatePool {
         let Some(notarize_pool) = self.vote_pools.get(&(slot, VoteType::Notarize)) else {
             return false;
         };
-
-        if !notarize_pool.has_prev_vote(my_vote_pubkey, None) {
+        let notarize_pool = notarize_pool.unwrap_duplicate_block_vote_pool(
+            "Notarize vote pool should be a DuplicateBlockVotePool",
+        );
+        if !notarize_pool.has_prev_validator_vote(my_vote_pubkey) {
             return false;
         }
-
         let voted_stake = notarize_pool.total_stake().saturating_add(
             self.vote_pools
                 .get(&(slot, VoteType::Skip))

--- a/votor/src/certificate_pool/vote_pool.rs
+++ b/votor/src/certificate_pool/vote_pool.rs
@@ -6,13 +6,13 @@ use {
     alpenglow_vote::bls_message::VoteMessage,
     solana_pubkey::Pubkey,
     solana_sdk::hash::Hash,
-    std::collections::HashMap,
+    std::collections::{HashMap, HashSet},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub(crate) struct VoteKey {
-    pub(crate) bank_hash: Option<Hash>,
-    pub(crate) block_id: Option<Hash>,
+pub(crate) struct VotedBlockKey {
+    pub(crate) bank_hash: Hash,
+    pub(crate) block_id: Hash,
 }
 
 #[derive(Debug)]
@@ -30,50 +30,141 @@ impl VoteEntry {
     }
 }
 
-pub struct VotePool {
+pub(crate) trait VotePool {
+    fn total_stake(&self) -> Stake;
+    fn has_prev_validator_vote(&self, validator_vote_key: &Pubkey) -> bool;
+}
+
+/// There are two types of vote pools:
+/// - SimpleVotePool: Tracks all votes of a specfic vote type made by validators for some slot N, but only one vote per block.
+/// - DuplicateBlockVotePool: Tracks all votes of a specfic vote type made by validators for some slot N,
+///   but allows votes for different blocks by the same validator. Only relevant for VotePool's that are of type
+///   Notarization or NotarizationFallback
+pub(crate) enum VotePoolType {
+    SimpleVotePool(SimpleVotePool),
+    DuplicateBlockVotePool(DuplicateBlockVotePool),
+}
+
+impl VotePoolType {
+    pub(crate) fn total_stake(&self) -> Stake {
+        match self {
+            VotePoolType::SimpleVotePool(pool) => pool.total_stake(),
+            VotePoolType::DuplicateBlockVotePool(pool) => pool.total_stake(),
+        }
+    }
+
+    pub(crate) fn has_prev_validator_vote(&self, validator_vote_key: &Pubkey) -> bool {
+        match self {
+            VotePoolType::SimpleVotePool(pool) => pool.has_prev_validator_vote(validator_vote_key),
+            VotePoolType::DuplicateBlockVotePool(pool) => {
+                pool.has_prev_validator_vote(validator_vote_key)
+            }
+        }
+    }
+
+    pub(crate) fn unwrap_duplicate_block_vote_pool(
+        &self,
+        error_message: &str,
+    ) -> &DuplicateBlockVotePool {
+        match self {
+            VotePoolType::SimpleVotePool(_pool) => panic!("{}", error_message),
+            VotePoolType::DuplicateBlockVotePool(pool) => pool,
+        }
+    }
+}
+
+pub(crate) struct SimpleVotePool {
+    /// Tracks all votes of a specfic vote type made by validators for some slot N.
+    pub(crate) vote_entry: VoteEntry,
+    prev_voted_validators: HashSet<Pubkey>,
+}
+
+impl SimpleVotePool {
+    pub fn new() -> Self {
+        Self {
+            vote_entry: VoteEntry::new(),
+            prev_voted_validators: HashSet::new(),
+        }
+    }
+
+    pub fn add_vote(
+        &mut self,
+        validator_vote_key: &Pubkey,
+        validator_stake: Stake,
+        transaction: &VoteMessage,
+    ) -> bool {
+        if self.prev_voted_validators.contains(validator_vote_key) {
+            return false;
+        }
+        self.prev_voted_validators.insert(*validator_vote_key);
+        self.vote_entry.transactions.push(*transaction);
+        self.vote_entry.total_stake_by_key = self
+            .vote_entry
+            .total_stake_by_key
+            .saturating_add(validator_stake);
+        true
+    }
+
+    pub fn add_to_certificate(&self, output: &mut VoteCertificate) -> Result<(), CertificateError> {
+        output.aggregate(self.vote_entry.transactions.iter())?;
+        Ok(())
+    }
+}
+
+impl VotePool for SimpleVotePool {
+    fn total_stake(&self) -> Stake {
+        self.vote_entry.total_stake_by_key
+    }
+    fn has_prev_validator_vote(&self, validator_vote_key: &Pubkey) -> bool {
+        self.prev_voted_validators.contains(validator_vote_key)
+    }
+}
+
+pub(crate) struct DuplicateBlockVotePool {
     max_entries_per_pubkey: usize,
-    pub(crate) votes: HashMap<VoteKey, VoteEntry>,
+    pub(crate) votes: HashMap<VotedBlockKey, VoteEntry>,
     total_stake: Stake,
-    prev_votes: HashMap<Pubkey, Vec<VoteKey>>,
+    prev_voted_block_keys: HashMap<Pubkey, Vec<VotedBlockKey>>,
     top_entry_stake: Stake,
 }
 
-impl VotePool {
+impl DuplicateBlockVotePool {
     pub fn new(max_entries_per_pubkey: usize) -> Self {
         Self {
             max_entries_per_pubkey,
             votes: HashMap::new(),
             total_stake: 0,
-            prev_votes: HashMap::new(),
+            prev_voted_block_keys: HashMap::new(),
             top_entry_stake: 0,
         }
     }
 
     pub fn add_vote(
         &mut self,
-        validator_key: &Pubkey,
-        bank_hash: Option<Hash>,
-        block_id: Option<Hash>,
+        validator_vote_key: &Pubkey,
+        voted_block_key: VotedBlockKey,
         transaction: &VoteMessage,
         validator_stake: Stake,
     ) -> bool {
-        // Check whether the validator_key already used the same vote_key or exceeded max_entries_per_pubkey
-        // If so, return false, otherwise add the vote_key to the prev_votes
-        let vote_key = VoteKey {
-            bank_hash,
-            block_id,
-        };
-        let prev_vote_keys = self.prev_votes.entry(*validator_key).or_default();
-        if prev_vote_keys.contains(&vote_key) {
+        // Check whether the validator_vote_key already used the same voted_block_key or exceeded max_entries_per_pubkey
+        // If so, return false, otherwise add the voted_block_key to the prev_votes
+        let prev_voted_block_keys = self
+            .prev_voted_block_keys
+            .entry(*validator_vote_key)
+            .or_default();
+        if prev_voted_block_keys.contains(&voted_block_key) {
             return false;
         }
-        let inserted_first_time = prev_vote_keys.is_empty();
-        if prev_vote_keys.len() >= self.max_entries_per_pubkey {
+        let inserted_first_time = prev_voted_block_keys.is_empty();
+        if prev_voted_block_keys.len() >= self.max_entries_per_pubkey {
             return false;
         }
-        prev_vote_keys.push(vote_key.clone());
+        prev_voted_block_keys.push(voted_block_key.clone());
 
-        let vote_entry = self.votes.entry(vote_key).or_insert_with(VoteEntry::new);
+        let vote_entry = self
+            .votes
+            .entry(voted_block_key)
+            .or_insert_with(VoteEntry::new);
         vote_entry.transactions.push(*transaction);
         vote_entry.total_stake_by_key = vote_entry
             .total_stake_by_key
@@ -88,54 +179,55 @@ impl VotePool {
         true
     }
 
-    pub fn total_stake_by_key(&self, bank_hash: Option<Hash>, block_id: Option<Hash>) -> Stake {
+    pub fn total_stake_by_voted_block_key(&self, voted_block_key: &VotedBlockKey) -> Stake {
         self.votes
-            .get(&VoteKey {
-                bank_hash,
-                block_id,
-            })
+            .get(voted_block_key)
             .map_or(0, |vote_entries| vote_entries.total_stake_by_key)
-    }
-
-    pub fn total_stake(&self) -> Stake {
-        self.total_stake
-    }
-
-    pub fn top_entry_stake(&self) -> Stake {
-        self.top_entry_stake
     }
 
     pub fn add_to_certificate(
         &self,
-        bank_hash: Option<Hash>,
-        block_id: Option<Hash>,
+        voted_block_key: &VotedBlockKey,
         output: &mut VoteCertificate,
     ) -> Result<(), CertificateError> {
-        if let Some(vote_entries) = self.votes.get(&VoteKey {
-            bank_hash,
-            block_id,
-        }) {
+        if let Some(vote_entries) = self.votes.get(voted_block_key) {
             output.aggregate(vote_entries.transactions.iter())?;
         }
         Ok(())
     }
 
     // Get the previous notarization vote, only used for safe to notar to figure out previous notar vote
-    pub(crate) fn get_prev_notarize_vote(&self, validator_key: &Pubkey) -> Option<(Hash, Hash)> {
-        self.prev_votes
-            .get(validator_key)
+    pub(crate) fn get_prev_vote(&self, validator_vote_key: &Pubkey) -> Option<VotedBlockKey> {
+        self.prev_voted_block_keys
+            .get(validator_vote_key)
             .and_then(|vs| vs.first())
-            .and_then(|vk| vk.block_id.zip(vk.bank_hash))
+            .map(|vk| VotedBlockKey {
+                block_id: vk.block_id,
+                bank_hash: vk.bank_hash,
+            })
     }
 
-    pub(crate) fn has_prev_vote(&self, validator_key: &Pubkey, vote_key: Option<&VoteKey>) -> bool {
-        match vote_key {
-            Some(vote_key) => self
-                .prev_votes
-                .get(validator_key)
-                .is_some_and(|vs| vs.contains(vote_key)),
-            None => self.prev_votes.contains_key(validator_key),
-        }
+    pub fn has_prev_validator_vote_for_block(
+        &self,
+        validator_vote_key: &Pubkey,
+        vote_key: &VotedBlockKey,
+    ) -> bool {
+        self.prev_voted_block_keys
+            .get(validator_vote_key)
+            .is_some_and(|vs| vs.contains(vote_key))
+    }
+
+    pub fn top_entry_stake(&self) -> Stake {
+        self.top_entry_stake
+    }
+}
+
+impl VotePool for DuplicateBlockVotePool {
+    fn total_stake(&self) -> Stake {
+        self.total_stake
+    }
+    fn has_prev_validator_vote(&self, validator_vote_key: &Pubkey) -> bool {
+        self.prev_voted_block_keys.contains_key(validator_vote_key)
     }
 }
 
@@ -149,7 +241,7 @@ mod test {
 
     #[test]
     fn test_skip_vote_pool() {
-        let mut vote_pool = VotePool::new(1);
+        let mut vote_pool = SimpleVotePool::new();
         let vote = Vote::new_skip_vote(5);
         let transaction = VoteMessage {
             vote,
@@ -158,24 +250,22 @@ mod test {
         };
         let my_pubkey = Pubkey::new_unique();
 
-        assert!(vote_pool.add_vote(&my_pubkey, None, None, &transaction, 10));
+        assert!(vote_pool.add_vote(&my_pubkey, 10, &transaction));
         assert_eq!(vote_pool.total_stake(), 10);
-        assert_eq!(vote_pool.total_stake_by_key(None, None), 10);
 
         // Adding the same key again should fail
-        assert!(!vote_pool.add_vote(&my_pubkey, None, None, &transaction, 10));
+        assert!(!vote_pool.add_vote(&my_pubkey, 10, &transaction));
         assert_eq!(vote_pool.total_stake(), 10);
 
         // Adding a different key should succeed
         let new_pubkey = Pubkey::new_unique();
-        assert!(vote_pool.add_vote(&new_pubkey, None, None, &transaction, 60),);
+        assert!(vote_pool.add_vote(&new_pubkey, 60, &transaction),);
         assert_eq!(vote_pool.total_stake(), 70);
-        assert_eq!(vote_pool.total_stake_by_key(None, None), 70);
     }
 
     #[test]
     fn test_notarization_pool() {
-        let mut vote_pool = VotePool::new(1);
+        let mut vote_pool = DuplicateBlockVotePool::new(1);
         let my_pubkey = Pubkey::new_unique();
         let block_id = Hash::new_unique();
         let bank_hash = Hash::new_unique();
@@ -187,22 +277,29 @@ mod test {
         };
         assert!(vote_pool.add_vote(
             &my_pubkey,
-            Some(bank_hash),
-            Some(block_id),
+            VotedBlockKey {
+                bank_hash,
+                block_id,
+            },
             &transaction,
-            10
+            10,
         ));
         assert_eq!(vote_pool.total_stake(), 10);
         assert_eq!(
-            vote_pool.total_stake_by_key(Some(bank_hash), Some(block_id)),
+            vote_pool.total_stake_by_voted_block_key(&VotedBlockKey {
+                bank_hash,
+                block_id,
+            }),
             10
         );
 
         // Adding the same key again should fail
         assert!(!vote_pool.add_vote(
             &my_pubkey,
-            Some(bank_hash),
-            Some(block_id),
+            VotedBlockKey {
+                bank_hash,
+                block_id,
+            },
             &transaction,
             10
         ));
@@ -211,8 +308,10 @@ mod test {
         // Adding a different bankhash should fail
         assert!(!vote_pool.add_vote(
             &my_pubkey,
-            Some(Hash::new_unique()),
-            Some(block_id),
+            VotedBlockKey {
+                bank_hash: Hash::new_unique(),
+                block_id,
+            },
             &transaction,
             10
         ));
@@ -222,14 +321,19 @@ mod test {
         let new_pubkey = Pubkey::new_unique();
         assert!(vote_pool.add_vote(
             &new_pubkey,
-            Some(bank_hash),
-            Some(block_id),
+            VotedBlockKey {
+                bank_hash,
+                block_id,
+            },
             &transaction,
             60
         ),);
         assert_eq!(vote_pool.total_stake(), 70);
         assert_eq!(
-            vote_pool.total_stake_by_key(Some(bank_hash), Some(block_id)),
+            vote_pool.total_stake_by_voted_block_key(&VotedBlockKey {
+                bank_hash,
+                block_id,
+            }),
             70
         );
     }
@@ -237,7 +341,7 @@ mod test {
     #[test]
     fn test_notarization_fallback_pool() {
         solana_logger::setup();
-        let mut vote_pool = VotePool::new(3);
+        let mut vote_pool = DuplicateBlockVotePool::new(3);
         let vote = Vote::new_notarization_fallback_vote(7, Hash::new_unique(), Hash::new_unique());
         let transaction = VoteMessage {
             vote,
@@ -253,28 +357,38 @@ mod test {
         for i in 0..3 {
             assert!(vote_pool.add_vote(
                 &my_pubkey,
-                Some(bank_hashes[i]),
-                Some(block_ids[i]),
+                VotedBlockKey {
+                    bank_hash: bank_hashes[i],
+                    block_id: block_ids[i],
+                },
                 &transaction,
                 10
             ));
             assert_eq!(vote_pool.total_stake(), 10);
             assert_eq!(
-                vote_pool.total_stake_by_key(Some(bank_hashes[i]), Some(block_ids[i])),
+                vote_pool.total_stake_by_voted_block_key(&VotedBlockKey {
+                    bank_hash: bank_hashes[i],
+                    block_id: block_ids[i],
+                }),
                 10
             );
         }
         // Adding the 4th vote should fail
         assert!(!vote_pool.add_vote(
             &my_pubkey,
-            Some(bank_hashes[3]),
-            Some(block_ids[3]),
+            VotedBlockKey {
+                bank_hash: bank_hashes[3],
+                block_id: block_ids[3],
+            },
             &transaction,
             10
         ));
         assert_eq!(vote_pool.total_stake(), 10);
         assert_eq!(
-            vote_pool.total_stake_by_key(Some(bank_hashes[3]), Some(block_ids[3])),
+            vote_pool.total_stake_by_voted_block_key(&VotedBlockKey {
+                bank_hash: bank_hashes[3],
+                block_id: block_ids[3],
+            }),
             0
         );
 
@@ -283,14 +397,19 @@ mod test {
         for i in 1..3 {
             assert!(vote_pool.add_vote(
                 &new_pubkey,
-                Some(bank_hashes[i]),
-                Some(block_ids[i]),
+                VotedBlockKey {
+                    bank_hash: bank_hashes[i],
+                    block_id: block_ids[i],
+                },
                 &transaction,
                 60
             ));
             assert_eq!(vote_pool.total_stake(), 70);
             assert_eq!(
-                vote_pool.total_stake_by_key(Some(bank_hashes[i]), Some(block_ids[i])),
+                vote_pool.total_stake_by_voted_block_key(&VotedBlockKey {
+                    bank_hash: bank_hashes[i],
+                    block_id: block_ids[i],
+                }),
                 70
             );
         }
@@ -298,22 +417,29 @@ mod test {
         // The new key only added 2 votes, so adding bank_hashes[3] should succeed
         assert!(vote_pool.add_vote(
             &new_pubkey,
-            Some(bank_hashes[3]),
-            Some(block_ids[3]),
+            VotedBlockKey {
+                bank_hash: bank_hashes[3],
+                block_id: block_ids[3],
+            },
             &transaction,
             60
         ));
         assert_eq!(vote_pool.total_stake(), 70);
         assert_eq!(
-            vote_pool.total_stake_by_key(Some(bank_hashes[3]), Some(block_ids[3])),
+            vote_pool.total_stake_by_voted_block_key(&VotedBlockKey {
+                bank_hash: bank_hashes[3],
+                block_id: block_ids[3],
+            }),
             60
         );
 
         // Now if adding the same key again, it should fail
         assert!(!vote_pool.add_vote(
             &new_pubkey,
-            Some(bank_hashes[0]),
-            Some(block_ids[0]),
+            VotedBlockKey {
+                bank_hash: bank_hashes[0],
+                block_id: block_ids[0],
+            },
             &transaction,
             60
         ));


### PR DESCRIPTION
#### Problem
Vote pools use Option<BankId>, Option<BankHash>  to distinguish between notarize/non-notarize pools, making all the API's hard to digest and error-prone if people pass in the wrong options.

#### Summary of Changes
Two different types of pools, `DuplicateBlockVotePool` that can take multiple votes per validator and `SimpleVotePool` that can't. 

Next steps could make a typed pool for each of the 5 different types of pools in `vote_pools: BTreeMap<PoolId, VotePoolType>,` so that each vote type has an explicitly typed pool of either `DuplicateBlockVotePool` or `SimpleVotePool`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
