### PR TITLE
InfluxDB doesn't understand u64 yet.

### DIFF
--- a/core/src/sigverifier/bls_sigverifier.rs
+++ b/core/src/sigverifier/bls_sigverifier.rs
@@ -15,10 +15,10 @@ const STATS_INTERVAL_DURATION: Duration = Duration::from_secs(1); // Log stats e
 // and we send one BLS message at a time. So it makes sense to have finer-grained stats
 #[derive(Debug)]
 pub(crate) struct BLSSigVerifierStats {
-    pub sent: u64,
-    pub sent_failed: u64,
-    pub received: u64,
-    pub received_malformed: u64,
+    pub sent: i64,
+    pub sent_failed: i64,
+    pub received: i64,
+    pub received_malformed: i64,
     pub last_stats_logged: Instant,
 }
 
@@ -98,10 +98,10 @@ impl BLSSigVerifier {
         }
         datapoint_info!(
             "bls_sig_verifier_stats",
-            ("sent", self.stats.sent, u64),
-            ("sent_failed", self.stats.sent_failed, u64),
-            ("received", self.stats.received, u64),
-            ("received_malformed", self.stats.received_malformed, u64),
+            ("sent", self.stats.sent, i64),
+            ("sent_failed", self.stats.sent_failed, i64),
+            ("received", self.stats.received, i64),
+            ("received_malformed", self.stats.received_malformed, i64),
         );
         self.stats = BLSSigVerifierStats::new();
     }

--- a/core/src/sigverifier/bls_sigverifier.rs
+++ b/core/src/sigverifier/bls_sigverifier.rs
@@ -15,10 +15,10 @@ const STATS_INTERVAL_DURATION: Duration = Duration::from_secs(1); // Log stats e
 // and we send one BLS message at a time. So it makes sense to have finer-grained stats
 #[derive(Debug)]
 pub(crate) struct BLSSigVerifierStats {
-    pub sent: i64,
-    pub sent_failed: i64,
-    pub received: i64,
-    pub received_malformed: i64,
+    pub sent: u64,
+    pub sent_failed: u64,
+    pub received: u64,
+    pub received_malformed: u64,
     pub last_stats_logged: Instant,
 }
 
@@ -98,10 +98,14 @@ impl BLSSigVerifier {
         }
         datapoint_info!(
             "bls_sig_verifier_stats",
-            ("sent", self.stats.sent, i64),
-            ("sent_failed", self.stats.sent_failed, i64),
-            ("received", self.stats.received, i64),
-            ("received_malformed", self.stats.received_malformed, i64),
+            ("sent", self.stats.sent as i64, i64),
+            ("sent_failed", self.stats.sent_failed as i64, i64),
+            ("received", self.stats.received as i64, i64),
+            (
+                "received_malformed",
+                self.stats.received_malformed as i64,
+                i64
+            ),
         );
         self.stats = BLSSigVerifierStats::new();
     }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9386,7 +9386,7 @@ dependencies = [
  "serde_derive",
  "solana-accounts-db",
  "solana-bloom",
- "solana-bls",
+ "solana-bls-signatures",
  "solana-entry",
  "solana-ledger",
  "solana-logger",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -8722,7 +8722,7 @@ dependencies = [
  "serde_derive",
  "solana-accounts-db",
  "solana-bloom",
- "solana-bls",
+ "solana-bls-signatures",
  "solana-entry",
  "solana-ledger",
  "solana-logger",


### PR DESCRIPTION
#### Problem
[2025-07-12T18:01:30.524548697Z WARN  solana_metrics::metrics] submit response unsuccessful: 400 Bad Request {"error":"partial write: unable to parse 'bls_sig_verifier_stats,host_id=tiv1zkpDdumabxfZisVjuQgDzGcVSVDTEaHJD6ueVuK sent=1u,sent_failed=0u,received=1u,received_malformed=0u 1752343289602304527': invalid number dropped=0"}

#### Summary of Changes
Change back to i64 for now, change to u64 when it is fixed.
