### PR TITLE
Make create_custom_leader_schedule give all slots in one leader window to the same person

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8520,6 +8520,7 @@ dependencies = [
  "solana-bls-signatures",
  "solana-build-alpenglow-vote",
  "solana-client",
+ "solana-clock",
  "solana-config-program",
  "solana-connection-cache",
  "solana-core",

--- a/local-cluster/Cargo.toml
+++ b/local-cluster/Cargo.toml
@@ -21,6 +21,7 @@ solana-accounts-db = { workspace = true }
 solana-bls-signatures = { workspace = true }
 solana-build-alpenglow-vote = { workspace = true }
 solana-client = { workspace = true }
+solana-clock = { workspace = true }
 solana-config-program = { workspace = true }
 solana-connection-cache = { workspace = true }
 solana-core = { workspace = true }

--- a/local-cluster/src/integration_tests.rs
+++ b/local-cluster/src/integration_tests.rs
@@ -18,6 +18,7 @@ use {
     },
     log::*,
     solana_accounts_db::utils::create_accounts_run_and_snapshot_dirs,
+    solana_clock::NUM_CONSECUTIVE_LEADER_SLOTS,
     solana_core::{
         consensus::{tower_storage::FileTowerStorage, Tower, SWITCH_FORK_THRESHOLD},
         validator::{is_snapshot_config_valid, ValidatorConfig},
@@ -334,7 +335,16 @@ pub fn create_custom_leader_schedule(
     validator_key_to_slots: impl Iterator<Item = (Pubkey, usize)>,
 ) -> LeaderSchedule {
     let leader_schedule: Vec<_> = validator_key_to_slots
-        .flat_map(|(pubkey, num_slots)| std::iter::repeat(pubkey).take(num_slots))
+        .flat_map(|(pubkey, num_slots)| {
+            // Ensure that the number of slots is a multiple of NUM_CONSECUTIVE_LEADER_SLOTS
+            // Because we only check leadership every NUM_CONSECUTIVE_LEADER_SLOTS slots, for
+            // example, you can have [(pubkey_A, 70), (pubkey_B, 30)], A will happily produce
+            // block 70 and 71 because it is the leader for block 68, but when B gets the shred
+            // it check leadership for block 70 and 71, it will see that it is the leader, so the
+            // shreds from A will be ignored.
+            assert!(num_slots % (NUM_CONSECUTIVE_LEADER_SLOTS as usize) == 0);
+            std::iter::repeat(pubkey).take(num_slots)
+        })
         .collect();
 
     info!("leader_schedule: {}", leader_schedule.len());

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -16,6 +16,7 @@ use {
     },
     solana_bls_signatures::{keypair::Keypair as BLSKeypair, Signature as BLSSignature},
     solana_client::connection_cache::ConnectionCache,
+    solana_clock::NUM_CONSECUTIVE_LEADER_SLOTS,
     solana_connection_cache::client_connection::ClientConnection,
     solana_core::{
         consensus::{
@@ -3386,7 +3387,7 @@ fn do_test_lockout_violation_with_or_without_tower(with_tower: bool) {
     let validator_to_slots = vec![
         (
             validator_b_pubkey,
-            validator_b_last_leader_slot as usize + 1,
+            (validator_b_last_leader_slot + NUM_CONSECUTIVE_LEADER_SLOTS) as usize,
         ),
         (validator_c_pubkey, DEFAULT_SLOTS_PER_EPOCH as usize),
     ];
@@ -4854,7 +4855,7 @@ fn test_duplicate_with_pruned_ancestor() {
     let observer_stake = DEFAULT_NODE_STAKE;
 
     let slots_per_epoch = 2048;
-    let fork_slot: u64 = 10;
+    let fork_slot: u64 = 12;
     let fork_length: u64 = 20;
     let majority_fork_buffer = 5;
 
@@ -5646,8 +5647,8 @@ fn test_duplicate_shreds_switch_failure() {
     );
 
     let validator_to_slots = vec![
-        (duplicate_leader_validator_pubkey, 50),
-        (target_switch_fork_validator_pubkey, 5),
+        (duplicate_leader_validator_pubkey, 52),
+        (target_switch_fork_validator_pubkey, 8),
         // The ideal sequence of events for the `duplicate_fork_validator1_pubkey` validator would go:
         // 1. Vote for duplicate block `D`
         // 2. See `D` is duplicate, remove from fork choice and reset to ancestor `A`, potentially generating a fork off that ancestor
@@ -5977,7 +5978,7 @@ fn test_invalid_forks_persisted_on_restart() {
     let (target_pubkey, majority_pubkey) = (validators[0], validators[1]);
     // Need majority validator to make the dup_slot
     let validator_to_slots = vec![
-        (majority_pubkey, dup_slot as usize + 5),
+        (majority_pubkey, dup_slot as usize + 6),
         (target_pubkey, DEFAULT_SLOTS_PER_EPOCH as usize),
     ];
     let leader_schedule = create_custom_leader_schedule(validator_to_slots.into_iter());
@@ -6168,9 +6169,9 @@ fn test_alpenglow_imbalanced_stakes_catchup() {
     let node_stakes = vec![node_a_stake, node_b_stake];
     let num_nodes = node_stakes.len();
 
-    // Create leader schedule with A and B as leader 70/30
+    // Create leader schedule with A and B as leader 72/28
     let (leader_schedule, validator_keys) =
-        create_custom_leader_schedule_with_random_keys(&[70, 30]);
+        create_custom_leader_schedule_with_random_keys(&[72, 28]);
 
     let leader_schedule = FixedSchedule {
         leader_schedule: Arc::new(leader_schedule),
@@ -6477,7 +6478,7 @@ fn test_alpenglow_ensure_liveness_after_double_notar_fallback() {
 
     // Create leader schedule with Node A as primary leader
     let (leader_schedule, validator_keys) =
-        create_custom_leader_schedule_with_random_keys(&[1, 0, 0, 0]);
+        create_custom_leader_schedule_with_random_keys(&[4, 0, 0, 0]);
 
     let leader_schedule = FixedSchedule {
         leader_schedule: Arc::new(leader_schedule),


### PR DESCRIPTION
#### Problem
Ensure that the number of slots is a multiple of NUM_CONSECUTIVE_LEADER_SLOTS. Because we only check leadership every NUM_CONSECUTIVE_LEADER_SLOTS slots in block_creation_loop.

For example, you can have [(pubkey_A, 70), (pubkey_B, 30)], A will happily produce block 70 and 71 because it is the leader for block 68, but when B gets the shred it check leadership for block 70 and 71, it will see that itself is the leader, so the shreds from A will be ignored.

This can cause tests to fail.

#### Summary of Changes
Make sure the number of slots in custom_leader_schedule is always a multiple of NUM_CONSECUTIVE_LEADER_SLOTS.