### PR TITLE
block_creation_loop: add metrics

### DIFF
--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -358,7 +358,7 @@ fn start_leader_retry_replay(
                 return Ok(());
             }
             Err(StartLeaderError::ReplayIsBehind(_)) => {
-                metrics.replay_is_behind_count += 1;
+                metrics.replay_is_behind_count.fetch_add(1, Ordering::Relaxed);
 
                 trace!(
                     "{my_pubkey}: Attempting to produce slot {slot}, however replay of the \

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -79,6 +79,8 @@ struct BlockCreationLoopMetrics {
     loop_count: AtomicUsize,
     replay_is_behind_count: AtomicUsize,
     delay_after_replay_is_behind_elapsed: AtomicU64,
+    record_receiver_timeout_count: AtomicUsize,
+    record_receiver_disconnected_count: AtomicUsize,
 }
 
 impl BlockCreationLoopMetrics {
@@ -91,11 +93,7 @@ impl BlockCreationLoopMetrics {
         if self.last_report.should_update(report_interval_ms) {
             datapoint_info!(
                 "block-creation-loop-metrics",
-                (
-                    "loop_count",
-                    self.loop_count.load(Ordering::Relaxed),
-                    i64
-                ),
+                ("loop_count", self.loop_count.load(Ordering::Relaxed), i64),
                 (
                     "replay_is_behind_count",
                     self.replay_is_behind_count.swap(0, Ordering::Relaxed),
@@ -104,6 +102,18 @@ impl BlockCreationLoopMetrics {
                 (
                     "delay_after_replay_is_behind_elapsed",
                     self.delay_after_replay_is_behind_elapsed
+                        .swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "record_receiver_timeout_count",
+                    self.record_receiver_timeout_count
+                        .swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "record_receiver_disconnected_count",
+                    self.record_receiver_disconnected_count
                         .swap(0, Ordering::Relaxed),
                     i64
                 ),
@@ -135,6 +145,7 @@ fn start_receive_and_record_loop(
     exit: Arc<AtomicBool>,
     poh_recorder: Arc<RwLock<PohRecorder>>,
     record_receiver: Receiver<Record>,
+    metrics: &mut BlockCreationLoopMetrics,
 ) {
     while !exit.load(Ordering::Relaxed) {
         // We need a timeout here to check the exit flag, chose 400ms
@@ -155,9 +166,16 @@ fn start_receive_and_record_loop(
             }
             Err(RecvTimeoutError::Disconnected) => {
                 info!("Record receiver disconnected");
+                metrics
+                    .record_receiver_disconnected_count
+                    .fetch_add(1, Ordering::Relaxed);
                 return;
             }
-            Err(RecvTimeoutError::Timeout) => (),
+            Err(RecvTimeoutError::Timeout) => {
+                metrics
+                    .record_receiver_timeout_count
+                    .fetch_add(1, Ordering::Relaxed);
+            }
         }
     }
 }
@@ -211,7 +229,7 @@ pub fn start_loop(config: BlockCreationLoopConfig) {
     let exit_c = exit.clone();
     let p_rec = poh_recorder.clone();
     let receive_record_loop = thread::spawn(move || {
-        start_receive_and_record_loop(exit_c, p_rec, record_receiver);
+        start_receive_and_record_loop(exit_c, p_rec, record_receiver, &mut metrics);
     });
 
     while !exit.load(Ordering::Relaxed) {

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -202,6 +202,11 @@ impl BlockCreationLoopMetrics {
                     i64
                 ),
             );
+
+            // .swap() resetted most of the metrics to 0, but not the histograms or non-atomic values. reset them.
+            self.slot_production_elapsed_hist.clear();
+            self.bank_completion_elapsed_hist.clear();
+            self.last_report = now;
         }
     }
 }

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -76,7 +76,7 @@ pub struct ReplayHighestFrozen {
 
 #[derive(Default)]
 struct BlockCreationLoopMetrics {
-    last_report: AtomicInterval,
+    last_report: u64,
     loop_count: u64,
     replay_is_behind_count: AtomicUsize,
     startup_verification_incomplete_count: AtomicUsize,
@@ -112,7 +112,10 @@ impl BlockCreationLoopMetrics {
             return;
         }
 
-        if self.last_report.should_update(report_interval_ms) {
+        let now = timestamp();
+        let elapsed_ms = now - self.last_report;
+
+        if elapsed_ms > report_interval_ms {
             datapoint_info!(
                 "block-creation-loop-metrics",
                 ("loop_count", self.loop_count, i64),

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -77,7 +77,7 @@ pub struct ReplayHighestFrozen {
 #[derive(Default)]
 struct BlockCreationLoopMetrics {
     last_report: AtomicInterval,
-    loop_count: AtomicUsize,
+    loop_count: u64,
     replay_is_behind_count: AtomicUsize,
     startup_verification_incomplete_count: AtomicUsize,
     already_have_bank_count: AtomicUsize,
@@ -92,7 +92,7 @@ struct BlockCreationLoopMetrics {
 
 impl BlockCreationLoopMetrics {
     fn is_empty(&self) -> bool {
-        0 == self.loop_count.load(Ordering::Relaxed) as u64
+        0 == self.loop_count
             + self.replay_is_behind_count.load(Ordering::Relaxed) as u64
             + self
                 .startup_verification_incomplete_count
@@ -115,7 +115,7 @@ impl BlockCreationLoopMetrics {
         if self.last_report.should_update(report_interval_ms) {
             datapoint_info!(
                 "block-creation-loop-metrics",
-                ("loop_count", self.loop_count.load(Ordering::Relaxed), i64),
+                ("loop_count", self.loop_count, i64),
                 (
                     "replay_is_behind_count",
                     self.replay_is_behind_count.swap(0, Ordering::Relaxed),
@@ -449,7 +449,7 @@ pub fn start_loop(config: BlockCreationLoopConfig) {
         metrics
             .window_production_elapsed
             .fetch_add(window_production_start.as_us(), Ordering::Relaxed);
-        metrics.loop_count.fetch_add(1, Ordering::Relaxed);
+        metrics.loop_count += 1;
         metrics.report(1000);
     }
 

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -26,7 +26,7 @@ use {
     solana_votor::{block_timeout, event::LeaderWindowInfo, votor::LeaderWindowNotifier},
     std::{
         sync::{
-            atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
+            atomic::{AtomicBool, Ordering},
             Arc, Condvar, Mutex, RwLock,
         },
         thread,
@@ -78,19 +78,19 @@ pub struct ReplayHighestFrozen {
 struct BlockCreationLoopMetrics {
     last_report: u64,
     loop_count: u64,
-    bank_timeout_completion_count: AtomicUsize,
-    bank_filled_completion_count: AtomicUsize,
+    bank_timeout_completion_count: u64,
+    bank_filled_completion_count: u64,
 
-    window_production_elapsed: AtomicU64,
+    window_production_elapsed: u64,
     bank_completion_elapsed_hist: histogram::Histogram,
 }
 
 impl BlockCreationLoopMetrics {
     fn is_empty(&self) -> bool {
         0 == self.loop_count
-            + self.bank_timeout_completion_count.load(Ordering::Relaxed) as u64
-            + self.bank_filled_completion_count.load(Ordering::Relaxed) as u64
-            + self.window_production_elapsed.load(Ordering::Relaxed)
+            + self.bank_timeout_completion_count
+            + self.bank_filled_completion_count
+            + self.window_production_elapsed
             + self.bank_completion_elapsed_hist.entries()
     }
 
@@ -109,18 +109,17 @@ impl BlockCreationLoopMetrics {
                 ("loop_count", self.loop_count, i64),
                 (
                     "bank_timeout_completion_count",
-                    self.bank_timeout_completion_count
-                        .swap(0, Ordering::Relaxed),
+                    self.bank_timeout_completion_count,
                     i64
                 ),
                 (
                     "bank_filled_completion_count",
-                    self.bank_filled_completion_count.swap(0, Ordering::Relaxed),
+                    self.bank_filled_completion_count,
                     i64
                 ),
                 (
                     "window_production_elapsed",
-                    self.window_production_elapsed.swap(0, Ordering::Relaxed),
+                    self.window_production_elapsed,
                     i64
                 ),
                 (
@@ -147,7 +146,10 @@ impl BlockCreationLoopMetrics {
                 ),
             );
 
-            // .swap() resetted most of the metrics to 0, but not the histograms or non-atomic values. reset them.
+            // reset metrics
+            self.bank_timeout_completion_count = 0;
+            self.bank_filled_completion_count = 0;
+            self.window_production_elapsed = 0;
             self.bank_completion_elapsed_hist.clear();
             self.last_report = now;
         }
@@ -174,21 +176,13 @@ impl SlotMetrics {
             "slot-metrics",
             ("slot", self.slot, i64),
             ("attempt_count", self.attempt_count, i64),
-            (
-                "replay_is_behind_count",
-                self.replay_is_behind_count,
-                i64
-            ),
+            ("replay_is_behind_count", self.replay_is_behind_count, i64),
             (
                 "startup_verification_incomplete_count",
                 self.startup_verification_incomplete_count,
                 i64
             ),
-            (
-                "already_have_bank_count",
-                self.already_have_bank_count,
-                i64
-            ),
+            ("already_have_bank_count", self.already_have_bank_count, i64),
             (
                 "slot_delay_90pct",
                 self.slot_delay_hist.percentile(90.0).unwrap_or(0),
@@ -216,7 +210,9 @@ impl SlotMetrics {
             ),
             (
                 "replay_is_behind_wait_elapsed_90pct",
-                self.replay_is_behind_wait_elapsed_hist.percentile(90.0).unwrap_or(0),
+                self.replay_is_behind_wait_elapsed_hist
+                    .percentile(90.0)
+                    .unwrap_or(0),
                 i64
             ),
             (
@@ -226,12 +222,16 @@ impl SlotMetrics {
             ),
             (
                 "replay_is_behind_wait_elapsed_min",
-                self.replay_is_behind_wait_elapsed_hist.minimum().unwrap_or(0),
+                self.replay_is_behind_wait_elapsed_hist
+                    .minimum()
+                    .unwrap_or(0),
                 i64
             ),
             (
                 "replay_is_behind_wait_elapsed_max",
-                self.replay_is_behind_wait_elapsed_hist.maximum().unwrap_or(0),
+                self.replay_is_behind_wait_elapsed_hist
+                    .maximum()
+                    .unwrap_or(0),
                 i64
             ),
         );
@@ -434,9 +434,7 @@ pub fn start_loop(config: BlockCreationLoopConfig) {
                     );
 
                     // Record timeout completion metric
-                    metrics
-                        .bank_timeout_completion_count
-                        .fetch_add(1, Ordering::Relaxed);
+                    metrics.bank_timeout_completion_count += 1;
 
                     let max_tick_height = bank.max_tick_height();
                     // Set the tick height for the bank to max_tick_height - 1, so that PohRecorder::flush_cache()
@@ -452,9 +450,7 @@ pub fn start_loop(config: BlockCreationLoopConfig) {
                     trace!("{my_pubkey}: {slot} reached max tick height, moving to next block");
 
                     // Record filled completion metric
-                    metrics
-                        .bank_filled_completion_count
-                        .fetch_add(1, Ordering::Relaxed);
+                    metrics.bank_filled_completion_count += 1;
                 }
             }
 
@@ -484,9 +480,7 @@ pub fn start_loop(config: BlockCreationLoopConfig) {
             }
         }
         window_production_start.stop();
-        metrics
-            .window_production_elapsed
-            .fetch_add(window_production_start.as_us(), Ordering::Relaxed);
+        metrics.window_production_elapsed += window_production_start.as_us();
         metrics.loop_count += 1;
         metrics.report(1000);
     }
@@ -531,7 +525,9 @@ fn start_leader_retry_replay(
             Ok(()) => {
                 // Record delay for successful slot
                 slot_delay_start.stop();
-                let _ = slot_metrics.slot_delay_hist.increment(slot_delay_start.as_us());
+                let _ = slot_metrics
+                    .slot_delay_hist
+                    .increment(slot_delay_start.as_us());
 
                 // slot was successful, report slot's metrics
                 slot_metrics.report();

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -23,6 +23,7 @@ use {
         bank::{Bank, NewBankOptions},
         bank_forks::BankForks,
     },
+    solana_time_utils::timestamp,
     solana_votor::{block_timeout, event::LeaderWindowInfo, votor::LeaderWindowNotifier},
     std::{
         sync::{
@@ -138,12 +139,16 @@ impl BlockCreationLoopMetrics {
                 ),
                 (
                     "bank_filled_completion_elapsed_min",
-                    self.bank_filled_completion_elapsed_hist.minimum().unwrap_or(0),
+                    self.bank_filled_completion_elapsed_hist
+                        .minimum()
+                        .unwrap_or(0),
                     i64
                 ),
                 (
                     "bank_filled_completion_elapsed_max",
-                    self.bank_filled_completion_elapsed_hist.maximum().unwrap_or(0),
+                    self.bank_filled_completion_elapsed_hist
+                        .maximum()
+                        .unwrap_or(0),
                     i64
                 ),
                 (
@@ -155,17 +160,23 @@ impl BlockCreationLoopMetrics {
                 ),
                 (
                     "bank_timeout_completion_elapsed_mean",
-                    self.bank_timeout_completion_elapsed_hist.mean().unwrap_or(0),
+                    self.bank_timeout_completion_elapsed_hist
+                        .mean()
+                        .unwrap_or(0),
                     i64
                 ),
                 (
                     "bank_timeout_completion_elapsed_min",
-                    self.bank_timeout_completion_elapsed_hist.minimum().unwrap_or(0),
+                    self.bank_timeout_completion_elapsed_hist
+                        .minimum()
+                        .unwrap_or(0),
                     i64
                 ),
                 (
                     "bank_timeout_completion_elapsed_max",
-                    self.bank_timeout_completion_elapsed_hist.maximum().unwrap_or(0),
+                    self.bank_timeout_completion_elapsed_hist
+                        .maximum()
+                        .unwrap_or(0),
                     i64
                 ),
             );

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -425,6 +425,9 @@ fn start_leader_retry_replay(
         }
     }
 
+    metrics
+        .replay_is_behind_count
+        .fetch_add(1, Ordering::Relaxed);
     error!(
         "{my_pubkey}: Skipping production of {slot}: \
         Unable to replay parent {parent_slot} in time"
@@ -452,10 +455,16 @@ fn maybe_start_leader(
     }
 
     let Some(parent_bank) = ctx.bank_forks.read().unwrap().get(parent_slot) else {
+        metrics
+            .replay_is_behind_count
+            .fetch_add(1, Ordering::Relaxed);
         return Err(StartLeaderError::ReplayIsBehind(parent_slot));
     };
 
     if !parent_bank.is_frozen() {
+        metrics
+            .replay_is_behind_count
+            .fetch_add(1, Ordering::Relaxed);
         return Err(StartLeaderError::ReplayIsBehind(parent_slot));
     }
 

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -86,7 +86,7 @@ struct BlockCreationLoopMetrics {
 
     replay_is_behind_wait_elapsed: AtomicU64,
     window_production_elapsed: AtomicU64,
-    slot_production_elapsed_hist: histogram::Histogram,
+    slot_delay_hist: histogram::Histogram,
     bank_completion_elapsed_hist: histogram::Histogram,
 }
 
@@ -102,7 +102,7 @@ impl BlockCreationLoopMetrics {
             + self.bank_filled_completion_count.load(Ordering::Relaxed) as u64
             + self.replay_is_behind_wait_elapsed.load(Ordering::Relaxed)
             + self.window_production_elapsed.load(Ordering::Relaxed)
-            + self.slot_production_elapsed_hist.entries()
+            + self.slot_delay_hist.entries()
             + self.bank_completion_elapsed_hist.entries()
     }
 
@@ -158,25 +158,23 @@ impl BlockCreationLoopMetrics {
                     i64
                 ),
                 (
-                    "slot_production_elapsed_90pct",
-                    self.slot_production_elapsed_hist
-                        .percentile(90.0)
-                        .unwrap_or(0),
+                    "slot_delay_90pct",
+                    self.slot_delay_hist.percentile(90.0).unwrap_or(0),
                     i64
                 ),
                 (
-                    "slot_production_elapsed_mean",
-                    self.slot_production_elapsed_hist.mean().unwrap_or(0),
+                    "slot_delay_mean",
+                    self.slot_delay_hist.mean().unwrap_or(0),
                     i64
                 ),
                 (
-                    "slot_production_elapsed_min",
-                    self.slot_production_elapsed_hist.minimum().unwrap_or(0),
+                    "slot_delay_min",
+                    self.slot_delay_hist.minimum().unwrap_or(0),
                     i64
                 ),
                 (
-                    "slot_production_elapsed_max",
-                    self.slot_production_elapsed_hist.maximum().unwrap_or(0),
+                    "slot_delay_max",
+                    self.slot_delay_hist.maximum().unwrap_or(0),
                     i64
                 ),
                 (
@@ -204,7 +202,7 @@ impl BlockCreationLoopMetrics {
             );
 
             // .swap() resetted most of the metrics to 0, but not the histograms or non-atomic values. reset them.
-            self.slot_production_elapsed_hist.clear();
+            self.slot_delay_hist.clear();
             self.bank_completion_elapsed_hist.clear();
             self.last_report = now;
         }
@@ -485,15 +483,13 @@ fn start_leader_retry_replay(
 ) -> Result<(), StartLeaderError> {
     let my_pubkey = ctx.my_pubkey;
     let timeout = block_timeout(leader_slot_index(slot));
-    let mut slot_production_start = Measure::start("slot_production");
+    let mut slot_delay_start = Measure::start("slot_delay");
     while !timeout.saturating_sub(skip_timer.elapsed()).is_zero() {
         match maybe_start_leader(slot, parent_slot, ctx, metrics) {
             Ok(()) => {
-                // Record successful slot production time
-                slot_production_start.stop();
-                let _ = metrics
-                    .slot_production_elapsed_hist
-                    .increment(slot_production_start.as_us());
+                // Record delay for successful slot
+                slot_delay_start.stop();
+                let _ = metrics.slot_delay_hist.increment(slot_delay_start.as_us());
 
                 return Ok(());
             }

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -75,31 +75,32 @@ pub struct ReplayHighestFrozen {
 
 #[derive(Default)]
 struct BlockCreationLoopMetrics {
-    last_submit: u64,
-    loop_count: u64,
-    replay_is_behind_count: u64,
+    last_report: AtomicInterval,
+    loop_count: AtomicUsize,
+    replay_is_behind_count: AtomicUsize,
 }
 
 impl BlockCreationLoopMetrics {
-    fn update(&mut self, replay_is_behind_count: u64) {
-        self.loop_count += 1;
-        self.replay_is_behind_count = replay_is_behind_count;
-        self.maybe_submit();
-    }
+    fn report(&mut self, report_interval_ms: u64) {
+        // skip reporting metrics if stats is empty
+        if self.is_empty() {
+            return;
+        }
 
-    fn maybe_submit(&mut self) {
-        let now = timestamp();
-        let elapsed_ms = now - self.last_submit;
-
-        if elapsed_ms > 1000 {
+        if self.last_report.should_update(report_interval_ms) {
             datapoint_info!(
                 "block-creation-loop-metrics",
-                ("loop_count", self.loop_count, i64),
-                ("replay_is_behind_count", self.replay_is_behind_count, i64),
+                (
+                    "loop_count",
+                    self.loop_count.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "replay_is_behind_count",
+                    self.replay_is_behind_count.swap(0, Ordering::Relaxed),
+                    i64
+                ),
             );
-            
-            *self = BlockCreationLoopMetrics::default();
-            self.last_submit = now;
         }
     }
 }
@@ -244,7 +245,9 @@ pub fn start_loop(config: BlockCreationLoopConfig) {
             parent: {parent_slot}"
         );
 
-        if let Err(e) = start_leader_retry_replay(start_slot, parent_slot, skip_timer, &ctx, &mut metrics) {
+        if let Err(e) =
+            start_leader_retry_replay(start_slot, parent_slot, skip_timer, &ctx, &mut metrics)
+        {
             // Give up on this leader window
             error!(
                 "{my_pubkey}: Unable to produce first slot {start_slot}, skipping production of our entire leader window \
@@ -307,13 +310,15 @@ pub fn start_loop(config: BlockCreationLoopConfig) {
 
             // Although `slot - 1`has been cleared from `poh_recorder`, it might not have finished processing in
             // `replay_stage`, which is why we use `start_leader_retry_replay`
-            if let Err(e) = start_leader_retry_replay(slot, slot - 1, skip_timer, &ctx, &mut metrics) {
+            if let Err(e) =
+                start_leader_retry_replay(slot, slot - 1, skip_timer, &ctx, &mut metrics)
+            {
                 error!("{my_pubkey}: Unable to produce {slot}, skipping rest of leader window {slot} - {end_slot}: {e:?}");
                 break;
             }
         }
-        metrics.loop_count += 1;
-        metrics.maybe_submit();
+        metrics.loop_count.fetch_add(1, Ordering::Relaxed);
+        metrics.report(1000);
     }
 
     receive_record_loop.join().unwrap();
@@ -354,7 +359,7 @@ fn start_leader_retry_replay(
             }
             Err(StartLeaderError::ReplayIsBehind(_)) => {
                 metrics.replay_is_behind_count += 1;
-                
+
                 trace!(
                     "{my_pubkey}: Attempting to produce slot {slot}, however replay of the \
                     the parent {parent_slot} is not yet finished, waiting. Skip timer {}",

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -14,6 +14,7 @@ use {
         blockstore::Blockstore, leader_schedule_cache::LeaderScheduleCache,
         leader_schedule_utils::leader_slot_index,
     },
+    solana_metrics::datapoint_info,
     solana_poh::poh_recorder::{PohRecorder, Record, GRACE_TICKS_FACTOR, MAX_GRACE_SLOTS},
     solana_pubkey::Pubkey,
     solana_rpc::{rpc_subscriptions::RpcSubscriptions, slot_status_notifier::SlotStatusNotifier},
@@ -70,6 +71,37 @@ struct LeaderContext {
 pub struct ReplayHighestFrozen {
     pub highest_frozen_slot: Mutex<Slot>,
     pub freeze_notification: Condvar,
+}
+
+#[derive(Default)]
+struct BlockCreationLoopTiming {
+    last_submit: u64,
+    loop_count: u64,
+    replay_is_behind_count: u64,
+}
+
+impl BlockCreationLoopTiming {
+    fn update(&mut self, replay_is_behind_count: u64) {
+        self.loop_count += 1;
+        self.replay_is_behind_count = replay_is_behind_count;
+        self.maybe_submit();
+    }
+
+    fn maybe_submit(&mut self) {
+        let now = timestamp();
+        let elapsed_ms = now - self.last_submit;
+
+        if elapsed_ms > 1000 {
+            datapoint_info!(
+                "block-creation-loop-timing-stats",
+                ("loop_count", self.loop_count, i64),
+                ("replay_is_behind_count", self.replay_is_behind_count, i64),
+            );
+            
+            *self = BlockCreationLoopTiming::default();
+            self.last_submit = now;
+        }
+    }
 }
 
 #[derive(Debug, Error)]
@@ -162,6 +194,8 @@ pub fn start_loop(config: BlockCreationLoopConfig) {
         replay_highest_frozen,
     };
 
+    let mut timing = BlockCreationLoopTiming::default();
+
     // Setup poh
     reset_poh_recorder(&ctx.bank_forks.read().unwrap().working_bank(), &ctx);
 
@@ -210,7 +244,7 @@ pub fn start_loop(config: BlockCreationLoopConfig) {
             parent: {parent_slot}"
         );
 
-        if let Err(e) = start_leader_retry_replay(start_slot, parent_slot, skip_timer, &ctx) {
+        if let Err(e) = start_leader_retry_replay(start_slot, parent_slot, skip_timer, &ctx, &mut timing) {
             // Give up on this leader window
             error!(
                 "{my_pubkey}: Unable to produce first slot {start_slot}, skipping production of our entire leader window \
@@ -273,11 +307,13 @@ pub fn start_loop(config: BlockCreationLoopConfig) {
 
             // Although `slot - 1`has been cleared from `poh_recorder`, it might not have finished processing in
             // `replay_stage`, which is why we use `start_leader_retry_replay`
-            if let Err(e) = start_leader_retry_replay(slot, slot - 1, skip_timer, &ctx) {
+            if let Err(e) = start_leader_retry_replay(slot, slot - 1, skip_timer, &ctx, &mut timing) {
                 error!("{my_pubkey}: Unable to produce {slot}, skipping rest of leader window {slot} - {end_slot}: {e:?}");
                 break;
             }
         }
+        timing.loop_count += 1;
+        timing.maybe_submit();
     }
 
     receive_record_loop.join().unwrap();
@@ -307,6 +343,7 @@ fn start_leader_retry_replay(
     parent_slot: Slot,
     skip_timer: Instant,
     ctx: &LeaderContext,
+    timing: &mut BlockCreationLoopTiming,
 ) -> Result<(), StartLeaderError> {
     let my_pubkey = ctx.my_pubkey;
     let timeout = block_timeout(leader_slot_index(slot));
@@ -316,6 +353,8 @@ fn start_leader_retry_replay(
                 return Ok(());
             }
             Err(StartLeaderError::ReplayIsBehind(_)) => {
+                timing.replay_is_behind_count += 1;
+                
                 trace!(
                     "{my_pubkey}: Attempting to produce slot {slot}, however replay of the \
                     the parent {parent_slot} is not yet finished, waiting. Skip timer {}",

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -414,10 +414,9 @@ pub fn start_loop(config: BlockCreationLoopConfig) {
 
             // Record individual slot production time
             slot_production_start.stop();
-            metrics
+            let _ = metrics
                 .slot_production_elapsed_hist
-                .increment(slot_production_start.as_us())
-                .unwrap();
+                .increment(slot_production_start.as_us());
         }
         window_production_start.stop();
         metrics

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -90,6 +90,24 @@ struct BlockCreationLoopMetrics {
 }
 
 impl BlockCreationLoopMetrics {
+    fn is_empty(&self) -> bool {
+        0 == self.loop_count.load(Ordering::Relaxed) as u64
+            + self.replay_is_behind_count.load(Ordering::Relaxed) as u64
+            + self
+                .delay_after_replay_is_behind_elapsed
+                .load(Ordering::Relaxed) as u64
+            + self.record_receiver_timeout_count.load(Ordering::Relaxed) as u64
+            + self
+                .record_receiver_disconnected_count
+                .load(Ordering::Relaxed) as u64
+            + self
+                .startup_verification_incomplete_count
+                .load(Ordering::Relaxed) as u64
+            + self.already_have_bank_count.load(Ordering::Relaxed) as u64
+            + self.window_production_elapsed.load(Ordering::Relaxed) as u64
+            + self.slot_production_elapsed_hist.entries() as u64
+    }
+
     fn report(&mut self, report_interval_ms: u64) {
         // skip reporting metrics if stats is empty
         if self.is_empty() {

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -78,31 +78,19 @@ pub struct ReplayHighestFrozen {
 struct BlockCreationLoopMetrics {
     last_report: u64,
     loop_count: u64,
-    replay_is_behind_count: AtomicUsize,
-    startup_verification_incomplete_count: AtomicUsize,
-    already_have_bank_count: AtomicUsize,
     bank_timeout_completion_count: AtomicUsize,
     bank_filled_completion_count: AtomicUsize,
 
-    replay_is_behind_wait_elapsed: AtomicU64,
     window_production_elapsed: AtomicU64,
-    slot_delay_hist: histogram::Histogram,
     bank_completion_elapsed_hist: histogram::Histogram,
 }
 
 impl BlockCreationLoopMetrics {
     fn is_empty(&self) -> bool {
         0 == self.loop_count
-            + self.replay_is_behind_count.load(Ordering::Relaxed) as u64
-            + self
-                .startup_verification_incomplete_count
-                .load(Ordering::Relaxed) as u64
-            + self.already_have_bank_count.load(Ordering::Relaxed) as u64
             + self.bank_timeout_completion_count.load(Ordering::Relaxed) as u64
             + self.bank_filled_completion_count.load(Ordering::Relaxed) as u64
-            + self.replay_is_behind_wait_elapsed.load(Ordering::Relaxed)
             + self.window_production_elapsed.load(Ordering::Relaxed)
-            + self.slot_delay_hist.entries()
             + self.bank_completion_elapsed_hist.entries()
     }
 
@@ -120,22 +108,6 @@ impl BlockCreationLoopMetrics {
                 "block-creation-loop-metrics",
                 ("loop_count", self.loop_count, i64),
                 (
-                    "replay_is_behind_count",
-                    self.replay_is_behind_count.swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "startup_verification_incomplete_count",
-                    self.startup_verification_incomplete_count
-                        .swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "already_have_bank_count",
-                    self.already_have_bank_count.swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
                     "bank_timeout_completion_count",
                     self.bank_timeout_completion_count
                         .swap(0, Ordering::Relaxed),
@@ -147,34 +119,8 @@ impl BlockCreationLoopMetrics {
                     i64
                 ),
                 (
-                    "replay_is_behind_wait_elapsed",
-                    self.replay_is_behind_wait_elapsed
-                        .swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
                     "window_production_elapsed",
                     self.window_production_elapsed.swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "slot_delay_90pct",
-                    self.slot_delay_hist.percentile(90.0).unwrap_or(0),
-                    i64
-                ),
-                (
-                    "slot_delay_mean",
-                    self.slot_delay_hist.mean().unwrap_or(0),
-                    i64
-                ),
-                (
-                    "slot_delay_min",
-                    self.slot_delay_hist.minimum().unwrap_or(0),
-                    i64
-                ),
-                (
-                    "slot_delay_max",
-                    self.slot_delay_hist.maximum().unwrap_or(0),
                     i64
                 ),
                 (
@@ -202,10 +148,102 @@ impl BlockCreationLoopMetrics {
             );
 
             // .swap() resetted most of the metrics to 0, but not the histograms or non-atomic values. reset them.
-            self.slot_delay_hist.clear();
             self.bank_completion_elapsed_hist.clear();
             self.last_report = now;
         }
+    }
+}
+
+// Metrics on slots that we attempt to start a leader block for
+#[derive(Default)]
+struct SlotMetrics {
+    slot: Slot,
+    attempt_count: u64,
+    replay_is_behind_count: u64,
+    startup_verification_incomplete_count: u64,
+    already_have_bank_count: u64,
+
+    slot_delay_hist: histogram::Histogram,
+    replay_is_behind_cumulative_wait_elapsed: u64,
+    replay_is_behind_wait_elapsed_hist: histogram::Histogram,
+}
+
+impl SlotMetrics {
+    fn report(&mut self) {
+        datapoint_info!(
+            "slot-metrics",
+            ("slot", self.slot, i64),
+            ("attempt_count", self.attempt_count, i64),
+            (
+                "replay_is_behind_count",
+                self.replay_is_behind_count,
+                i64
+            ),
+            (
+                "startup_verification_incomplete_count",
+                self.startup_verification_incomplete_count,
+                i64
+            ),
+            (
+                "already_have_bank_count",
+                self.already_have_bank_count,
+                i64
+            ),
+            (
+                "slot_delay_90pct",
+                self.slot_delay_hist.percentile(90.0).unwrap_or(0),
+                i64
+            ),
+            (
+                "slot_delay_mean",
+                self.slot_delay_hist.mean().unwrap_or(0),
+                i64
+            ),
+            (
+                "slot_delay_min",
+                self.slot_delay_hist.minimum().unwrap_or(0),
+                i64
+            ),
+            (
+                "slot_delay_max",
+                self.slot_delay_hist.maximum().unwrap_or(0),
+                i64
+            ),
+            (
+                "replay_is_behind_cumulative_wait_elapsed",
+                self.replay_is_behind_cumulative_wait_elapsed,
+                i64
+            ),
+            (
+                "replay_is_behind_wait_elapsed_90pct",
+                self.replay_is_behind_wait_elapsed_hist.percentile(90.0).unwrap_or(0),
+                i64
+            ),
+            (
+                "replay_is_behind_wait_elapsed_mean",
+                self.replay_is_behind_wait_elapsed_hist.mean().unwrap_or(0),
+                i64
+            ),
+            (
+                "replay_is_behind_wait_elapsed_min",
+                self.replay_is_behind_wait_elapsed_hist.minimum().unwrap_or(0),
+                i64
+            ),
+            (
+                "replay_is_behind_wait_elapsed_max",
+                self.replay_is_behind_wait_elapsed_hist.maximum().unwrap_or(0),
+                i64
+            ),
+        );
+
+        // reset metrics
+        self.attempt_count = 0;
+        self.replay_is_behind_count = 0;
+        self.startup_verification_incomplete_count = 0;
+        self.already_have_bank_count = 0;
+        self.slot_delay_hist.clear();
+        self.replay_is_behind_cumulative_wait_elapsed = 0;
+        self.replay_is_behind_wait_elapsed_hist.clear();
     }
 }
 
@@ -300,6 +338,7 @@ pub fn start_loop(config: BlockCreationLoopConfig) {
     };
 
     let mut metrics = BlockCreationLoopMetrics::default();
+    let mut slot_metrics = SlotMetrics::default();
 
     // Setup poh
     reset_poh_recorder(&ctx.bank_forks.read().unwrap().working_bank(), &ctx);
@@ -350,7 +389,7 @@ pub fn start_loop(config: BlockCreationLoopConfig) {
         );
 
         if let Err(e) =
-            start_leader_retry_replay(start_slot, parent_slot, skip_timer, &ctx, &mut metrics)
+            start_leader_retry_replay(start_slot, parent_slot, skip_timer, &ctx, &mut slot_metrics)
         {
             // Give up on this leader window
             error!(
@@ -438,7 +477,7 @@ pub fn start_loop(config: BlockCreationLoopConfig) {
             // Although `slot - 1`has been cleared from `poh_recorder`, it might not have finished processing in
             // `replay_stage`, which is why we use `start_leader_retry_replay`
             if let Err(e) =
-                start_leader_retry_replay(slot, slot - 1, skip_timer, &ctx, &mut metrics)
+                start_leader_retry_replay(slot, slot - 1, skip_timer, &ctx, &mut slot_metrics)
             {
                 error!("{my_pubkey}: Unable to produce {slot}, skipping rest of leader window {slot} - {end_slot}: {e:?}");
                 break;
@@ -479,24 +518,28 @@ fn start_leader_retry_replay(
     parent_slot: Slot,
     skip_timer: Instant,
     ctx: &LeaderContext,
-    metrics: &mut BlockCreationLoopMetrics,
+    slot_metrics: &mut SlotMetrics,
 ) -> Result<(), StartLeaderError> {
     let my_pubkey = ctx.my_pubkey;
     let timeout = block_timeout(leader_slot_index(slot));
     let mut slot_delay_start = Measure::start("slot_delay");
     while !timeout.saturating_sub(skip_timer.elapsed()).is_zero() {
-        match maybe_start_leader(slot, parent_slot, ctx, metrics) {
+        // Count attempts to start a leader block
+        slot_metrics.attempt_count += 1;
+
+        match maybe_start_leader(slot, parent_slot, ctx, slot_metrics) {
             Ok(()) => {
                 // Record delay for successful slot
                 slot_delay_start.stop();
-                let _ = metrics.slot_delay_hist.increment(slot_delay_start.as_us());
+                let _ = slot_metrics.slot_delay_hist.increment(slot_delay_start.as_us());
+
+                // slot was successful, report slot's metrics
+                slot_metrics.report();
 
                 return Ok(());
             }
             Err(StartLeaderError::ReplayIsBehind(_)) => {
-                metrics
-                    .replay_is_behind_count
-                    .fetch_add(1, Ordering::Relaxed);
+                // slot_metrics.replay_is_behind_count already gets incremented in maybe_start_leader
 
                 trace!(
                     "{my_pubkey}: Attempting to produce slot {slot}, however replay of the \
@@ -521,17 +564,15 @@ fn start_leader_retry_replay(
                     )
                     .unwrap();
                 wait_start.stop();
-                metrics
-                    .replay_is_behind_wait_elapsed
-                    .fetch_add(wait_start.as_us(), Ordering::Relaxed);
+                slot_metrics.replay_is_behind_cumulative_wait_elapsed += wait_start.as_us();
+                let _ = slot_metrics
+                    .replay_is_behind_wait_elapsed_hist
+                    .increment(wait_start.as_us());
             }
             Err(e) => return Err(e),
         }
     }
 
-    metrics
-        .replay_is_behind_count
-        .fetch_add(1, Ordering::Relaxed);
     error!(
         "{my_pubkey}: Skipping production of {slot}: \
         Unable to replay parent {parent_slot} in time"
@@ -552,33 +593,25 @@ fn maybe_start_leader(
     slot: Slot,
     parent_slot: Slot,
     ctx: &LeaderContext,
-    metrics: &mut BlockCreationLoopMetrics,
+    slot_metrics: &mut SlotMetrics,
 ) -> Result<(), StartLeaderError> {
     if ctx.bank_forks.read().unwrap().get(slot).is_some() {
-        metrics
-            .already_have_bank_count
-            .fetch_add(1, Ordering::Relaxed);
+        slot_metrics.already_have_bank_count += 1;
         return Err(StartLeaderError::AlreadyHaveBank(slot));
     }
 
     let Some(parent_bank) = ctx.bank_forks.read().unwrap().get(parent_slot) else {
-        metrics
-            .replay_is_behind_count
-            .fetch_add(1, Ordering::Relaxed);
+        slot_metrics.replay_is_behind_count += 1;
         return Err(StartLeaderError::ReplayIsBehind(parent_slot));
     };
 
     if !parent_bank.is_frozen() {
-        metrics
-            .replay_is_behind_count
-            .fetch_add(1, Ordering::Relaxed);
+        slot_metrics.replay_is_behind_count += 1;
         return Err(StartLeaderError::ReplayIsBehind(parent_slot));
     }
 
     if !parent_bank.has_initial_accounts_hash_verification_completed() {
-        metrics
-            .startup_verification_incomplete_count
-            .fetch_add(1, Ordering::Relaxed);
+        slot_metrics.startup_verification_incomplete_count += 1;
         return Err(StartLeaderError::StartupVerificationIncomplete(parent_slot));
     }
 

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -100,10 +100,10 @@ impl BlockCreationLoopMetrics {
             + self.already_have_bank_count.load(Ordering::Relaxed) as u64
             + self.bank_timeout_completion_count.load(Ordering::Relaxed) as u64
             + self.bank_filled_completion_count.load(Ordering::Relaxed) as u64
-            + self.replay_is_behind_wait_elapsed.load(Ordering::Relaxed) as u64
-            + self.window_production_elapsed.load(Ordering::Relaxed) as u64
-            + self.slot_production_elapsed_hist.entries() as u64
-            + self.bank_completion_elapsed_hist.entries() as u64
+            + self.replay_is_behind_wait_elapsed.load(Ordering::Relaxed)
+            + self.window_production_elapsed.load(Ordering::Relaxed)
+            + self.slot_production_elapsed_hist.entries()
+            + self.bank_completion_elapsed_hist.entries()
     }
 
     fn report(&mut self, report_interval_ms: u64) {

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -79,8 +79,6 @@ struct BlockCreationLoopMetrics {
     last_report: AtomicInterval,
     loop_count: AtomicUsize,
     replay_is_behind_count: AtomicUsize,
-    record_receiver_timeout_count: AtomicUsize,
-    record_receiver_disconnected_count: AtomicUsize,
     startup_verification_incomplete_count: AtomicUsize,
     already_have_bank_count: AtomicUsize,
 
@@ -93,10 +91,6 @@ impl BlockCreationLoopMetrics {
     fn is_empty(&self) -> bool {
         0 == self.loop_count.load(Ordering::Relaxed) as u64
             + self.replay_is_behind_count.load(Ordering::Relaxed) as u64
-            + self.record_receiver_timeout_count.load(Ordering::Relaxed) as u64
-            + self
-                .record_receiver_disconnected_count
-                .load(Ordering::Relaxed) as u64
             + self
                 .startup_verification_incomplete_count
                 .load(Ordering::Relaxed) as u64
@@ -119,18 +113,6 @@ impl BlockCreationLoopMetrics {
                 (
                     "replay_is_behind_count",
                     self.replay_is_behind_count.swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "record_receiver_timeout_count",
-                    self.record_receiver_timeout_count
-                        .swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "record_receiver_disconnected_count",
-                    self.record_receiver_disconnected_count
-                        .swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
@@ -205,7 +187,6 @@ fn start_receive_and_record_loop(
     exit: Arc<AtomicBool>,
     poh_recorder: Arc<RwLock<PohRecorder>>,
     record_receiver: Receiver<Record>,
-    metrics: &mut BlockCreationLoopMetrics,
 ) {
     while !exit.load(Ordering::Relaxed) {
         // We need a timeout here to check the exit flag, chose 400ms
@@ -226,16 +207,9 @@ fn start_receive_and_record_loop(
             }
             Err(RecvTimeoutError::Disconnected) => {
                 info!("Record receiver disconnected");
-                metrics
-                    .record_receiver_disconnected_count
-                    .fetch_add(1, Ordering::Relaxed);
                 return;
             }
-            Err(RecvTimeoutError::Timeout) => {
-                metrics
-                    .record_receiver_timeout_count
-                    .fetch_add(1, Ordering::Relaxed);
-            }
+            Err(RecvTimeoutError::Timeout) => (),
         }
     }
 }
@@ -289,7 +263,7 @@ pub fn start_loop(config: BlockCreationLoopConfig) {
     let exit_c = exit.clone();
     let p_rec = poh_recorder.clone();
     let receive_record_loop = thread::spawn(move || {
-        start_receive_and_record_loop(exit_c, p_rec, record_receiver, &mut metrics);
+        start_receive_and_record_loop(exit_c, p_rec, record_receiver);
     });
 
     while !exit.load(Ordering::Relaxed) {

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -387,13 +387,14 @@ pub fn start_loop(config: BlockCreationLoopConfig) {
                 }
             }
 
+            // Assert that the bank has been cleared
+            assert!(!poh_recorder.read().unwrap().has_bank());
+
             // Record bank completion time
             bank_completion_measure.stop();
             let _ = metrics
                 .bank_completion_elapsed_hist
                 .increment(bank_completion_measure.as_us());
-
-            assert!(!poh_recorder.read().unwrap().has_bank());
 
             // Produce our next slot
             slot += 1;

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -93,7 +93,7 @@ impl BlockCreationLoopMetrics {
                 "block-creation-loop-metrics",
                 (
                     "loop_count",
-                    self.loop_count.swap(0, Ordering::Relaxed),
+                    self.loop_count.load(Ordering::Relaxed),
                     i64
                 ),
                 (

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -79,12 +79,12 @@ struct BlockCreationLoopMetrics {
     last_report: AtomicInterval,
     loop_count: AtomicUsize,
     replay_is_behind_count: AtomicUsize,
-    delay_after_replay_is_behind_elapsed: AtomicU64,
     record_receiver_timeout_count: AtomicUsize,
     record_receiver_disconnected_count: AtomicUsize,
     startup_verification_incomplete_count: AtomicUsize,
     already_have_bank_count: AtomicUsize,
 
+    replay_is_behind_wait_elapsed: AtomicU64,
     window_production_elapsed: AtomicU64,
     slot_production_elapsed_hist: histogram::Histogram,
 }
@@ -93,9 +93,6 @@ impl BlockCreationLoopMetrics {
     fn is_empty(&self) -> bool {
         0 == self.loop_count.load(Ordering::Relaxed) as u64
             + self.replay_is_behind_count.load(Ordering::Relaxed) as u64
-            + self
-                .delay_after_replay_is_behind_elapsed
-                .load(Ordering::Relaxed) as u64
             + self.record_receiver_timeout_count.load(Ordering::Relaxed) as u64
             + self
                 .record_receiver_disconnected_count
@@ -104,6 +101,7 @@ impl BlockCreationLoopMetrics {
                 .startup_verification_incomplete_count
                 .load(Ordering::Relaxed) as u64
             + self.already_have_bank_count.load(Ordering::Relaxed) as u64
+            + self.replay_is_behind_wait_elapsed.load(Ordering::Relaxed) as u64
             + self.window_production_elapsed.load(Ordering::Relaxed) as u64
             + self.slot_production_elapsed_hist.entries() as u64
     }
@@ -121,12 +119,6 @@ impl BlockCreationLoopMetrics {
                 (
                     "replay_is_behind_count",
                     self.replay_is_behind_count.swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "delay_after_replay_is_behind_elapsed",
-                    self.delay_after_replay_is_behind_elapsed
-                        .swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
@@ -150,6 +142,12 @@ impl BlockCreationLoopMetrics {
                 (
                     "already_have_bank_count",
                     self.already_have_bank_count.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "replay_is_behind_wait_elapsed",
+                    self.replay_is_behind_wait_elapsed
+                        .swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
@@ -474,7 +472,7 @@ fn start_leader_retry_replay(
                     .unwrap();
 
                 // We wait until either we finish replay of the parent or the skip timer finishes
-                let mut wait_start = Measure::start("delay_after_replay_is_behind");
+                let mut wait_start = Measure::start("replay_is_behind");
                 let _unused = ctx
                     .replay_highest_frozen
                     .freeze_notification
@@ -486,7 +484,7 @@ fn start_leader_retry_replay(
                     .unwrap();
                 wait_start.stop();
                 metrics
-                    .delay_after_replay_is_behind_elapsed
+                    .replay_is_behind_wait_elapsed
                     .fetch_add(wait_start.as_us(), Ordering::Relaxed);
             }
             Err(e) => return Err(e),

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -78,6 +78,7 @@ struct BlockCreationLoopMetrics {
     last_report: AtomicInterval,
     loop_count: AtomicUsize,
     replay_is_behind_count: AtomicUsize,
+    delay_after_replay_is_behind_elapsed: AtomicU64,
 }
 
 impl BlockCreationLoopMetrics {
@@ -98,6 +99,12 @@ impl BlockCreationLoopMetrics {
                 (
                     "replay_is_behind_count",
                     self.replay_is_behind_count.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "delay_after_replay_is_behind_elapsed",
+                    self.delay_after_replay_is_behind_elapsed
+                        .swap(0, Ordering::Relaxed),
                     i64
                 ),
             );
@@ -358,7 +365,9 @@ fn start_leader_retry_replay(
                 return Ok(());
             }
             Err(StartLeaderError::ReplayIsBehind(_)) => {
-                metrics.replay_is_behind_count.fetch_add(1, Ordering::Relaxed);
+                metrics
+                    .replay_is_behind_count
+                    .fetch_add(1, Ordering::Relaxed);
 
                 trace!(
                     "{my_pubkey}: Attempting to produce slot {slot}, however replay of the \
@@ -370,7 +379,9 @@ fn start_leader_retry_replay(
                     .highest_frozen_slot
                     .lock()
                     .unwrap();
+
                 // We wait until either we finish replay of the parent or the skip timer finishes
+                let mut wait_start = Measure::start("delay_after_replay_is_behind");
                 let _unused = ctx
                     .replay_highest_frozen
                     .freeze_notification
@@ -380,6 +391,10 @@ fn start_leader_retry_replay(
                         |hfs| *hfs < parent_slot,
                     )
                     .unwrap();
+                wait_start.stop();
+                metrics
+                    .delay_after_replay_is_behind_elapsed
+                    .fetch_add(wait_start.as_us(), Ordering::Relaxed);
             }
             Err(e) => return Err(e),
         }

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -74,13 +74,13 @@ pub struct ReplayHighestFrozen {
 }
 
 #[derive(Default)]
-struct BlockCreationLoopTiming {
+struct BlockCreationLoopMetrics {
     last_submit: u64,
     loop_count: u64,
     replay_is_behind_count: u64,
 }
 
-impl BlockCreationLoopTiming {
+impl BlockCreationLoopMetrics {
     fn update(&mut self, replay_is_behind_count: u64) {
         self.loop_count += 1;
         self.replay_is_behind_count = replay_is_behind_count;
@@ -93,12 +93,12 @@ impl BlockCreationLoopTiming {
 
         if elapsed_ms > 1000 {
             datapoint_info!(
-                "block-creation-loop-timing-stats",
+                "block-creation-loop-metrics",
                 ("loop_count", self.loop_count, i64),
                 ("replay_is_behind_count", self.replay_is_behind_count, i64),
             );
             
-            *self = BlockCreationLoopTiming::default();
+            *self = BlockCreationLoopMetrics::default();
             self.last_submit = now;
         }
     }
@@ -194,7 +194,7 @@ pub fn start_loop(config: BlockCreationLoopConfig) {
         replay_highest_frozen,
     };
 
-    let mut timing = BlockCreationLoopTiming::default();
+    let mut metrics = BlockCreationLoopMetrics::default();
 
     // Setup poh
     reset_poh_recorder(&ctx.bank_forks.read().unwrap().working_bank(), &ctx);
@@ -244,7 +244,7 @@ pub fn start_loop(config: BlockCreationLoopConfig) {
             parent: {parent_slot}"
         );
 
-        if let Err(e) = start_leader_retry_replay(start_slot, parent_slot, skip_timer, &ctx, &mut timing) {
+        if let Err(e) = start_leader_retry_replay(start_slot, parent_slot, skip_timer, &ctx, &mut metrics) {
             // Give up on this leader window
             error!(
                 "{my_pubkey}: Unable to produce first slot {start_slot}, skipping production of our entire leader window \
@@ -307,13 +307,13 @@ pub fn start_loop(config: BlockCreationLoopConfig) {
 
             // Although `slot - 1`has been cleared from `poh_recorder`, it might not have finished processing in
             // `replay_stage`, which is why we use `start_leader_retry_replay`
-            if let Err(e) = start_leader_retry_replay(slot, slot - 1, skip_timer, &ctx, &mut timing) {
+            if let Err(e) = start_leader_retry_replay(slot, slot - 1, skip_timer, &ctx, &mut metrics) {
                 error!("{my_pubkey}: Unable to produce {slot}, skipping rest of leader window {slot} - {end_slot}: {e:?}");
                 break;
             }
         }
-        timing.loop_count += 1;
-        timing.maybe_submit();
+        metrics.loop_count += 1;
+        metrics.maybe_submit();
     }
 
     receive_record_loop.join().unwrap();
@@ -343,7 +343,7 @@ fn start_leader_retry_replay(
     parent_slot: Slot,
     skip_timer: Instant,
     ctx: &LeaderContext,
-    timing: &mut BlockCreationLoopTiming,
+    metrics: &mut BlockCreationLoopMetrics,
 ) -> Result<(), StartLeaderError> {
     let my_pubkey = ctx.my_pubkey;
     let timeout = block_timeout(leader_slot_index(slot));
@@ -353,7 +353,7 @@ fn start_leader_retry_replay(
                 return Ok(());
             }
             Err(StartLeaderError::ReplayIsBehind(_)) => {
-                timing.replay_is_behind_count += 1;
+                metrics.replay_is_behind_count += 1;
                 
                 trace!(
                     "{my_pubkey}: Attempting to produce slot {slot}, however replay of the \


### PR DESCRIPTION
### Problem
Solves #122 for the block creation loop by adding in metrics to track the metrics in [this comment](https://github.com/anza-xyz/alpenglow/issues/122#issuecomment-3047284188).

### Summary of Changes
In this PR, I add two types of metrics for the block creation loop. `BlockCreationLoopMetrics` which provides high-level performance monitoring for the entire block creation loop, and `SlotMetrics` which provides granular monitoring for individual slot production attempts inside of the block creation loop.

---

### Metrics Specification

#### BlockCreationLoopMetrics

These metrics provides high-level performance monitoring for the entire block creation loop.

| Metric | Type | Description |
|--------|---------|----------|
| `loop_count` | Counter | Total number of leader windows processed |
| `window_production_elapsed` | Duration | Total time spent producing all the slots for the given window |
| `bank_filled_completion_elapsed_hist` | Histogram | Distribution of completion times for filled banks |
| `bank_timeout_completion_elapsed_hist` | Histogram | Distribution of completion times for timed-out banks |
| `bank_filled_completion_count` | Counter | Banks completed due to being filled |
| `bank_timeout_completion_count` | Counter | Banks completed due to timeout |

#### SlotMetrics

These metrics provides granular monitoring for individual slot production attempts inside of the block creation loop.

| Metric | Type | Description |
|--------|---------|----------|
| `slot` | Identifier | Current slot being monitored |
| `attempt_count` | Counter | Number of attempts to start this slot (`AlreadyHaveBank` error) |
| `replay_is_behind_count` | Counter | Times replay was behind parent slot (`ReplayIsBehind` error) |
| `startup_verification_incomplete_count` | Counter | Times startup verification was incomplete (`StartupVerificationIncomplete` error) |
| `already_have_bank_count` | Counter | Times bank already existed for slot |
| `slot_delay_hist` | Histogram | Distribution of the times elapsed between attempting to start producing a slot -> successfully starting production of the slot  |
| `replay_is_behind_cumulative_wait_elapsed` | Duration | Total time waiting for replay to catch up |
| `replay_is_behind_wait_elapsed_hist` | Histogram | Distribution of individual replay wait times |

#### todo list
Add metrics for the following:
- [x] count on the number of times a replay is behind (`ReplayIsBehind` error). `replay_is_behind_count`
- [x] count on number of `StartupVerificationIncomplete` error. `startup_verification_incomplete_count`
- [x] time it takes to create and insert a bank as `bank_completion_elapsed`
- [x] time it takes to create a window, starting from after the voting loop gets notified & node is prepared [here](https://github.com/anza-xyz/alpenglow/blob/331c3bd905ac4f9180f4a38868cacc848f55f25b/core/src/block_creation_loop.rs#L230-L287). `window_production_elapsed`
- [x] of the time it takes to create a window of slots, how long does it take to create each slot in this loop [here](https://github.com/anza-xyz/alpenglow/blob/331c3bd905ac4f9180f4a38868cacc848f55f25b/core/src/block_creation_loop.rs#L232-L287). `slot_production_elapsed`
- [x]  number of times we hit bank completion via timeout. `bank_timeout_completion_count`
- [x] number of times we hit bank completion via bank getting filled. `bank_filled_completion_count`
- [x] how much time `start_leader_retry_replay()` ends up waiting for replay (specifically, how long it took to wait on `wait_timeout_while`) as `replay_is_behind_wait_elapsed`
