### PR TITLE
refactor: start retuning errors in `voting_loop.rs`

### DIFF
--- a/votor/src/certificate_pool.rs
+++ b/votor/src/certificate_pool.rs
@@ -75,6 +75,9 @@ pub enum AddVoteError {
 
     #[error("Invalid rank: {0}")]
     InvalidRank(u16),
+
+    #[error("Updating the commitment cache failed")]
+    UpdateCommitmentCache,
 }
 
 #[derive(Default)]

--- a/votor/src/voting_utils.rs
+++ b/votor/src/voting_utils.rs
@@ -221,7 +221,6 @@ pub fn generate_vote_tx(
 /// For notarization & finalization votes this will be the voted bank
 /// for skip votes we need to ensure that the bank selected will be on
 /// the leader's choosen fork.
-#[allow(clippy::too_many_arguments)]
 pub fn send_vote(
     vote: Vote,
     is_refresh: bool,
@@ -288,9 +287,11 @@ pub fn add_message_and_maybe_update_commitment(
     };
     trace!("{my_pubkey}: new finalization certificate for {new_finalized_slot}");
     alpenglow_update_commitment_cache(
-        AlpenglowCommitmentType::Finalized,
-        new_finalized_slot,
+        AlpenglowCommitmentAggregationData {
+            commitment_type: AlpenglowCommitmentType::Finalized,
+            slot: new_finalized_slot,
+        },
         commitment_sender,
-    );
-    Ok(())
+    )
+    .map_err(|_msg| AddVoteError::UpdateCommitmentCache)
 }


### PR DESCRIPTION
Related: https://github.com/anza-xyz/alpenglow/issues/131.

Updates some functions to return `Result` instead of `bool`.  This enables cleaner error handling that can be bubbled up to the main loop so that we can exit the loop cleanly when needed.