### PR TITLE
Remove bank hash from Alpenglow structures

### DIFF
--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -194,7 +194,7 @@ pub fn start_loop(config: BlockCreationLoopConfig) {
             start_slot,
             end_slot,
             // TODO: handle duplicate blocks by using the hash here
-            parent_block: (parent_slot, _, _),
+            parent_block: (parent_slot, _),
             skip_timer,
         } = {
             let window_info = leader_window_notifier.window_info.lock().unwrap();

--- a/core/src/repair/certificate_service.rs
+++ b/core/src/repair/certificate_service.rs
@@ -7,6 +7,7 @@ use {
     crate::result::{Error, Result},
     crossbeam_channel::{Receiver, RecvTimeoutError},
     solana_ledger::blockstore::Blockstore,
+    solana_sdk::hash::Hash,
     solana_vote::alpenglow::bls_message::CertificateMessage,
     solana_votor::CertificateId,
     std::{
@@ -89,19 +90,19 @@ impl CertificateService {
         vote_certificate: CertificateMessage,
     ) -> Result<()> {
         match cert_id {
-            CertificateId::NotarizeFallback(slot, block_id, bank_hash) => blockstore
+            CertificateId::NotarizeFallback(slot, block_id) => blockstore
                 .insert_new_notarization_fallback_certificate(
                     slot,
                     block_id,
-                    bank_hash,
+                    Hash::default(),
                     vote_certificate,
                 )?,
             CertificateId::Skip(slot) => {
                 blockstore.insert_new_skip_certificate(slot, vote_certificate)?
             }
             CertificateId::Finalize(_)
-            | CertificateId::FinalizeFast(_, _, _)
-            | CertificateId::Notarize(_, _, _) => {
+            | CertificateId::FinalizeFast(_, _)
+            | CertificateId::Notarize(_, _) => {
                 panic!("Programmer error, certificate pool should not notify for {cert_id:?}")
             }
         }

--- a/core/src/repair/certificate_service.rs
+++ b/core/src/repair/certificate_service.rs
@@ -7,7 +7,6 @@ use {
     crate::result::{Error, Result},
     crossbeam_channel::{Receiver, RecvTimeoutError},
     solana_ledger::blockstore::Blockstore,
-    solana_sdk::hash::Hash,
     solana_vote::alpenglow::bls_message::CertificateMessage,
     solana_votor::CertificateId,
     std::{
@@ -91,12 +90,7 @@ impl CertificateService {
     ) -> Result<()> {
         match cert_id {
             CertificateId::NotarizeFallback(slot, block_id) => blockstore
-                .insert_new_notarization_fallback_certificate(
-                    slot,
-                    block_id,
-                    Hash::default(),
-                    vote_certificate,
-                )?,
+                .insert_new_notarization_fallback_certificate(slot, block_id, vote_certificate)?,
             CertificateId::Skip(slot) => {
                 blockstore.insert_new_skip_certificate(slot, vote_certificate)?
             }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -4026,13 +4026,12 @@ impl Blockstore {
         &self,
         slot: Slot,
         block_id: Hash,
-        bank_hash: Hash,
         certificate: CertificateMessage,
     ) -> Result<()> {
         let mut certificates = self
             .slot_certificates(slot)?
             .unwrap_or(SlotCertificates::default());
-        certificates.add_notarization_fallback_certificate(block_id, bank_hash, certificate);
+        certificates.add_notarization_fallback_certificate(block_id, certificate);
         self.slot_certificates_cf.put(slot, &certificates)
     }
 

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -887,8 +887,8 @@ impl OptimisticSlotMetaVersioned {
 /// This will normally be written to once per slot, but in the worst case 4 times per slot
 /// It will be read to serve repair to other nodes.
 pub struct SlotCertificates {
-    /// The notarization fallback certificates keyed by (block_id, bank_hash)
-    pub notarize_fallback_certificates: HashMap<(Hash, Hash), CertificateMessage>,
+    /// The notarization fallback certificates keyed by block_id
+    pub notarize_fallback_certificates: HashMap<Hash, CertificateMessage>,
     /// The skip certificate
     pub skip_certificate: Option<CertificateMessage>,
 }
@@ -899,11 +899,9 @@ impl SlotCertificates {
     pub fn add_notarization_fallback_certificate(
         &mut self,
         block_id: Hash,
-        bank_hash: Hash,
         cert: CertificateMessage,
     ) {
-        self.notarize_fallback_certificates
-            .insert((block_id, bank_hash), cert);
+        self.notarize_fallback_certificates.insert(block_id, cert);
     }
 
     pub fn set_skip_certificate(&mut self, cert: CertificateMessage) {

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -6460,7 +6460,7 @@ fn test_alpenglow_ensure_liveness_after_single_notar_fallback() {
 /// Node C, observing the conflicting votes, triggers SafeToNotar for both blocks:
 /// - Issues NotarizeFallback for b1 (A's block)
 /// - Issues NotarizeFallback for b2 (B's equivocated block)
-/// - Verifies the block IDs and bank hashes are different due to equivocation
+/// - Verifies the block IDs are different due to equivocation
 /// - Continues this pattern until 3 slots have double NotarizeFallback votes
 ///
 /// ## Phase 4: Recovery and Liveness
@@ -6587,7 +6587,7 @@ fn test_alpenglow_ensure_liveness_after_double_notar_fallback() {
     struct VoteListenerState {
         num_notar_fallback_votes: u32,
         a_equivocates: bool,
-        notar_fallback_map: HashMap<Slot, Vec<(Hash, Hash)>>,
+        notar_fallback_map: HashMap<Slot, Vec<Hash>>,
         double_notar_fallback_slots: Vec<Slot>,
         check_for_roots: bool,
         post_experiment_votes: HashMap<Slot, Vec<u16>>,
@@ -6678,10 +6678,9 @@ fn test_alpenglow_ensure_liveness_after_double_notar_fallback() {
             // Handle double NotarizeFallback during equivocation
             if self.a_equivocates && vote.is_notarize_fallback() {
                 let block_id = vote.block_id().copied().unwrap();
-                let bank_hash = vote.replayed_bank_hash().copied().unwrap();
 
                 let entry = self.notar_fallback_map.entry(vote.slot()).or_default();
-                entry.push((block_id, bank_hash));
+                entry.push(block_id);
 
                 assert!(
                     entry.len() <= 2,
@@ -6690,14 +6689,10 @@ fn test_alpenglow_ensure_liveness_after_double_notar_fallback() {
                 );
 
                 if entry.len() == 2 {
-                    // Verify equivocation: different block IDs and bank hashes
+                    // Verify equivocation: different block IDs
                     assert_ne!(
-                        entry[0].0, entry[1].0,
+                        entry[0], entry[1],
                         "Block IDs should differ due to equivocation"
-                    );
-                    assert_ne!(
-                        entry[0].1, entry[1].1,
-                        "Bank hashes should differ due to equivocation"
                     );
 
                     self.double_notar_fallback_slots.push(vote.slot());

--- a/votor/src/certificate_pool.rs
+++ b/votor/src/certificate_pool.rs
@@ -5,9 +5,7 @@ use {
             parent_ready_tracker::ParentReadyTracker,
             stats::CertificatePoolStats,
             vote_certificate::{CertificateError, VoteCertificate},
-            vote_pool::{
-                DuplicateBlockVotePool, SimpleVotePool, VotePool, VotePoolType, VotedBlockKey,
-            },
+            vote_pool::{DuplicateBlockVotePool, SimpleVotePool, VotePool, VotePoolType},
         },
         conflicting_types,
         event::VotorEvent,
@@ -97,7 +95,7 @@ pub struct CertificatePool {
     /// - All slots from the parent have a Skip certificate
     pub parent_ready_tracker: ParentReadyTracker,
     /// Highest block that has a NotarizeFallback certificate, for use in producing our leader window
-    highest_notarized_fallback: Option<(Slot, Hash, Hash)>,
+    highest_notarized_fallback: Option<(Slot, Hash)>,
     /// Highest slot that has a Finalized variant certificate, for use in notifying RPC
     highest_finalized_slot: Option<Slot>,
     // Cached epoch_schedule
@@ -122,11 +120,7 @@ impl CertificatePool {
     ) -> Self {
         // To account for genesis and snapshots we allow default block id until
         // block id can be serialized  as part of the snapshot
-        let root_block = (
-            bank.slot(),
-            bank.block_id().unwrap_or_default(),
-            bank.hash(),
-        );
+        let root_block = (bank.slot(), bank.block_id().unwrap_or_default());
         let parent_ready_tracker = ParentReadyTracker::new(my_pubkey, root_block);
 
         let mut pool = Self {
@@ -179,7 +173,7 @@ impl CertificatePool {
         &mut self,
         slot: Slot,
         vote_type: VoteType,
-        voted_block_key: Option<VotedBlockKey>,
+        block_id: Option<Hash>,
         transaction: &VoteMessage,
         validator_vote_key: &Pubkey,
         validator_stake: Stake,
@@ -194,7 +188,7 @@ impl CertificatePool {
             }
             VotePoolType::DuplicateBlockVotePool(pool) => pool.add_vote(
                 validator_vote_key,
-                voted_block_key.expect("Duplicate block pool expects a voted block key"),
+                block_id.expect("Duplicate block pool expects a voted block key"),
                 transaction,
                 validator_stake,
             ),
@@ -213,7 +207,7 @@ impl CertificatePool {
     fn update_certificates(
         &mut self,
         vote: &Vote,
-        voted_block_key: Option<VotedBlockKey>,
+        block_id: Option<Hash>,
         events: &mut Vec<VotorEvent>,
         total_stake: Stake,
     ) -> Result<Vec<Arc<CertificateMessage>>, AddVoteError> {
@@ -232,7 +226,7 @@ impl CertificatePool {
                     Some(match self.vote_pools
                         .get(&(slot, *vote_type))? {
                             VotePoolType::SimpleVotePool(pool) => pool.total_stake(),
-                            VotePoolType::DuplicateBlockVotePool(pool) => pool.total_stake_by_voted_block_key(voted_block_key.as_ref().expect("Duplicate block pool for {vote_type:?} expects a voted block key for certificate {cert_id:?}")),
+                            VotePoolType::DuplicateBlockVotePool(pool) => pool.total_stake_by_block_id(block_id.as_ref().expect("Duplicate block pool for {vote_type:?} expects a voted block key for certificate {cert_id:?}")),
                         })
                 })
                 .sum::<Stake>();
@@ -244,7 +238,7 @@ impl CertificatePool {
                 if let Some(vote_pool) = self.vote_pools.get(&(slot, *vote_type)) {
                 match vote_pool {
                     VotePoolType::SimpleVotePool(pool) => pool.add_to_certificate(&mut vote_certificate),
-                    VotePoolType::DuplicateBlockVotePool(pool) => pool.add_to_certificate(voted_block_key.as_ref().expect("Duplicate block pool for {vote_type:?} expects a voted block key for certificate {cert_id:?}"), &mut vote_certificate),
+                    VotePoolType::DuplicateBlockVotePool(pool) => pool.add_to_certificate(block_id.as_ref().expect("Duplicate block pool for {vote_type:?} expects a voted block key for certificate {cert_id:?}"), &mut vote_certificate),
                 };
             }
             });
@@ -280,7 +274,7 @@ impl CertificatePool {
         slot: Slot,
         vote_type: VoteType,
         validator_vote_key: &Pubkey,
-        voted_block_key: &Option<VotedBlockKey>,
+        block_id: &Option<Hash>,
     ) -> Option<VoteType> {
         for conflicting_type in conflicting_types(vote_type) {
             if let Some(pool) = self.vote_pools.get(&(slot, *conflicting_type)) {
@@ -294,13 +288,10 @@ impl CertificatePool {
                     // TODO: This can be made much cleaner/safer if VoteType carried the bank hash, block id so we
                     // could check which exact VoteType(blockid, bankhash) was the source of the conflict.
                     VotePoolType::DuplicateBlockVotePool(pool) => {
-                        if let Some(voted_block_key) = &voted_block_key {
+                        if let Some(block_id) = &block_id {
                             // Reject votes for the same block with a conflicting type, i.e.
                             // a NotarizeFallback vote for the same block as a Notarize vote.
-                            pool.has_prev_validator_vote_for_block(
-                                validator_vote_key,
-                                voted_block_key,
-                            )
+                            pool.has_prev_validator_vote_for_block(validator_vote_key, block_id)
                         } else {
                             pool.has_prev_validator_vote(validator_vote_key)
                         }
@@ -322,21 +313,21 @@ impl CertificatePool {
     ) {
         self.completed_certificates.insert(cert_id, cert);
         match cert_id {
-            CertificateId::NotarizeFallback(slot, block_id, bank_hash) => {
+            CertificateId::NotarizeFallback(slot, block_id) => {
                 self.parent_ready_tracker
-                    .add_new_notar_fallback((slot, block_id, bank_hash), events);
+                    .add_new_notar_fallback((slot, block_id), events);
                 if self
                     .highest_notarized_fallback
-                    .map_or(true, |(s, _, _)| s < slot)
+                    .map_or(true, |(s, _)| s < slot)
                 {
-                    self.highest_notarized_fallback = Some((slot, block_id, bank_hash));
+                    self.highest_notarized_fallback = Some((slot, block_id));
                 }
             }
             CertificateId::Skip(slot) => self.parent_ready_tracker.add_new_skip(slot, events),
-            CertificateId::Notarize(slot, block_id, bank_hash) => {
-                events.push(VotorEvent::BlockNotarized((slot, block_id, bank_hash)));
+            CertificateId::Notarize(slot, block_id) => {
+                events.push(VotorEvent::BlockNotarized((slot, block_id)));
                 if self.is_finalized(slot) {
-                    events.push(VotorEvent::Finalized((slot, block_id, bank_hash)));
+                    events.push(VotorEvent::Finalized((slot, block_id)));
                 }
             }
             CertificateId::Finalize(slot) => {
@@ -347,8 +338,8 @@ impl CertificatePool {
                     self.highest_finalized_slot = Some(slot);
                 }
             }
-            CertificateId::FinalizeFast(slot, block_id, bank_hash) => {
-                events.push(VotorEvent::Finalized((slot, block_id, bank_hash)));
+            CertificateId::FinalizeFast(slot, block_id) => {
+                events.push(VotorEvent::Finalized((slot, block_id)));
                 if self.highest_finalized_slot.map_or(true, |s| s < slot) {
                     self.highest_finalized_slot = Some(slot);
                 }
@@ -441,20 +432,15 @@ impl CertificatePool {
             return Err(AddVoteError::SlotInFuture);
         }
 
-        let voted_block_key = vote.block_id().map(|block_id| {
+        let block_id = vote.block_id().map(|block_id| {
             if !matches!(vote, Vote::Notarize(_) | Vote::NotarizeFallback(_)) {
                 panic!("expected Notarize or NotarizeFallback vote");
             }
-            VotedBlockKey {
-                block_id: *block_id,
-                bank_hash: *vote
-                    .replayed_bank_hash()
-                    .expect("replayed_bank_hash should be Some for Notarize and NotarizeFallback"),
-            }
+            *block_id
         });
         let vote_type = VoteType::get_type(vote);
         if let Some(conflicting_type) =
-            self.has_conflicting_vote(slot, vote_type, &validator_vote_key, &voted_block_key)
+            self.has_conflicting_vote(slot, vote_type, &validator_vote_key, &block_id)
         {
             self.stats.conflicting_votes = self.stats.conflicting_votes.saturating_add(1);
             return Err(AddVoteError::ConflictingVoteType(
@@ -467,7 +453,7 @@ impl CertificatePool {
         if !self.update_vote_pool(
             slot,
             vote_type,
-            voted_block_key.clone(),
+            block_id,
             vote_message,
             &validator_vote_key,
             validator_stake,
@@ -483,14 +469,14 @@ impl CertificatePool {
             events.push(VotorEvent::SafeToSkip(slot));
             self.stats.event_safe_to_skip = self.stats.event_safe_to_skip.saturating_add(1);
         }
-        for (block_id, bank_hash) in self.safe_to_notar(my_vote_pubkey, slot) {
-            events.push(VotorEvent::SafeToNotar((slot, block_id, bank_hash)));
+        for block_id in self.safe_to_notar(my_vote_pubkey, slot) {
+            events.push(VotorEvent::SafeToNotar((slot, block_id)));
             self.stats.event_safe_to_notarize = self.stats.event_safe_to_notarize.saturating_add(1);
         }
 
         self.stats.incr_ingested_vote_type(vote_type);
 
-        self.update_certificates(vote, voted_block_key, events, total_stake)
+        self.update_certificates(vote, block_id, events, total_stake)
     }
 
     fn add_certificate(
@@ -519,7 +505,7 @@ impl CertificatePool {
     }
 
     /// The highest notarized fallback slot, for use as the parent slot in leader window
-    pub fn highest_notarized_fallback(&self) -> Option<(Slot, Hash, Hash)> {
+    pub fn highest_notarized_fallback(&self) -> Option<(Slot, Hash)> {
         self.highest_notarized_fallback
     }
 
@@ -528,9 +514,7 @@ impl CertificatePool {
         self.completed_certificates
             .iter()
             .find_map(|(cert_id, _)| match cert_id {
-                CertificateId::Notarize(s, block_id, bank_hash) if slot == *s => {
-                    Some((*s, *block_id, *bank_hash))
-                }
+                CertificateId::Notarize(s, block_id) if slot == *s => Some((*s, *block_id)),
                 _ => None,
             })
     }
@@ -541,8 +525,8 @@ impl CertificatePool {
         self.completed_certificates
             .iter()
             .filter_map(|(cert_id, _)| match cert_id {
-                CertificateId::Notarize(s, _, _) => Some(s),
-                CertificateId::NotarizeFallback(s, _, _) => Some(s),
+                CertificateId::Notarize(s, _) => Some(s),
+                CertificateId::NotarizeFallback(s, _) => Some(s),
                 _ => None,
             })
             .max()
@@ -568,7 +552,7 @@ impl CertificatePool {
             .iter()
             .filter_map(|(cert_id, _)| match cert_id {
                 CertificateId::Finalize(s) => Some(s),
-                CertificateId::FinalizeFast(s, _, _) => Some(s),
+                CertificateId::FinalizeFast(s, _) => Some(s),
                 _ => None,
             })
             .max()
@@ -580,7 +564,7 @@ impl CertificatePool {
         self.completed_certificates
             .iter()
             .filter_map(|(cert_id, _)| match cert_id {
-                CertificateId::FinalizeFast(s, bid, bh) => Some((*s, *bid, *bh)),
+                CertificateId::FinalizeFast(s, bid) => Some((*s, *bid)),
                 _ => None,
             })
             .max()
@@ -589,14 +573,14 @@ impl CertificatePool {
     /// Checks if any block in the slot `s` is finalized
     pub fn is_finalized(&self, slot: Slot) -> bool {
         self.completed_certificates.keys().any(|cert_id| {
-            matches!(cert_id, CertificateId::Finalize(s) | CertificateId::FinalizeFast(s, _, _) if *s == slot)
+            matches!(cert_id, CertificateId::Finalize(s) | CertificateId::FinalizeFast(s, _) if *s == slot)
         })
     }
 
-    /// Check if the specific block `(block_id, bank_hash)` in slot `s` is notarized
-    pub fn is_notarized(&self, slot: Slot, block_id: Hash, bank_hash: Hash) -> bool {
+    /// Check if the specific block `(block_id)` in slot `s` is notarized
+    pub fn is_notarized(&self, slot: Slot, block_id: Hash) -> bool {
         self.completed_certificates
-            .contains_key(&CertificateId::Notarize(slot, block_id, bank_hash))
+            .contains_key(&CertificateId::Notarize(slot, block_id))
     }
 
     /// Checks if the any block in slot `slot` has received a `NotarizeFallback` certificate, if so return
@@ -604,7 +588,7 @@ impl CertificatePool {
     #[cfg(test)]
     pub fn slot_has_notarized_fallback(&self, slot: Slot) -> bool {
         self.completed_certificates.iter().any(
-            |(cert_id, _)| matches!(cert_id, CertificateId::NotarizeFallback(s,_,_) if *s == slot),
+            |(cert_id, _)| matches!(cert_id, CertificateId::NotarizeFallback(s,_) if *s == slot),
         )
     }
 
@@ -614,13 +598,13 @@ impl CertificatePool {
             .contains_key(&CertificateId::Skip(slot))
     }
 
-    /// Checks if we have voted to skip `slot` or notarize some block `b' = (block_id', bank_hash')` in `slot`
-    /// Additionally check that for some different block `b = (block_id, bank_hash)` in `slot` either:
+    /// Checks if we have voted to skip `slot` or notarize some block `b' = block_id'` in `slot`
+    /// Additionally check that for some different block `b = block_id` in `slot` either:
     /// (i) At least 40% of stake has voted to notarize `b`
     /// (ii) At least 20% of stake voted to notarize `b` and at least 60% of stake voted to either notarize `b` or skip `slot`
     /// and we have not already cast a notarize fallback for this `b`
-    /// If all the above hold, return `Some(block_id, bank_hash)` for the `b`
-    pub fn safe_to_notar(&self, my_vote_pubkey: &Pubkey, slot: Slot) -> Vec<(Hash, Hash)> {
+    /// If all the above hold, return `Some(block_id)` for the `b`
+    pub fn safe_to_notar(&self, my_vote_pubkey: &Pubkey, slot: Slot) -> Vec<Hash> {
         let Some(epoch_stakes) = self
             .epoch_stakes_map
             .get(&self.epoch_schedule.get_epoch(slot))
@@ -646,21 +630,14 @@ impl CertificatePool {
         let notarize_pool = notarize_pool.unwrap_duplicate_block_vote_pool(
             "Notarize vote pool should be a DuplicateBlockVotePool",
         );
-        let my_prev_notarize_vote = notarize_pool.get_prev_vote(my_vote_pubkey);
+        let my_prev_voted_block_id = notarize_pool.get_prev_voted_block_id(my_vote_pubkey);
 
         let mut safe_to_notar = vec![];
-        for (
-            VotedBlockKey {
-                bank_hash,
-                block_id,
-            },
-            votes,
-        ) in notarize_pool.votes.iter()
-        {
+        for (block_id, votes) in notarize_pool.votes.iter() {
             if !voted_skip
-                && my_prev_notarize_vote
+                && my_prev_voted_block_id
                     .as_ref()
-                    .is_none_or(|prev_vote| prev_vote.block_id == *block_id)
+                    .is_none_or(|prev_block_id| *prev_block_id == *block_id)
             {
                 // We either have not voted for the slot or we voted notarize on this block.
                 // Not eligble for safe to notar
@@ -676,7 +653,7 @@ impl CertificatePool {
                     && notarized_ratio + skip_ratio >= SAFE_TO_NOTAR_MIN_NOTARIZE_AND_SKIP);
 
             if qualifies {
-                safe_to_notar.push((*block_id, *bank_hash));
+                safe_to_notar.push(*block_id);
             }
         }
         safe_to_notar
@@ -760,9 +737,9 @@ impl CertificatePool {
         self.completed_certificates
             .retain(|cert_id, _| match cert_id {
                 CertificateId::Finalize(s)
-                | CertificateId::FinalizeFast(s, _, _)
-                | CertificateId::Notarize(s, _, _)
-                | CertificateId::NotarizeFallback(s, _, _)
+                | CertificateId::FinalizeFast(s, _)
+                | CertificateId::Notarize(s, _)
+                | CertificateId::NotarizeFallback(s, _)
                 | CertificateId::Skip(s) => *s >= self.root,
             });
         self.vote_pools = self.vote_pools.split_off(&(new_root, VoteType::Finalize));
@@ -799,7 +776,7 @@ pub fn load_from_blockstore(
             .notarize_fallback_certificates
             .into_iter()
             .map(|((block_id, bank_hash), cert)| {
-                let cert_id = CertificateId::NotarizeFallback(slot, block_id, bank_hash);
+                let cert_id = CertificateId::NotarizeFallback(slot, block_id);
                 (cert_id, cert)
             })
             .chain(slot_cert.skip_certificate.map(|cert| {
@@ -830,7 +807,7 @@ mod tests {
                 ValidatorVoteKeypairs,
             },
         },
-        solana_sdk::{clock::Slot, hash::Hash, pubkey::Pubkey, signer::Signer},
+        solana_sdk::{clock::Slot, pubkey::Pubkey, signer::Signer},
         solana_vote::alpenglow::{
             bls_message::{VoteMessage, BLS_KEYPAIR_DERIVE_SEED},
             certificate::{Certificate, CertificateType},
@@ -1539,7 +1516,6 @@ mod tests {
         // Create bank 2
         let slot = 2;
         let block_id = Hash::new_unique();
-        let bank_hash = Hash::new_unique();
 
         // With no votes, this should fail.
         assert!(pool.safe_to_notar(&my_vote_key, slot).is_empty());
@@ -1555,7 +1531,7 @@ mod tests {
             .is_ok());
         // 40% notarized, should succeed
         for rank in 1..5 {
-            let vote = Vote::new_notarization_vote(2, block_id, bank_hash);
+            let vote = Vote::new_notarization_vote(2, block_id, Hash::default());
             assert!(pool
                 .add_message(
                     &Pubkey::new_unique(),
@@ -1564,19 +1540,15 @@ mod tests {
                 )
                 .is_ok());
         }
-        assert_eq!(
-            pool.safe_to_notar(&my_vote_key, slot),
-            vec![(block_id, bank_hash)]
-        );
+        assert_eq!(pool.safe_to_notar(&my_vote_key, slot), vec![block_id]);
 
         // Create bank 3
         let slot = 3;
         let block_id = Hash::new_unique();
-        let bank_hash = Hash::new_unique();
 
         // Add 20% notarize, but no vote from myself, should fail
         for rank in 1..3 {
-            let vote = Vote::new_notarization_vote(3, block_id, bank_hash);
+            let vote = Vote::new_notarization_vote(3, block_id, Hash::default());
             assert!(pool
                 .add_message(
                     &Pubkey::new_unique(),
@@ -1588,7 +1560,7 @@ mod tests {
         assert!(pool.safe_to_notar(&my_vote_key, slot).is_empty());
 
         // Add a notarize from myself for some other block, but still not enough notar or skip, should fail.
-        let vote = Vote::new_notarization_vote(3, Hash::new_unique(), Hash::new_unique());
+        let vote = Vote::new_notarization_vote(3, Hash::new_unique(), Hash::default());
         assert!(pool
             .add_message(
                 &Pubkey::new_unique(),
@@ -1609,16 +1581,12 @@ mod tests {
                 )
                 .is_ok());
         }
-        assert_eq!(
-            pool.safe_to_notar(&my_vote_key, slot),
-            vec![(block_id, bank_hash)]
-        );
+        assert_eq!(pool.safe_to_notar(&my_vote_key, slot), vec![block_id]);
 
         // Add 20% notarization for another block, we should notify on both
         let duplicate_block_id = Hash::new_unique();
-        let duplicate_bank_hash = Hash::new_unique();
         for rank in 7..9 {
-            let vote = Vote::new_notarization_vote(3, duplicate_block_id, duplicate_bank_hash);
+            let vote = Vote::new_notarization_vote(3, duplicate_block_id, Hash::default());
             assert!(pool
                 .add_message(
                     &Pubkey::new_unique(),
@@ -1633,13 +1601,10 @@ mod tests {
                 .into_iter()
                 .sorted()
                 .collect::<Vec<_>>(),
-            vec![
-                (block_id, bank_hash),
-                (duplicate_block_id, duplicate_bank_hash),
-            ]
-            .into_iter()
-            .sorted()
-            .collect::<Vec<_>>()
+            vec![block_id, duplicate_block_id,]
+                .into_iter()
+                .sorted()
+                .collect::<Vec<_>>()
         );
     }
 
@@ -1653,8 +1618,8 @@ mod tests {
 
         // Add a notarize from myself.
         let block_id = Hash::new_unique();
-        let block_hash = Hash::new_unique();
-        let vote = Vote::new_notarization_vote(2, block_id, block_hash);
+        let bank_hash = Hash::default();
+        let vote = Vote::new_notarization_vote(2, block_id, bank_hash);
         assert!(pool
             .add_message(
                 &Pubkey::new_unique(),
@@ -1677,7 +1642,7 @@ mod tests {
         }
         assert!(pool.safe_to_skip(&my_vote_key, slot));
         // Add 10% more notarize, still safe to skip any more because total voted increased.
-        let vote = Vote::new_notarization_vote(2, block_id, block_hash);
+        let vote = Vote::new_notarization_vote(2, block_id, bank_hash);
         assert!(pool
             .add_message(
                 &Pubkey::new_unique(),

--- a/votor/src/certificate_pool.rs
+++ b/votor/src/certificate_pool.rs
@@ -775,7 +775,7 @@ pub fn load_from_blockstore(
         let certs = slot_cert
             .notarize_fallback_certificates
             .into_iter()
-            .map(|((block_id, bank_hash), cert)| {
+            .map(|(block_id, cert)| {
                 let cert_id = CertificateId::NotarizeFallback(slot, block_id);
                 (cert_id, cert)
             })

--- a/votor/src/certificate_pool/parent_ready_tracker.rs
+++ b/votor/src/certificate_pool/parent_ready_tracker.rs
@@ -57,7 +57,7 @@ struct ParentReadyStatus {
 
 impl ParentReadyTracker {
     /// Creates a new tracker with the root bank as implicitely notarized fallback
-    pub fn new(my_pubkey: Pubkey, root_block @ (root_slot, _, _): Block) -> Self {
+    pub fn new(my_pubkey: Pubkey, root_block @ (root_slot, _): Block) -> Self {
         let mut slot_statuses = HashMap::new();
         slot_statuses.insert(
             root_slot,
@@ -86,7 +86,7 @@ impl ParentReadyTracker {
     /// Adds a new notar-fallback certificate
     pub fn add_new_notar_fallback(
         &mut self,
-        block @ (slot, _, _): Block,
+        block @ (slot, _): Block,
         events: &mut Vec<VotorEvent>,
     ) {
         if slot <= self.root {
@@ -257,7 +257,7 @@ mod tests {
         let mut events = vec![];
 
         for i in 1..2 * NUM_CONSECUTIVE_LEADER_SLOTS {
-            let block = (i, Hash::new_unique(), Hash::new_unique());
+            let block = (i, Hash::new_unique());
             tracker.add_new_notar_fallback(block, &mut events);
             assert_eq!(tracker.highest_parent_ready(), i + 1);
             assert!(tracker.parent_ready(i + 1, block));
@@ -269,7 +269,7 @@ mod tests {
         let genesis = Block::default();
         let mut tracker = ParentReadyTracker::new(Pubkey::default(), genesis);
         let mut events = vec![];
-        let block = (1, Hash::new_unique(), Hash::new_unique());
+        let block = (1, Hash::new_unique());
 
         tracker.add_new_notar_fallback(block, &mut events);
         tracker.add_new_skip(1, &mut events);
@@ -286,7 +286,7 @@ mod tests {
         let genesis = Block::default();
         let mut tracker = ParentReadyTracker::new(Pubkey::default(), genesis);
         let mut events = vec![];
-        let block = (1, Hash::new_unique(), Hash::new_unique());
+        let block = (1, Hash::new_unique());
 
         tracker.add_new_skip(3, &mut events);
         tracker.add_new_skip(2, &mut events);
@@ -303,7 +303,7 @@ mod tests {
     #[test]
     fn snapshot_wfsm() {
         let root_slot = 2147;
-        let root_block = (root_slot, Hash::new_unique(), Hash::new_unique());
+        let root_block = (root_slot, Hash::new_unique());
         let mut tracker = ParentReadyTracker::new(Pubkey::default(), root_block);
         let mut events = vec![];
 
@@ -321,7 +321,7 @@ mod tests {
         assert!(tracker.parent_ready(root_slot + 3, root_block));
         assert_eq!(tracker.highest_parent_ready(), root_slot + 3);
 
-        let block = (root_slot + 4, Hash::new_unique(), Hash::new_unique());
+        let block = (root_slot + 4, Hash::new_unique());
         tracker.add_new_notar_fallback(block, &mut events);
         assert!(tracker.parent_ready(root_slot + 3, root_block));
         assert!(tracker.parent_ready(root_slot + 5, block));
@@ -361,7 +361,7 @@ mod tests {
             BlockProductionParent::ParentNotReady
         );
 
-        tracker.add_new_notar_fallback((4, Hash::new_unique(), Hash::new_unique()), &mut events);
+        tracker.add_new_notar_fallback((4, Hash::new_unique()), &mut events);
         assert_eq!(tracker.highest_parent_ready(), 5);
         assert_eq!(
             tracker.block_production_parent(4),
@@ -372,7 +372,7 @@ mod tests {
             tracker.block_production_parent(8),
             BlockProductionParent::ParentNotReady
         );
-        tracker.add_new_notar_fallback((64, Hash::new_unique(), Hash::new_unique()), &mut events);
+        tracker.add_new_notar_fallback((64, Hash::new_unique()), &mut events);
         assert_eq!(tracker.highest_parent_ready(), 65);
         assert_eq!(
             tracker.block_production_parent(8),

--- a/votor/src/certificate_pool/vote_certificate.rs
+++ b/votor/src/certificate_pool/vote_certificate.rs
@@ -129,23 +129,23 @@ impl From<CertificateId> for Certificate {
                 block_id: None,
                 replayed_bank_hash: None,
             },
-            CertificateId::FinalizeFast(slot, block_id, replayed_bank_hash) => Certificate {
+            CertificateId::FinalizeFast(slot, block_id) => Certificate {
                 slot,
                 certificate_type: CertificateType::FinalizeFast,
                 block_id: Some(block_id),
-                replayed_bank_hash: Some(replayed_bank_hash),
+                replayed_bank_hash: None,
             },
-            CertificateId::Notarize(slot, block_id, replayed_bank_hash) => Certificate {
+            CertificateId::Notarize(slot, block_id) => Certificate {
                 certificate_type: CertificateType::Notarize,
                 slot,
                 block_id: Some(block_id),
-                replayed_bank_hash: Some(replayed_bank_hash),
+                replayed_bank_hash: None,
             },
-            CertificateId::NotarizeFallback(slot, block_id, replayed_bank_hash) => Certificate {
+            CertificateId::NotarizeFallback(slot, block_id) => Certificate {
                 certificate_type: CertificateType::NotarizeFallback,
                 slot,
                 block_id: Some(block_id),
-                replayed_bank_hash: Some(replayed_bank_hash),
+                replayed_bank_hash: None,
             },
             CertificateId::Skip(slot) => Certificate {
                 certificate_type: CertificateType::Skip,

--- a/votor/src/certificate_pool_service.rs
+++ b/votor/src/certificate_pool_service.rs
@@ -207,11 +207,7 @@ impl CertificatePoolService {
 
         // Kick off parent ready
         let root_bank = ctx.root_bank_cache.root_bank();
-        let root_block = (
-            root_bank.slot(),
-            root_bank.block_id().unwrap_or_default(),
-            root_bank.hash(),
-        );
+        let root_block = (root_bank.slot(), root_bank.block_id().unwrap_or_default());
         let mut highest_parent_ready = root_bank.slot();
         events.push(VotorEvent::ParentReady {
             slot: root_bank.slot().checked_add(1).unwrap(),

--- a/votor/src/event.rs
+++ b/votor/src/event.rs
@@ -67,16 +67,16 @@ impl VotorEvent {
     pub(crate) fn should_ignore(&self, root: Slot) -> bool {
         match self {
             VotorEvent::Block(completed_block) => completed_block.slot <= root,
-            VotorEvent::BlockNotarized((s, _, _)) => *s <= root,
+            VotorEvent::BlockNotarized((s, _)) => *s <= root,
             VotorEvent::ParentReady {
                 slot,
                 parent_block: _,
             } => *slot <= root,
             VotorEvent::Timeout(s) => *s <= root,
-            VotorEvent::SafeToNotar((s, _, _)) => *s <= root,
+            VotorEvent::SafeToNotar((s, _)) => *s <= root,
             VotorEvent::SafeToSkip(s) => *s <= root,
             VotorEvent::ProduceWindow(_) => false,
-            VotorEvent::Finalized((s, _, _)) => *s <= root,
+            VotorEvent::Finalized((s, _)) => *s <= root,
             VotorEvent::Standstill(_) => false,
             VotorEvent::SetIdentity => false,
         }

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -225,20 +225,18 @@ impl EventHandler {
 
             // We have observed the safe to notar condition, and can send a notar fallback vote
             // TODO: update cert pool to check parent block id for intra window slots
-            VotorEvent::SafeToNotar(block @ (slot, block_id, bank_hash)) => {
+            VotorEvent::SafeToNotar(block @ (slot, block_id)) => {
                 info!("{my_pubkey}: SafeToNotar {block:?}");
                 Self::try_skip_window(my_pubkey, slot, vctx, &mut votes);
                 if vctx.vote_history.its_over(slot)
-                    || vctx
-                        .vote_history
-                        .voted_notar_fallback(slot, block_id, bank_hash)
+                    || vctx.vote_history.voted_notar_fallback(slot, block_id)
                 {
                     return Ok(votes);
                 }
                 info!("{my_pubkey}: Voting notarize-fallback for {slot} {block_id}");
                 votes.push(voting_utils::insert_vote_and_create_bls_message(
                     my_pubkey,
-                    Vote::new_notarization_fallback_vote(slot, block_id, bank_hash),
+                    Vote::new_notarization_fallback_vote(slot, block_id, Hash::default()),
                     false,
                     vctx,
                 ));
@@ -344,7 +342,6 @@ impl EventHandler {
         let block = (
             slot,
             bank.block_id().expect("Block id must be set upstream"),
-            bank.hash(),
         );
         let parent_slot = bank.parent_slot();
         let parent_block_id = bank.parent_block_id().unwrap_or_else(|| {
@@ -355,7 +352,7 @@ impl EventHandler {
             trace!("Using default block id for {slot} parent {parent_slot}");
             Hash::default()
         });
-        let parent_block = (parent_slot, parent_block_id, bank.parent_hash());
+        let parent_block = (parent_slot, parent_block_id);
         (block, parent_block)
     }
 
@@ -368,8 +365,8 @@ impl EventHandler {
     /// If successful returns true
     fn try_notar(
         my_pubkey: &Pubkey,
-        (slot, block_id, bank_hash): Block,
-        parent_block @ (parent_slot, parent_block_id, parent_bank_hash): Block,
+        (slot, block_id): Block,
+        parent_block @ (parent_slot, parent_block_id): Block,
         pending_blocks: &mut PendingBlocks,
         voting_context: &mut VotingContext,
         votes: &mut Vec<Result<BLSOp, VoteError>>,
@@ -391,9 +388,7 @@ impl EventHandler {
                 // Non consecutive
                 return false;
             }
-            if voting_context.vote_history.voted_notar(parent_slot)
-                != Some((parent_block_id, parent_bank_hash))
-            {
+            if voting_context.vote_history.voted_notar(parent_slot) != Some(parent_block_id) {
                 // Voted skip, or notarize on a different version of the parent
                 return false;
             }
@@ -402,7 +397,7 @@ impl EventHandler {
         info!("{my_pubkey}: Voting notarize for {slot} {block_id}");
         votes.push(voting_utils::insert_vote_and_create_bls_message(
             my_pubkey,
-            Vote::new_notarization_vote(slot, block_id, bank_hash),
+            Vote::new_notarization_vote(slot, block_id, Hash::default()),
             false,
             voting_context,
         ));
@@ -451,7 +446,7 @@ impl EventHandler {
     /// If successful returns true
     fn try_final(
         my_pubkey: &Pubkey,
-        block @ (slot, block_id, _): Block,
+        block @ (slot, block_id): Block,
         voting_context: &mut VotingContext,
         votes: &mut Vec<Result<BLSOp, VoteError>>,
     ) -> bool {
@@ -465,7 +460,7 @@ impl EventHandler {
         if voting_context
             .vote_history
             .voted_notar(slot)
-            .is_none_or(|(bid, _)| bid != block_id)
+            .is_none_or(|bid| bid != block_id)
         {
             return false;
         }
@@ -547,14 +542,13 @@ impl EventHandler {
         let old_root = bank_forks_r.root();
         let Some(new_root) = finalized_blocks
             .iter()
-            .filter_map(|&(slot, block_id, bank_hash)| {
+            .filter_map(|&(slot, block_id)| {
                 let bank = bank_forks_r.get(slot)?;
                 (slot > old_root
                     && vctx.vote_history.voted(slot)
                     && bank.is_frozen()
-                    && bank.block_id().is_some_and(|bid| bid == block_id)
-                    && bank.hash() == bank_hash)
-                    .then_some(slot)
+                    && bank.block_id().is_some_and(|bid| bid == block_id))
+                .then_some(slot)
             })
             .max()
         else {

--- a/votor/src/root_utils.rs
+++ b/votor/src/root_utils.rs
@@ -45,7 +45,7 @@ pub(crate) fn set_root(
     info!("{my_pubkey}: setting root {new_root}");
     vctx.vote_history.set_root(new_root);
     *pending_blocks = pending_blocks.split_off(&new_root);
-    *finalized_blocks = finalized_blocks.split_off(&(new_root, Hash::default(), Hash::default()));
+    *finalized_blocks = finalized_blocks.split_off(&(new_root, Hash::default()));
 
     check_and_handle_new_root(
         new_root,


### PR DESCRIPTION
#### Problem
Follow up to https://github.com/anza-xyz/alpenglow/pull/264

Bank hashes no longer necessary to identify blocks, block ids are sufficient

#### Summary of Changes
Remove bank hashes everywhere except in places that touch the separate alpenglow vote crate, those need to be updated separately

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
