### PR TITLE
improve ci

### DIFF
--- a/.buildkite/alpenglow/pipeline.sh
+++ b/.buildkite/alpenglow/pipeline.sh
@@ -23,7 +23,7 @@ steps:
         timeout_in_minutes: 40
         agents:
           queue: "default"
-        parallelism: 2
+        parallelism: 3
         retry:
           automatic:
             - limit: 3

--- a/ci/stable/run-partition.sh
+++ b/ci/stable/run-partition.sh
@@ -34,6 +34,7 @@ ARGS=(
   --partition hash:"$((INDEX + 1))/$LIMIT"
   --verbose
   --exclude solana-local-cluster
+  --exclude solana-cargo-build-sbf
   --no-tests=warn
 )
 


### PR DESCRIPTION
#### Problem

our ci is very close to the timeout.

#### Summary of Changes

- split it into 3
- exclude solana-cargo-build-sbf since we won't touch the logic in Alpenglow. (any errors will still be caught when submitting a PR back to Agave)
