### PR TITLE
Refactor safe_to_notar and safe_to_skip into SlotStakeCounters.

### DIFF
--- a/votor/src/certificate_pool.rs
+++ b/votor/src/certificate_pool.rs
@@ -487,10 +487,12 @@ impl CertificatePool {
                 return Ok(vec![]);
             }
             Some(entry_stake) => {
-                let fallback_vote_counters = self.slot_stake_counters_map.entry(slot).or_default();
+                let fallback_vote_counters = self
+                    .slot_stake_counters_map
+                    .entry(slot)
+                    .or_insert_with(|| SlotStakeCounters::new(total_stake));
                 fallback_vote_counters.add_vote(
                     vote,
-                    total_stake,
                     entry_stake,
                     my_vote_pubkey == &validator_vote_key,
                     events,

--- a/votor/src/certificate_pool/slot_stake_counters.rs
+++ b/votor/src/certificate_pool/slot_stake_counters.rs
@@ -1,0 +1,301 @@
+use {
+    crate::{
+        certificate_pool::stats::CertificatePoolStats, event::VotorEvent, Stake,
+        SAFE_TO_NOTAR_MIN_NOTARIZE_AND_SKIP, SAFE_TO_NOTAR_MIN_NOTARIZE_FOR_NOTARIZE_OR_SKIP,
+        SAFE_TO_NOTAR_MIN_NOTARIZE_ONLY, SAFE_TO_SKIP_THRESHOLD,
+    },
+    solana_sdk::hash::Hash,
+    solana_votor_messages::vote::Vote,
+    std::collections::BTreeMap,
+};
+
+#[derive(Debug, Default)]
+pub(crate) struct SlotStakeCounters {
+    my_first_vote: Option<Vote>,
+    total_stake: Stake,
+    skip_total: Stake,
+    notarize_total: Stake,
+    notarize_entry_total: BTreeMap<Hash, Stake>,
+    top_notarized_stake: Stake,
+    safe_to_notar_sent: Vec<Hash>,
+    safe_to_skip_sent: bool,
+}
+
+impl SlotStakeCounters {
+    pub fn add_vote(
+        &mut self,
+        vote: &Vote,
+        total_stake: Stake,
+        entry_stake: Stake,
+        is_my_own_vote: bool,
+        events: &mut Vec<VotorEvent>,
+        stats: &mut CertificatePoolStats,
+    ) {
+        match vote {
+            Vote::Skip(_) => self.skip_total = entry_stake,
+            Vote::Notarize(vote) => {
+                self.notarize_entry_total
+                    .insert(*vote.block_id(), entry_stake);
+                self.notarize_total = self.notarize_entry_total.values().sum();
+                self.top_notarized_stake = self.top_notarized_stake.max(entry_stake);
+            }
+            _ => return, // Not interested in other vote types
+        }
+        if self.my_first_vote.is_none() && is_my_own_vote {
+            self.my_first_vote = Some(*vote);
+            self.total_stake = total_stake;
+        }
+        if self.my_first_vote.is_some() {
+            let slot = vote.slot();
+            // Check safe to notar
+            for (block_id, stake) in &self.notarize_entry_total {
+                if !self.safe_to_notar_sent.contains(block_id)
+                    && self.is_safe_to_notar(block_id, stake)
+                {
+                    events.push(VotorEvent::SafeToNotar((slot, *block_id)));
+                    stats.event_safe_to_notarize = stats.event_safe_to_notarize.saturating_add(1);
+                    self.safe_to_notar_sent.push(*block_id);
+                }
+            }
+            // Check safe to skip
+            if !self.safe_to_skip_sent && self.is_safe_to_skip() {
+                events.push(VotorEvent::SafeToSkip(slot));
+                self.safe_to_skip_sent = true;
+                stats.event_safe_to_skip = stats.event_safe_to_skip.saturating_add(1);
+            }
+        }
+    }
+
+    fn is_safe_to_notar(&self, block_id: &Hash, stake: &Stake) -> bool {
+        // White paper v1.1 page 22: The event is only issued if the node voted in slot s already,
+        // but not to notarize b. Moreover:
+        // notar(b) >= 40% or (skip(s) + notar(b) >= 60% and notar(b) >= 20%)
+        if let Some(Vote::Notarize(my_vote)) = self.my_first_vote.as_ref() {
+            if my_vote.block_id() == block_id {
+                return false; // I voted for the same block, no need to send NotarizeFallback
+            }
+        }
+        let skip_ratio = self.skip_total as f64 / self.total_stake as f64;
+        let notarized_ratio = *stake as f64 / self.total_stake as f64;
+        // Check if the block fits condition (i) 40% of stake holders voted notarize
+        notarized_ratio >= SAFE_TO_NOTAR_MIN_NOTARIZE_ONLY
+            // Check if the block fits condition (ii) 20% notarized, and 60% notarized or skip
+            || (notarized_ratio >= SAFE_TO_NOTAR_MIN_NOTARIZE_FOR_NOTARIZE_OR_SKIP
+                && notarized_ratio + skip_ratio >= SAFE_TO_NOTAR_MIN_NOTARIZE_AND_SKIP)
+    }
+
+    fn is_safe_to_skip(&self) -> bool {
+        // White paper v1.1 page 22: The event is only issued if the node voted in slot s already,
+        // but not to skip s. Moreover:
+        // skip(s) + Sum of all notarize - (max in notarize(b)) >= 40%
+        if let Some(Vote::Notarize(_)) = self.my_first_vote.as_ref() {
+            error!(
+                "{} {} {}",
+                self.skip_total, self.notarize_total, self.top_notarized_stake
+            );
+            self.skip_total
+                .saturating_add(self.notarize_total.saturating_sub(self.top_notarized_stake))
+                as f64
+                / self.total_stake as f64
+                >= SAFE_TO_SKIP_THRESHOLD
+        } else {
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, solana_votor_messages::vote::Vote};
+
+    #[test]
+    fn test_safe_to_notar() {
+        let mut counters = SlotStakeCounters::default();
+
+        let mut events = vec![];
+        let mut stats = CertificatePoolStats::default();
+        let slot = 2;
+        // I voted for skip
+        counters.add_vote(
+            &Vote::new_skip_vote(slot),
+            100,
+            10,
+            true,
+            &mut events,
+            &mut stats,
+        );
+        assert!(events.is_empty());
+        assert_eq!(stats.event_safe_to_notarize, 0);
+
+        // 40% of stake holders voted notarize
+        counters.add_vote(
+            &Vote::new_notarization_vote(slot, Hash::default()),
+            100,
+            40,
+            false,
+            &mut events,
+            &mut stats,
+        );
+        assert_eq!(events.len(), 1);
+        assert!(
+            matches!(events[0], VotorEvent::SafeToNotar((s, block_id)) if s == slot && block_id == Hash::default())
+        );
+        assert_eq!(stats.event_safe_to_notarize, 1);
+        events.clear();
+
+        // Adding more notarizations does not trigger more events
+        counters.add_vote(
+            &Vote::new_notarization_vote(slot, Hash::default()),
+            100,
+            20,
+            false,
+            &mut events,
+            &mut stats,
+        );
+        assert!(events.is_empty());
+        assert_eq!(stats.event_safe_to_notarize, 1);
+
+        // Reset counters
+        counters = SlotStakeCounters::default();
+        events.clear();
+        stats = CertificatePoolStats::default();
+
+        // I voted for notarize b
+        let hash_1 = Hash::new_unique();
+        counters.add_vote(
+            &Vote::new_notarization_vote(slot, hash_1),
+            100,
+            1,
+            true,
+            &mut events,
+            &mut stats,
+        );
+        assert!(events.is_empty());
+        assert_eq!(stats.event_safe_to_notarize, 0);
+
+        // 25% of stake holders voted notarize b'
+        let hash_2 = Hash::new_unique();
+        counters.add_vote(
+            &Vote::new_notarization_vote(slot, hash_2),
+            100,
+            25,
+            false,
+            &mut events,
+            &mut stats,
+        );
+        assert!(events.is_empty());
+        assert_eq!(stats.event_safe_to_notarize, 0);
+
+        // 35% more of stake holders voted skip
+        counters.add_vote(
+            &Vote::new_skip_vote(slot),
+            100,
+            35,
+            false,
+            &mut events,
+            &mut stats,
+        );
+        assert_eq!(events.len(), 1);
+        assert!(
+            matches!(events[0], VotorEvent::SafeToNotar((s, block_id)) if s == slot && block_id == hash_2)
+        );
+        assert_eq!(stats.event_safe_to_notarize, 1);
+    }
+
+    #[test]
+    fn test_safe_to_skip() {
+        let mut counters = SlotStakeCounters::default();
+
+        let mut events = vec![];
+        let mut stats = CertificatePoolStats::default();
+        let slot = 2;
+        // I voted for notarize b
+        counters.add_vote(
+            &Vote::new_notarization_vote(slot, Hash::default()),
+            100,
+            10,
+            true,
+            &mut events,
+            &mut stats,
+        );
+        assert!(events.is_empty());
+        assert_eq!(stats.event_safe_to_skip, 0);
+
+        // 40% of stake holders voted skip
+        counters.add_vote(
+            &Vote::new_skip_vote(slot),
+            100,
+            40,
+            false,
+            &mut events,
+            &mut stats,
+        );
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], VotorEvent::SafeToSkip(s) if s == slot));
+        assert_eq!(stats.event_safe_to_skip, 1);
+        events.clear();
+
+        // Adding more skips does not trigger more events
+        counters.add_vote(
+            &Vote::new_skip_vote(slot),
+            100,
+            20,
+            false,
+            &mut events,
+            &mut stats,
+        );
+        assert!(events.is_empty());
+        assert_eq!(stats.event_safe_to_skip, 1);
+
+        // Reset counters
+        counters = SlotStakeCounters::default();
+        events.clear();
+        stats = CertificatePoolStats::default();
+
+        // I voted for notarize b, 10% of stake holders voted with me
+        let hash_1 = Hash::new_unique();
+        counters.add_vote(
+            &Vote::new_notarization_vote(slot, hash_1),
+            100,
+            10,
+            true,
+            &mut events,
+            &mut stats,
+        );
+        // 20% of stake holders voted a different notarization b'
+        let hash_2 = Hash::new_unique();
+        counters.add_vote(
+            &Vote::new_notarization_vote(slot, hash_2),
+            100,
+            20,
+            false,
+            &mut events,
+            &mut stats,
+        );
+        // 30% of stake holders voted skip
+        counters.add_vote(
+            &Vote::new_skip_vote(slot),
+            100,
+            30,
+            false,
+            &mut events,
+            &mut stats,
+        );
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], VotorEvent::SafeToSkip(s) if s == slot));
+        assert_eq!(stats.event_safe_to_skip, 1);
+        events.clear();
+
+        // Adding more notarization on b does not trigger more events
+        counters.add_vote(
+            &Vote::new_notarization_vote(slot, hash_1),
+            100,
+            10,
+            false,
+            &mut events,
+            &mut stats,
+        );
+        assert!(events.is_empty());
+        assert_eq!(stats.event_safe_to_skip, 1);
+    }
+}


### PR DESCRIPTION
We used to check safe_to_notar and safe_to_skip on every vote, there are two problems:
1. Too many unnecessary checks, we don't need to check them until at least I voted or we got new Notarize/Skip votes
2. We repeatedly send out the same event upstream, these events should only be sent once

Added SlotStakeCounters to update internal state on only corresponding votes.
