### PR TITLE
refactor: use similar terminology as the paper for timeout values

### DIFF
--- a/votor/src/certificate_pool_service.rs
+++ b/votor/src/certificate_pool_service.rs
@@ -15,7 +15,7 @@ use {
         event::{LeaderWindowInfo, VotorEvent, VotorEventSender},
         voting_utils::BLSOp,
         votor::Votor,
-        Certificate, STANDSTILL_TIMEOUT,
+        Certificate, DELTA_STANDSTILL,
     },
     crossbeam_channel::{select, Sender, TrySendError},
     solana_ledger::{
@@ -224,7 +224,7 @@ impl CertificatePoolService {
                 &mut stats,
             );
 
-            if standstill_timer.elapsed() > STANDSTILL_TIMEOUT {
+            if standstill_timer.elapsed() > DELTA_STANDSTILL {
                 events.push(VotorEvent::Standstill(cert_pool.highest_finalized_slot()));
                 stats.standstill = true;
                 standstill_timer = Instant::now();

--- a/votor/src/lib.rs
+++ b/votor/src/lib.rs
@@ -105,28 +105,26 @@ pub const SAFE_TO_NOTAR_MIN_NOTARIZE_AND_SKIP: f64 = 0.6;
 
 pub const SAFE_TO_SKIP_THRESHOLD: f64 = 0.4;
 
-pub const STANDSTILL_TIMEOUT: Duration = Duration::from_secs(10);
+/// Time bound assumed on network transmission delays during periods of synchrony.
+const DELTA: Duration = Duration::from_millis(250);
 
-/// Alpenglow block constants
-/// The amount of time a leader has to build their block
-pub const BLOCKTIME: Duration = Duration::from_millis(400);
+/// Time the leader has for producing and sending the block.
+const DELTA_BLOCK: Duration = Duration::from_millis(400);
 
-/// The maximum message delay
-pub const DELTA: Duration = Duration::from_millis(200);
+/// Base timeout for when leader's first slice should arrive if they sent it immediately.
+const DELTA_TIMEOUT: Duration = DELTA.checked_mul(3).unwrap();
 
-/// The maximum delay a node can observe between entering the loop iteration
-/// for a window and receiving any shred of the first block of the leader.
-/// As a conservative global constant we set this to 3 * DELTA
-pub const DELTA_TIMEOUT: Duration = DELTA.saturating_mul(3);
+/// Timeout for standstill detection mechanism.
+const DELTA_STANDSTILL: Duration = Duration::from_millis(10_000);
 
-/// The timeout in ms for the leader block index within the leader window
+/// Returns the Duration for when the `SkipTimer` should be set for for the given slot in the leader window.
 #[inline]
 pub fn skip_timeout(leader_block_index: usize) -> Duration {
     DELTA_TIMEOUT
         .saturating_add(
-            BLOCKTIME
+            DELTA_BLOCK
                 .saturating_mul(leader_block_index as u32)
-                .saturating_add(BLOCKTIME),
+                .saturating_add(DELTA_TIMEOUT),
         )
         .saturating_add(DELTA)
 }
@@ -136,5 +134,5 @@ pub fn skip_timeout(leader_block_index: usize) -> Duration {
 #[inline]
 pub fn block_timeout(leader_block_index: usize) -> Duration {
     // TODO: based on testing, perhaps adjust this
-    BLOCKTIME.saturating_mul((leader_block_index as u32).saturating_add(1))
+    DELTA_BLOCK.saturating_mul((leader_block_index as u32).saturating_add(1))
 }

--- a/votor/src/skip_timer.rs
+++ b/votor/src/skip_timer.rs
@@ -4,7 +4,7 @@
 use {
     crate::{
         event::{VotorEvent, VotorEventSender},
-        skip_timeout, BLOCKTIME,
+        skip_timeout, DELTA_BLOCK,
     },
     solana_ledger::leader_schedule_utils::{
         last_of_consecutive_leader_slots, remaining_slots_in_window,
@@ -95,7 +95,7 @@ impl SkipTimerManager {
         let timer = SkipTimer {
             id,
             next_fire,
-            interval: BLOCKTIME,
+            interval: DELTA_BLOCK,
             remaining,
             start_slot,
         };


### PR DESCRIPTION
Updates some timeout names to be closer to what is used in the alpenglow paper.

Part of #243.