### PR TITLE
Put discarded packets in stats separately.

### DIFF
--- a/core/src/sigverifier/bls_sigverifier.rs
+++ b/core/src/sigverifier/bls_sigverifier.rs
@@ -414,8 +414,14 @@ mod tests {
         let packet_batches = vec![PinnedPacketBatch::new(packets).into()];
         assert!(verifier.send_packets(packet_batches).is_ok());
         assert_eq!(verifier.stats.sent, 0);
+        assert_eq!(verifier.stats.sent_failed, 0);
+        assert_eq!(verifier.stats.verified_votes_sent, 0);
+        assert_eq!(verifier.stats.verified_votes_sent_failed, 0);
         assert_eq!(verifier.stats.received, 1);
         assert_eq!(verifier.stats.received_discarded, 1);
+        assert_eq!(verifier.stats.received_malformed, 0);
+        assert_eq!(verifier.stats.received_no_epoch_stakes, 0);
+        assert_eq!(verifier.stats.received_votes, 0);
         assert!(receiver.is_empty());
     }
 }

--- a/core/src/sigverifier/bls_sigverifier.rs
+++ b/core/src/sigverifier/bls_sigverifier.rs
@@ -54,6 +54,11 @@ impl SigVerifier for BLSSigVerifier {
         for packet in packet_batches.iter().flatten() {
             stats_updater.received += 1;
 
+            if packet.meta().discard() {
+                stats_updater.received_discarded += 1;
+                continue;
+            }
+
             let message = match packet.deserialize_slice(..) {
                 Ok(msg) => msg,
                 Err(e) => {
@@ -388,5 +393,29 @@ mod tests {
             rank: 0,
         })];
         test_bls_message_transmission(&mut verifier, None, &messages, false);
+    }
+
+    #[test]
+    fn test_blssigverifier_send_discarded_packets() {
+        let (sender, receiver) = crossbeam_channel::unbounded();
+        let (verified_vote_sender, _) = crossbeam_channel::unbounded();
+        let (_, mut verifier) = create_keypairs_and_bls_sig_verifier(verified_vote_sender, sender);
+        let message = BLSMessage::Vote(VoteMessage {
+            vote: Vote::new_finalization_vote(5),
+            signature: Signature::default(),
+            rank: 0,
+        });
+        let mut packet = Packet::default();
+        packet
+            .populate_packet(None, &message)
+            .expect("Failed to populate packet");
+        packet.meta_mut().set_discard(true);
+        let packets = vec![packet];
+        let packet_batches = vec![PinnedPacketBatch::new(packets).into()];
+        assert!(verifier.send_packets(packet_batches).is_ok());
+        assert_eq!(verifier.stats.sent, 0);
+        assert_eq!(verifier.stats.received, 1);
+        assert_eq!(verifier.stats.received_discarded, 1);
+        assert!(receiver.is_empty());
     }
 }

--- a/core/src/sigverifier/bls_sigverifier/stats.rs
+++ b/core/src/sigverifier/bls_sigverifier/stats.rs
@@ -9,6 +9,7 @@ pub(super) struct StatsUpdater {
     pub(super) verified_votes_sent: u64,
     pub(super) verified_votes_sent_failed: u64,
     pub(super) received: u64,
+    pub(super) received_discarded: u64,
     pub(super) received_malformed: u64,
     pub(super) received_no_epoch_stakes: u64,
     pub(super) received_votes: u64,
@@ -26,6 +27,7 @@ pub(super) struct BLSSigVerifierStats {
     pub(super) verified_votes_sent: u64,
     pub(super) verified_votes_sent_failed: u64,
     pub(super) received: u64,
+    pub(super) received_discarded: u64,
     pub(super) received_malformed: u64,
     pub(super) received_no_epoch_stakes: u64,
     pub(super) received_votes: u64,
@@ -40,6 +42,7 @@ impl BLSSigVerifierStats {
             verified_votes_sent: 0,
             verified_votes_sent_failed: 0,
             received: 0,
+            received_discarded: 0,
             received_malformed: 0,
             received_no_epoch_stakes: 0,
             received_votes: 0,
@@ -65,6 +68,7 @@ impl BLSSigVerifierStats {
                 i64
             ),
             ("received", self.received as i64, i64),
+            ("received_discarded", self.received_discarded as i64, i64),
             ("received_votes", self.received_votes as i64, i64),
             (
                 "received_no_epoch_stakes",
@@ -84,6 +88,7 @@ impl BLSSigVerifierStats {
             verified_votes_sent,
             verified_votes_sent_failed,
             received,
+            received_discarded,
             received_malformed,
             received_no_epoch_stakes,
             received_votes,
@@ -94,6 +99,7 @@ impl BLSSigVerifierStats {
         self.verified_votes_sent += verified_votes_sent;
         self.verified_votes_sent_failed += verified_votes_sent_failed;
         self.received += received;
+        self.received_discarded += received_discarded;
         self.received_malformed += received_malformed;
         self.received_no_epoch_stakes += received_no_epoch_stakes;
         self.received_votes += received_votes;

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -10066,6 +10066,7 @@ dependencies = [
  "etcd-client",
  "itertools 0.12.1",
  "log",
+ "parking_lot 0.12.2",
  "qualifier_attr",
  "rayon",
  "serde",

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -9149,6 +9149,7 @@ dependencies = [
  "etcd-client",
  "itertools 0.12.1",
  "log",
+ "parking_lot 0.12.3",
  "qualifier_attr",
  "rayon",
  "serde",


### PR DESCRIPTION
We could have many discarded packets, for example, when the same cert is being forwarded by several sources, deduper will mark the late ones discarded.

They will currently fail with this error message:
Failed to deserialize BLS message: the size limit has been reached

Then they will be counted as malformed packets, this is confusing, we should count discarded packets separately in stats.