### PR TITLE
blockstore: add alternative shred and block versions columns

### DIFF
--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -262,6 +262,10 @@ impl Blockstore {
                 .delete_range_in_batch(write_batch, from_slot, to_slot)
                 .is_ok()
             & self
+                .block_versions_cf
+                .delete_range_in_batch(write_batch, from_slot, to_slot)
+                .is_ok()
+            & self
                 .dead_slots_cf
                 .delete_range_in_batch(write_batch, from_slot, to_slot)
                 .is_ok()
@@ -307,6 +311,26 @@ impl Blockstore {
                 .is_ok()
             & self
                 .slot_certificates_cf
+                .delete_range_in_batch(write_batch, from_slot, to_slot)
+                .is_ok()
+            & self
+                .alt_meta_cf
+                .delete_range_in_batch(write_batch, from_slot, to_slot)
+                .is_ok()
+            & self
+                .alt_erasure_meta_cf
+                .delete_range_in_batch(write_batch, from_slot, to_slot)
+                .is_ok()
+            & self
+                .alt_index_cf
+                .delete_range_in_batch(write_batch, from_slot, to_slot)
+                .is_ok()
+            & self
+                .alt_data_shred_cf
+                .delete_range_in_batch(write_batch, from_slot, to_slot)
+                .is_ok()
+            & self
+                .alt_merkle_root_meta_cf
                 .delete_range_in_batch(write_batch, from_slot, to_slot)
                 .is_ok();
 
@@ -346,6 +370,10 @@ impl Blockstore {
                 .delete_file_in_range(from_slot, to_slot)
                 .is_ok()
             & self
+                .block_versions_cf
+                .delete_file_in_range(from_slot, to_slot)
+                .is_ok()
+            & self
                 .dead_slots_cf
                 .delete_file_in_range(from_slot, to_slot)
                 .is_ok()
@@ -391,6 +419,26 @@ impl Blockstore {
                 .is_ok()
             & self
                 .slot_certificates_cf
+                .delete_file_in_range(from_slot, to_slot)
+                .is_ok()
+            & self
+                .alt_meta_cf
+                .delete_file_in_range(from_slot, to_slot)
+                .is_ok()
+            & self
+                .alt_erasure_meta_cf
+                .delete_file_in_range(from_slot, to_slot)
+                .is_ok()
+            & self
+                .alt_index_cf
+                .delete_file_in_range(from_slot, to_slot)
+                .is_ok()
+            & self
+                .alt_data_shred_cf
+                .delete_file_in_range(from_slot, to_slot)
+                .is_ok()
+            & self
+                .alt_merkle_root_meta_cf
                 .delete_file_in_range(from_slot, to_slot)
                 .is_ok()
     }

--- a/ledger/src/blockstore/column.rs
+++ b/ledger/src/blockstore/column.rs
@@ -4,9 +4,9 @@ use {
         blockstore::error::Result,
         blockstore_meta::{self},
     },
-    bincode::Options as BincodeOptions,
     serde::{de::DeserializeOwned, Serialize},
     solana_clock::{Slot, UnixTimestamp},
+    solana_hash::{Hash, HASH_BYTES},
     solana_pubkey::{Pubkey, PUBKEY_BYTES},
     solana_signature::{Signature, SIGNATURE_BYTES},
     solana_storage_proto::convert::generated,
@@ -37,6 +37,16 @@ pub mod columns {
     /// * index type: `u64` (see [`SlotColumn`])
     /// * value type: [`blockstore_meta::SlotMeta`]
     pub struct SlotMeta;
+
+    #[derive(Debug)]
+    /// The alternate slot metadata column.
+    ///
+    /// Similar to [`SlotMeta`], however this column is only populated for alternate
+    /// versions fetched via block_id based repair.
+    ///
+    /// * index type: `(slot: u64, block_id: Hash)`
+    /// * value type: [`blockstore_meta::SlotMeta`]
+    pub struct AlternateSlotMeta;
 
     #[derive(Debug)]
     /// The orphans column.
@@ -88,6 +98,16 @@ pub mod columns {
     pub struct ErasureMeta;
 
     #[derive(Debug)]
+    /// The alternate erasure meta column.
+    ///
+    /// Similar to [`ErasureMeta`], however this column is only populated for alternate
+    /// versions fetched via block_id based repair.
+    ///
+    /// * index type: `(slot: u64, fec_set_index: u64, block_id: Hash)`
+    /// * value type: [`blockstore_meta::ErasureMeta`]
+    pub struct AlternateErasureMeta;
+
+    #[derive(Debug)]
     /// The bank hash column.
     ///
     /// This column family persists the bank hash of a given slot.  Note that
@@ -120,6 +140,16 @@ pub mod columns {
     pub struct Index;
 
     #[derive(Debug)]
+    /// The alternate index column.
+    ///
+    /// Similar to [`Index`], however this column is only populated for alternate
+    /// versions fetched via block_id based repair.
+    ///
+    /// * index type: `(slot: u64, block_id: Hash)`
+    /// * value type: [`blockstore_meta::Index`]
+    pub struct AlternateIndex;
+
+    #[derive(Debug)]
     /// The shred data column
     ///
     /// * index type: `(u64, u64)`
@@ -132,6 +162,26 @@ pub mod columns {
     /// * index type: `(u64, u64)`
     /// * value type: [`Vec<u8>`]
     pub struct ShredCode;
+
+    #[derive(Debug)]
+    /// The alternate shred data column
+    ///
+    /// Similar to [`ShredData`], however this column is only populated for alternate
+    /// versions fetched via block_id based repair.
+    ///
+    /// * index type: `(slot: u64, shred_index: u64, block_id: Hash)`
+    /// * value type: [`Vec<u8>`]
+    pub struct AlternateShredData;
+
+    #[derive(Debug)]
+    /// The block verisons
+    ///
+    /// This column stores information about what versions of blocks in `slot` we
+    /// have available, for use in serving repair or switching replayed banks
+    ///
+    /// * index type: `u64` (see [`SlotColumn`])
+    /// * value type: [`blockstore_meta::BlockVersions`]
+    pub struct BlockVersions;
 
     #[derive(Debug)]
     /// The transaction status column
@@ -206,8 +256,18 @@ pub mod columns {
     /// Its index type is (Slot, fec_set_index).
     ///
     /// * index type: `crate::shred::ErasureSetId` `(Slot, fec_set_index: u32)`
-    /// * value type: [`blockstore_meta::MerkleRootMeta`]`
+    /// * value type: [`blockstore_meta::MerkleRootMeta`]
     pub struct MerkleRootMeta;
+
+    #[derive(Debug)]
+    /// The alternate merkle root meta column
+    ///
+    /// Similar to [`MerkleRootMeta`], however this column is only populated for alternate
+    /// versions fetched via block_id based repair.
+    ///
+    /// * index type: `(slot: u64, fec_set_index: u32, block_id: Hash)`
+    /// * value type: [`blockstore_meta::MerkleRootMeta`]
+    pub struct AlternateMerkleRootMeta;
 
     #[derive(Debug)]
     /// The vote certificate column
@@ -669,6 +729,47 @@ impl ColumnName for columns::ShredData {
     const NAME: &'static str = "data_shred";
 }
 
+impl Column for columns::AlternateShredData {
+    type Index = (Slot, /*shred index:*/ u64, /* block id*/ Hash);
+    type Key = [u8; std::mem::size_of::<Slot>() + std::mem::size_of::<u64>() + HASH_BYTES];
+
+    #[inline]
+    fn key((slot, index, hash): &Self::Index) -> Self::Key {
+        convert_column_index_to_key_bytes!(Key,
+            ..8 => &slot.to_be_bytes(),
+            8..16 => &index.to_be_bytes(),
+            16.. => &hash.to_bytes(),
+        )
+    }
+
+    fn index(key: &[u8]) -> Self::Index {
+        convert_column_key_bytes_to_index!(key,
+            0..8  => Slot::from_be_bytes,
+            8..16 => u64::from_be_bytes,  // shred index
+            16..48 => Hash::new_from_array,
+        )
+    }
+
+    fn slot(index: Self::Index) -> Slot {
+        index.0
+    }
+
+    fn as_index(slot: Slot) -> Self::Index {
+        (slot, 0, Hash::default())
+    }
+}
+impl ColumnName for columns::AlternateShredData {
+    const NAME: &'static str = "alt_data_shred";
+}
+
+impl SlotColumn for columns::BlockVersions {}
+impl ColumnName for columns::BlockVersions {
+    const NAME: &'static str = "block_versions";
+}
+impl TypedColumn for columns::BlockVersions {
+    type Type = blockstore_meta::BlockVersions;
+}
+
 impl SlotColumn for columns::Index {}
 impl ColumnName for columns::Index {
     const NAME: &'static str = "index";
@@ -677,25 +778,45 @@ impl TypedColumn for columns::Index {
     type Type = blockstore_meta::Index;
 
     fn deserialize(data: &[u8]) -> Result<Self::Type> {
-        let config = bincode::DefaultOptions::new()
-            // `bincode::serialize` uses fixint encoding by default, so we need to use the same here
-            .with_fixint_encoding()
-            .reject_trailing_bytes();
+        blockstore_meta::deserialize_index(data)
+    }
+}
 
-        // Migration strategy for new column format:
-        // 1. Release 1: Add ability to read new format as fallback, keep writing old format
-        // 2. Release 2: Switch to writing new format, keep reading old format as fallback
-        // 3. Release 3: Remove old format support once stable
-        // This allows safe downgrade to Release 1 since it can read both formats
-        // https://github.com/anza-xyz/agave/issues/3570
-        let index: bincode::Result<blockstore_meta::Index> = config.deserialize(data);
-        match index {
-            Ok(index) => Ok(index),
-            Err(_) => {
-                let index: blockstore_meta::IndexFallback = config.deserialize(data)?;
-                Ok(index.into())
-            }
-        }
+impl Column for columns::AlternateIndex {
+    type Index = (Slot, /* block_id */ Hash);
+    type Key = [u8; std::mem::size_of::<Slot>() + HASH_BYTES];
+
+    #[inline]
+    fn key((slot, block_id): &Self::Index) -> Self::Key {
+        convert_column_index_to_key_bytes!(Key,
+            ..8 => &slot.to_be_bytes(),
+            8.. => &block_id.to_bytes(),
+        )
+    }
+
+    fn index(key: &[u8]) -> Self::Index {
+        convert_column_key_bytes_to_index!(key,
+            0..8  => Slot::from_be_bytes,
+            8..40 => Hash::new_from_array, // block_id
+        )
+    }
+
+    fn slot(index: Self::Index) -> Slot {
+        index.0
+    }
+
+    fn as_index(slot: Slot) -> Self::Index {
+        (slot, Hash::default())
+    }
+}
+impl ColumnName for columns::AlternateIndex {
+    const NAME: &'static str = "alt_index";
+}
+impl TypedColumn for columns::AlternateIndex {
+    type Type = blockstore_meta::Index;
+
+    fn deserialize(data: &[u8]) -> Result<Self::Type> {
+        blockstore_meta::deserialize_index(data)
     }
 }
 
@@ -747,27 +868,45 @@ impl TypedColumn for columns::SlotMeta {
     type Type = blockstore_meta::SlotMeta;
 
     fn deserialize(data: &[u8]) -> Result<Self::Type> {
-        // SlotMeta is being migrated to a new `completed_data_indexes` format.
-        //
-        // Ensure that reject trailing bytes is enabled to prevent false postivies in deserialization.
-        let config = bincode::DefaultOptions::new()
-            // `bincode::serialize` uses fixint encoding by default, so we need to use the same here
-            .with_fixint_encoding()
-            .reject_trailing_bytes();
+        blockstore_meta::deserialize_slot_meta(data)
+    }
+}
 
-        // Migration strategy for new column format:
-        // 1. Release 1: Add ability to read new format as fallback, keep writing old format
-        // 2. Release 2: Switch to writing new format, keep reading old format as fallback
-        // 3. Release 3: Remove old format support once stable
-        // This allows safe downgrade to Release 1 since it can read both formats
-        let index: bincode::Result<blockstore_meta::SlotMeta> = config.deserialize(data);
-        match index {
-            Ok(index) => Ok(index),
-            Err(_) => {
-                let index: blockstore_meta::SlotMetaFallback = config.deserialize(data)?;
-                Ok(index.into())
-            }
-        }
+impl Column for columns::AlternateSlotMeta {
+    type Index = (Slot, /* block_id */ Hash);
+    type Key = [u8; std::mem::size_of::<Slot>() + HASH_BYTES];
+
+    #[inline]
+    fn key((slot, block_id): &Self::Index) -> Self::Key {
+        convert_column_index_to_key_bytes!(Key,
+            ..8 => &slot.to_be_bytes(),
+            8.. => &block_id.to_bytes(),
+        )
+    }
+
+    fn index(key: &[u8]) -> Self::Index {
+        convert_column_key_bytes_to_index!(key,
+            0..8  => Slot::from_be_bytes,
+            8..40 => Hash::new_from_array, // block_id
+        )
+    }
+
+    fn slot(index: Self::Index) -> Slot {
+        index.0
+    }
+
+    fn as_index(slot: Slot) -> Self::Index {
+        (slot, Hash::default())
+    }
+}
+impl ColumnName for columns::AlternateSlotMeta {
+    const NAME: &'static str = "alt_meta";
+}
+impl TypedColumn for columns::AlternateSlotMeta {
+    type Type = blockstore_meta::SlotMeta;
+
+    fn deserialize(data: &[u8]) -> Result<Self::Type> {
+        blockstore_meta::deserialize_slot_meta(data)
     }
 }
 
@@ -802,6 +941,42 @@ impl ColumnName for columns::ErasureMeta {
     const NAME: &'static str = "erasure_meta";
 }
 impl TypedColumn for columns::ErasureMeta {
+    type Type = blockstore_meta::ErasureMeta;
+}
+
+impl Column for columns::AlternateErasureMeta {
+    type Index = (Slot, /*fec_set_index:*/ u32, /* block_id */ Hash);
+    type Key = [u8; std::mem::size_of::<Slot>() + std::mem::size_of::<u32>() + HASH_BYTES];
+
+    #[inline]
+    fn key((slot, fec_set_index, block_id): &Self::Index) -> Self::Key {
+        convert_column_index_to_key_bytes!(Key,
+            ..8 => &slot.to_be_bytes(),
+            8..12 => &fec_set_index.to_be_bytes(),
+            12.. => &block_id.to_bytes(),
+        )
+    }
+
+    fn index(key: &[u8]) -> Self::Index {
+        convert_column_key_bytes_to_index!(key,
+            0..8  => Slot::from_be_bytes,
+            8..12 => u32::from_be_bytes,  // fec_set_index
+            12..44 => Hash::new_from_array, // block_id
+        )
+    }
+
+    fn slot(index: Self::Index) -> Slot {
+        index.0
+    }
+
+    fn as_index(slot: Slot) -> Self::Index {
+        (slot, 0, Hash::default())
+    }
+}
+impl ColumnName for columns::AlternateErasureMeta {
+    const NAME: &'static str = "alt_erasure_meta";
+}
+impl TypedColumn for columns::AlternateErasureMeta {
     type Type = blockstore_meta::ErasureMeta;
 }
 
@@ -845,6 +1020,43 @@ impl ColumnName for columns::MerkleRootMeta {
     const NAME: &'static str = "merkle_root_meta";
 }
 impl TypedColumn for columns::MerkleRootMeta {
+    type Type = blockstore_meta::MerkleRootMeta;
+}
+
+impl Column for columns::AlternateMerkleRootMeta {
+    type Index = (Slot, /*fec_set_index:*/ u32, /* block_id */ Hash);
+    type Key = [u8; std::mem::size_of::<Slot>() + std::mem::size_of::<u32>() + HASH_BYTES];
+
+    #[inline]
+    fn key((slot, fec_set_index, block_id): &Self::Index) -> Self::Key {
+        convert_column_index_to_key_bytes!(Key,
+            ..8 => &slot.to_be_bytes(),
+            8..12 => &fec_set_index.to_be_bytes(),
+            12.. => &block_id.to_bytes(),
+        )
+    }
+
+    fn index(key: &[u8]) -> Self::Index {
+        convert_column_key_bytes_to_index!(key,
+            0..8  => Slot::from_be_bytes,
+            8..12 => u32::from_be_bytes,  // fec_set_index
+            12..44 => Hash::new_from_array, // block_id
+        )
+    }
+
+    fn slot((slot, _fec_set_index, _block_id): Self::Index) -> Slot {
+        slot
+    }
+
+    fn as_index(slot: Slot) -> Self::Index {
+        (slot, 0, Hash::default())
+    }
+}
+
+impl ColumnName for columns::AlternateMerkleRootMeta {
+    const NAME: &'static str = "alt_merkle_root_meta";
+}
+impl TypedColumn for columns::AlternateMerkleRootMeta {
     type Type = blockstore_meta::MerkleRootMeta;
 }
 

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -184,6 +184,7 @@ impl Rocks {
             new_cf_descriptor::<columns::Index>(options, oldest_slot),
             new_cf_descriptor::<columns::ShredData>(options, oldest_slot),
             new_cf_descriptor::<columns::ShredCode>(options, oldest_slot),
+            new_cf_descriptor::<columns::BlockVersions>(options, oldest_slot),
             new_cf_descriptor::<columns::TransactionStatus>(options, oldest_slot),
             new_cf_descriptor::<columns::AddressSignatures>(options, oldest_slot),
             new_cf_descriptor::<columns::TransactionMemos>(options, oldest_slot),
@@ -195,6 +196,11 @@ impl Rocks {
             new_cf_descriptor::<columns::OptimisticSlots>(options, oldest_slot),
             new_cf_descriptor::<columns::MerkleRootMeta>(options, oldest_slot),
             new_cf_descriptor::<columns::SlotCertificates>(options, oldest_slot),
+            new_cf_descriptor::<columns::AlternateSlotMeta>(options, oldest_slot),
+            new_cf_descriptor::<columns::AlternateErasureMeta>(options, oldest_slot),
+            new_cf_descriptor::<columns::AlternateIndex>(options, oldest_slot),
+            new_cf_descriptor::<columns::AlternateShredData>(options, oldest_slot),
+            new_cf_descriptor::<columns::AlternateMerkleRootMeta>(options, oldest_slot),
         ];
 
         // If the access type is Secondary, we don't need to open all of the
@@ -243,7 +249,7 @@ impl Rocks {
         cf_descriptors
     }
 
-    const fn columns() -> [&'static str; 21] {
+    const fn columns() -> [&'static str; 27] {
         [
             columns::ErasureMeta::NAME,
             columns::DeadSlots::NAME,
@@ -255,6 +261,7 @@ impl Rocks {
             columns::SlotMeta::NAME,
             columns::ShredData::NAME,
             columns::ShredCode::NAME,
+            columns::BlockVersions::NAME,
             columns::TransactionStatus::NAME,
             columns::AddressSignatures::NAME,
             columns::TransactionMemos::NAME,
@@ -266,6 +273,11 @@ impl Rocks {
             columns::OptimisticSlots::NAME,
             columns::MerkleRootMeta::NAME,
             columns::SlotCertificates::NAME,
+            columns::AlternateSlotMeta::NAME,
+            columns::AlternateErasureMeta::NAME,
+            columns::AlternateIndex::NAME,
+            columns::AlternateShredData::NAME,
+            columns::AlternateMerkleRootMeta::NAME,
         ]
     }
 

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -1,9 +1,10 @@
 use {
     crate::{
         bit_vec::BitVec,
-        blockstore::MAX_DATA_SHREDS_PER_SLOT,
+        blockstore::{BlockstoreError, MAX_DATA_SHREDS_PER_SLOT},
         shred::{self, Shred, ShredType},
     },
+    bincode::Options,
     bitflags::bitflags,
     serde::{Deserialize, Deserializer, Serialize, Serializer},
     solana_clock::{Slot, UnixTimestamp},
@@ -221,6 +222,30 @@ pub type SlotMeta = SlotMetaV1;
 pub type CompletedDataIndexes = CompletedDataIndexesV1;
 pub type SlotMetaFallback = SlotMetaV2;
 
+pub(crate) fn deserialize_slot_meta(data: &[u8]) -> Result<SlotMeta, BlockstoreError> {
+    // SlotMeta is being migrated to a new `completed_data_indexes` format.
+    //
+    // Ensure that reject trailing bytes is enabled to prevent false postivies in deserialization.
+    let config = bincode::DefaultOptions::new()
+        // `bincode::serialize` uses fixint encoding by default, so we need to use the same here
+        .with_fixint_encoding()
+        .reject_trailing_bytes();
+
+    // Migration strategy for new column format:
+    // 1. Release 1: Add ability to read new format as fallback, keep writing old format
+    // 2. Release 2: Switch to writing new format, keep reading old format as fallback
+    // 3. Release 3: Remove old format support once stable
+    // This allows safe downgrade to Release 1 since it can read both formats
+    let index: bincode::Result<SlotMeta> = config.deserialize(data);
+    match index {
+        Ok(index) => Ok(index),
+        Err(_) => {
+            let index: SlotMetaFallback = config.deserialize(data)?;
+            Ok(index.into())
+        }
+    }
+}
+
 // Serde implementation of serialize and deserialize for Option<u64>
 // where None is represented as u64::MAX; for backward compatibility.
 mod serde_compat {
@@ -249,6 +274,28 @@ pub type ShredIndex = ShredIndexV2;
 /// See https://github.com/anza-xyz/agave/issues/3570.
 pub type IndexFallback = IndexV1;
 pub type ShredIndexFallback = ShredIndexV1;
+
+pub(crate) fn deserialize_index(data: &[u8]) -> Result<Index, BlockstoreError> {
+    let config = bincode::DefaultOptions::new()
+        // `bincode::serialize` uses fixint encoding by default, so we need to use the same here
+        .with_fixint_encoding()
+        .reject_trailing_bytes();
+
+    // Migration strategy for new column format:
+    // 1. Release 1: Add ability to read new format as fallback, keep writing old format
+    // 2. Release 2: Switch to writing new format, keep reading old format as fallback
+    // 3. Release 3: Remove old format support once stable
+    // This allows safe downgrade to Release 1 since it can read both formats
+    // https://github.com/anza-xyz/agave/issues/3570
+    let index: bincode::Result<Index> = config.deserialize(data);
+    match index {
+        Ok(index) => Ok(index),
+        Err(_) => {
+            let index: IndexFallback = config.deserialize(data)?;
+            Ok(index.into())
+        }
+    }
+}
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 /// Index recording presence/absence of shreds
@@ -363,6 +410,51 @@ pub struct DuplicateSlotProof {
     pub shred1: shred::Payload,
     #[serde(with = "shred::serde_bytes_payload")]
     pub shred2: shred::Payload,
+}
+
+#[derive(Deserialize, Serialize)]
+pub enum BlockStatus {
+    /// The block is being ingested, of the shreds received there are no conflicts
+    Incomplete,
+
+    /// The block `block_id` has been fully ingested, has consistent shreds and is ready for replay
+    Complete { block_id: Hash },
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct BlockVersions {
+    pub turbine_version: BlockStatus,
+    pub repaired_versions: [(Hash, BlockStatus); 3],
+}
+
+/// Which column an associated block currently resides
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum BlockLocation {
+    Turbine,
+    Repair { block_id: Hash },
+}
+
+impl BlockVersions {
+    pub(crate) fn get_location(self, block_id: Hash) -> Option<BlockLocation> {
+        match self.turbine_version {
+            BlockStatus::Complete { block_id: bid } if bid == block_id => {
+                return Some(BlockLocation::Turbine);
+            }
+            _ => (),
+        };
+
+        self.repaired_versions
+            .into_iter()
+            .find_map(|(bid, block_status)| match block_status {
+                BlockStatus::Complete {
+                    block_id: status_bid,
+                } if status_bid == block_id => {
+                    assert!(bid == status_bid);
+                    Some(BlockLocation::Repair { block_id })
+                }
+                _ => None,
+            })
+    }
 }
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]


### PR DESCRIPTION
#### Problem
As part of alpenglow, we need to be able to repair and store up to 3 alternate versions of a block separately
from the block that is received via turbine. We need to enable blockstore to ingest and store these blocks.

#### Summary of Changes
After discussion with Steve and Carl we have taken the approach that I believe will allow us to enable this with the smallest surface area:
- Add alternate versions of the columns relevant to shred ingest (SlotMeta, ErasureMeta, Index, ShredData, MerkleRootMeta)
- Add a BlockVersions column which keeps track of available complete versions in order to serve repair requests and facilitate replay / intrawindow safe to notar checks
- Future PR will modify the do_insert_shreds call path to accept a location to store these repaired shreds in the appropriate column
- Future PR will allow for replaying banks from an alternate column, and update the appropriate tracking in Bank/BankForks
- In the case where we have a block that we have to fetch via block id repair and it ends up getting rooted, we will move the relevant data from these alternate columns back into the original columns. This avoids having to update the full blockstore API,  RPC and any downstream tooling (e.g. ledger-tool). This situation should be rare during steady state, so we are fine eating the copy cost.

In V2 we can consider migrating from the original columns completely (Turbine blocks could be stored with Hash::default) and updating downstream dependencies