### PR TITLE
repair: add new block_id based repair variants

### DIFF
--- a/core/src/repair/repair_handler.rs
+++ b/core/src/repair/repair_handler.rs
@@ -11,9 +11,11 @@ use {
     bincode::serialize,
     solana_clock::Slot,
     solana_gossip::cluster_info::ClusterInfo,
+    solana_hash::Hash,
     solana_ledger::{
         ancestor_iterator::{AncestorIterator, AncestorIteratorWithHash},
         blockstore::Blockstore,
+        blockstore_meta::BlockLocation,
         shred::Nonce,
     },
     solana_perf::packet::{Packet, PacketBatch, PacketBatchRecycler, PinnedPacketBatch},
@@ -33,6 +35,7 @@ pub trait RepairHandler {
         &self,
         slot: Slot,
         shred_index: u64,
+        block_id: Option<Hash>,
         dest: &SocketAddr,
         nonce: Nonce,
     ) -> Option<Packet>;
@@ -43,10 +46,10 @@ pub trait RepairHandler {
         from_addr: &SocketAddr,
         slot: Slot,
         shred_index: u64,
+        block_id: Option<Hash>,
         nonce: Nonce,
     ) -> Option<PacketBatch> {
-        // Try to find the requested index in one of the slots
-        let packet = self.repair_response_packet(slot, shred_index, from_addr, nonce)?;
+        let packet = self.repair_response_packet(slot, shred_index, block_id, from_addr, nonce)?;
         Some(
             PinnedPacketBatch::new_unpinned_with_recycler_data(
                 recycler,
@@ -63,13 +66,24 @@ pub trait RepairHandler {
         from_addr: &SocketAddr,
         slot: Slot,
         highest_index: u64,
+        block_id: Option<Hash>,
         nonce: Nonce,
     ) -> Option<PacketBatch> {
-        // Try to find the requested index in one of the slots
-        let meta = self.blockstore().meta(slot).ok()??;
+        let location = match block_id {
+            None => BlockLocation::Turbine,
+            Some(block_id) => self
+                .blockstore()
+                .get_block_location(slot, block_id)
+                .expect("Unable to fetch block location from blockstore")?,
+        };
+        let meta = self
+            .blockstore()
+            .meta_from_location(slot, location)
+            .expect("Unable to fetch slot meta from blockstore")?;
         if meta.received > highest_index {
             // meta.received must be at least 1 by this point
-            let packet = self.repair_response_packet(slot, meta.received - 1, from_addr, nonce)?;
+            let packet =
+                self.repair_response_packet(slot, meta.received - 1, block_id, from_addr, nonce)?;
             return Some(
                 PinnedPacketBatch::new_unpinned_with_recycler_data(
                     recycler,
@@ -87,6 +101,7 @@ pub trait RepairHandler {
         recycler: &PacketBatchRecycler,
         from_addr: &SocketAddr,
         slot: Slot,
+        block_id: Option<Hash>,
         max_responses: usize,
         nonce: Nonce,
     ) -> Option<PacketBatch>;

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -157,19 +157,30 @@ pub struct RepairStats {
     pub shred: RepairStatsGroup,
     pub highest_shred: RepairStatsGroup,
     pub orphan: RepairStatsGroup,
+    pub orphan_for_block_id: RepairStatsGroup,
+    pub shred_for_block_id: RepairStatsGroup,
+    pub highest_shred_for_block_id: RepairStatsGroup,
     pub get_best_orphans_us: u64,
     pub get_best_shreds_us: u64,
 }
 
 impl RepairStats {
     fn report(&self) {
-        let repair_total = self.shred.count + self.highest_shred.count + self.orphan.count;
+        let repair_total = self.shred.count
+            + self.highest_shred.count
+            + self.orphan.count
+            + self.orphan_for_block_id.count
+            + self.shred_for_block_id.count
+            + self.highest_shred_for_block_id.count;
         let slot_to_count: Vec<_> = self
             .shred
             .slot_pubkeys
             .iter()
             .chain(self.highest_shred.slot_pubkeys.iter())
             .chain(self.orphan.slot_pubkeys.iter())
+            .chain(self.orphan_for_block_id.slot_pubkeys.iter())
+            .chain(self.shred_for_block_id.slot_pubkeys.iter())
+            .chain(self.highest_shred_for_block_id.slot_pubkeys.iter())
             .map(|(slot, slot_repairs)| (slot, slot_repairs.pubkey_repairs.values().sum::<u64>()))
             .collect();
         info!("repair_stats: {slot_to_count:?}");
@@ -181,6 +192,9 @@ impl RepairStats {
                 ("shred-count", self.shred.count, i64),
                 ("highest-shred-count", self.highest_shred.count, i64),
                 ("orphan-count", self.orphan.count, i64),
+                ("orphan-for-block-id-count", self.orphan_for_block_id.count, i64),
+                ("shred-for-block-id-count", self.shred_for_block_id.count, i64),
+                ("highest-shred-for-block-id-count", self.highest_shred_for_block_id.count, i64),
                 ("shred-slot-max", nonzero_num(self.shred.max), Option<i64>),
                 ("shred-slot-min", nonzero_num(self.shred.min), Option<i64>),
                 ("repair-highest-slot", self.highest_shred.max, i64), // deprecated

--- a/core/src/repair/standard_repair_handler.rs
+++ b/core/src/repair/standard_repair_handler.rs
@@ -1,7 +1,12 @@
 use {
     super::{repair_handler::RepairHandler, repair_response},
     solana_clock::Slot,
-    solana_ledger::{blockstore::Blockstore, shred::Nonce},
+    solana_hash::Hash,
+    solana_ledger::{
+        blockstore::{Blockstore, SlotMeta},
+        blockstore_meta::BlockLocation,
+        shred::Nonce,
+    },
     solana_perf::packet::{Packet, PacketBatch, PacketBatchRecycler, PinnedPacketBatch},
     std::{net::SocketAddr, sync::Arc},
 };
@@ -25,19 +30,112 @@ impl RepairHandler for StandardRepairHandler {
         &self,
         slot: Slot,
         shred_index: u64,
+        block_id: Option<Hash>,
         dest: &SocketAddr,
         nonce: Nonce,
     ) -> Option<Packet> {
-        repair_response::repair_response_packet(
-            self.blockstore.as_ref(),
-            slot,
-            shred_index,
-            dest,
-            nonce,
-        )
+        match block_id {
+            None => repair_response::repair_response_packet(
+                self.blockstore.as_ref(),
+                slot,
+                shred_index,
+                dest,
+                nonce,
+            ),
+            Some(block_id) => {
+                let location = self
+                    .blockstore()
+                    .get_block_location(slot, block_id)
+                    .expect("Unable to fetch block location from blockstore")?;
+                let shred = self
+                    .blockstore()
+                    .get_data_shred_from_location(slot, shred_index, location)
+                    .expect("Blockstore could not get data shred")?;
+                repair_response::repair_response_packet_from_bytes(shred, dest, nonce)
+            }
+        }
     }
 
     fn run_orphan(
+        &self,
+        recycler: &PacketBatchRecycler,
+        from_addr: &SocketAddr,
+        slot: Slot,
+        block_id: Option<Hash>,
+        max_responses: usize,
+        nonce: Nonce,
+    ) -> Option<PacketBatch> {
+        match block_id {
+            None => self.run_orphan_turbine_only(recycler, from_addr, slot, max_responses, nonce),
+            Some(block_id) => self.run_orphan_for_block_id(
+                recycler,
+                from_addr,
+                slot,
+                block_id,
+                max_responses,
+                nonce,
+            ),
+        }
+    }
+}
+
+impl StandardRepairHandler {
+    /// Fulfills orphan requests for the specified `block_id`.
+    /// We responded with up to `max_repsonses` ancestors, only if we've fully ingested said blocks.
+    fn run_orphan_for_block_id(
+        &self,
+        recycler: &PacketBatchRecycler,
+        from_addr: &SocketAddr,
+        slot: Slot,
+        block_id: Hash,
+        max_responses: usize,
+        nonce: Nonce,
+    ) -> Option<PacketBatch> {
+        let mut res =
+            PinnedPacketBatch::new_unpinned_with_recycler(recycler, max_responses, "run_orphan");
+
+        let get_parent_location_meta = |(location, meta): &(BlockLocation, SlotMeta)| {
+            let parent_slot = meta.parent_slot?;
+            let parent_block_id = self
+                .blockstore
+                .get_parent_block_id_from_location(meta.slot, *location)
+                .ok()??;
+            let parent_location = self
+                .blockstore
+                .get_block_location(parent_slot, parent_block_id)
+                .ok()??;
+            let parent_meta = self
+                .blockstore
+                .meta_from_location(parent_slot, parent_location)
+                .ok()??;
+            Some((parent_location, parent_meta))
+        };
+
+        let location = self.blockstore.get_block_location(slot, block_id).ok()??;
+        let meta = self.blockstore.meta_from_location(slot, location).ok()??;
+        let packets = std::iter::successors(Some((location, meta)), get_parent_location_meta)
+            .map_while(|(location, meta)| {
+                assert!(meta.is_full());
+                let shred = self
+                    .blockstore()
+                    .get_data_shred_from_location(
+                        slot,
+                        meta.last_index.expect("slot is full").checked_sub(1u64)?,
+                        location,
+                    )
+                    .ok()??;
+                repair_response::repair_response_packet_from_bytes(shred, from_addr, nonce)
+            });
+
+        for packet in packets.take(max_responses) {
+            res.push(packet);
+        }
+        (!res.is_empty()).then_some(res.into())
+    }
+
+    /// Fulfills orphan requests from the turbine column only. This predates block id logic and is left for compatability
+    /// with TowerBFT. This variant will respond to requests even if the block has not been fully ingested.
+    fn run_orphan_turbine_only(
         &self,
         recycler: &PacketBatchRecycler,
         from_addr: &SocketAddr,


### PR DESCRIPTION
#### Problem
We need to be able to fetch alternate versions of a block and store them in the appropriate blockstore columns

#### Summary of Changes
Create a block id based version of orphan, highest shred, and shred, and plug in the responder.

Unlike TowerBFT the responder only fulfills these requests if it has the *complete* block for the shred(s) that are being requested.