### PR TITLE
nit: refactor: minor improvements to `new_vote_pool` 

### DIFF
--- a/votor/src/certificate_pool.rs
+++ b/votor/src/certificate_pool.rs
@@ -12,7 +12,7 @@ use {
         conflicting_types,
         event::VotorEvent,
         vote_to_certificate_ids, Certificate, Stake, VoteType,
-        MAX_ENTRIES_PER_PUBKEY_FOR_NOTARIZE_LITE, MAX_ENTRIES_PER_PUBKEY_FOR_OTHER_TYPES,
+        MAX_ENTRIES_PER_PUBKEY_FOR_OTHER_TYPES,
     },
     crossbeam_channel::Sender,
     log::{error, trace},


### PR DESCRIPTION
Removes some code duplication and specify enum variants instead of using `_` so that the compiler helps us in figuring out all the places that need changes if we add or remove variants in future.