### PR TITLE
ParentReady should be able to use NotarizeFallback/Notarize/FinalizeFast.

### DIFF
--- a/votor/src/certificate_pool.rs
+++ b/votor/src/certificate_pool.rs
@@ -322,7 +322,7 @@ impl CertificatePool {
         match cert_id {
             Certificate::NotarizeFallback(slot, block_id) => {
                 self.parent_ready_tracker
-                    .add_new_notar_fallback((slot, block_id), events);
+                    .add_new_notar_fallback_or_equivalent((slot, block_id), events);
                 if self
                     .highest_notarized_fallback
                     .is_none_or(|(s, _)| s < slot)
@@ -333,6 +333,8 @@ impl CertificatePool {
             Certificate::Skip(slot) => self.parent_ready_tracker.add_new_skip(slot, events),
             Certificate::Notarize(slot, block_id) => {
                 events.push(VotorEvent::BlockNotarized((slot, block_id)));
+                self.parent_ready_tracker
+                    .add_new_notar_fallback_or_equivalent((slot, block_id), events);
                 if self.is_finalized(slot) {
                     events.push(VotorEvent::Finalized((slot, block_id)));
                     if self
@@ -359,6 +361,8 @@ impl CertificatePool {
             }
             Certificate::FinalizeFast(slot, block_id) => {
                 events.push(VotorEvent::Finalized((slot, block_id)));
+                self.parent_ready_tracker
+                    .add_new_notar_fallback_or_equivalent((slot, block_id), events);
                 if self.highest_finalized_slot.is_none_or(|s| s < slot) {
                     self.highest_finalized_slot = Some(slot);
                 }
@@ -2176,5 +2180,112 @@ mod tests {
             && cert.certificate.certificate_type() == CertificateType::Notarize));
         assert!(certs.iter().any(|cert| cert.certificate.slot() == 7
             && cert.certificate.certificate_type() == CertificateType::Skip));
+    }
+
+    #[test]
+    fn test_new_parent_ready_with_certificates() {
+        solana_logger::setup();
+        let (_, mut pool, bank_forks) = create_initial_state();
+        let bank = bank_forks.read().unwrap().root_bank();
+        let mut events = vec![];
+
+        // Add a notarization cert on slot 1 to 3
+        let hash = Hash::new_unique();
+        for slot in 1..=3 {
+            let cert = CertificateMessage {
+                certificate: Certificate::new(CertificateType::Notarize, slot, Some(hash)),
+                signature: BLSSignature::default(),
+                bitmap: Vec::new(),
+            };
+            assert!(pool
+                .add_message(
+                    bank.epoch_schedule(),
+                    bank.epoch_stakes_map(),
+                    bank.slot(),
+                    &Pubkey::new_unique(),
+                    &BLSMessage::Certificate(cert),
+                    &mut events,
+                )
+                .is_ok());
+        }
+        // events should now contain ParentReady for slot 4
+        error!("Events: {:?}", events);
+        assert!(events
+            .iter()
+            .any(|event| matches!(event, VotorEvent::ParentReady {
+                slot: 4,
+                parent_block: (3, h)
+            } if h == &hash)));
+        events.clear();
+
+        // Also works if we add FinalizeFast for slot 4 to 7
+        for slot in 4..=7 {
+            let cert = CertificateMessage {
+                certificate: Certificate::new(CertificateType::FinalizeFast, slot, Some(hash)),
+                signature: BLSSignature::default(),
+                bitmap: Vec::new(),
+            };
+            assert!(pool
+                .add_message(
+                    bank.epoch_schedule(),
+                    bank.epoch_stakes_map(),
+                    bank.slot(),
+                    &Pubkey::new_unique(),
+                    &BLSMessage::Certificate(cert),
+                    &mut events,
+                )
+                .is_ok());
+        }
+        // events should now contain ParentReady for slot 8
+        error!("Events: {:?}", events);
+        assert!(events
+            .iter()
+            .any(|event| matches!(event, VotorEvent::ParentReady {
+                slot: 8,
+                parent_block: (7, h)
+            } if h == &hash)));
+        events.clear();
+
+        // NotarizeFallback on slot 8 to 10 and FinalizeFast on slot 11
+        for slot in 8..=10 {
+            let cert = CertificateMessage {
+                certificate: Certificate::new(CertificateType::NotarizeFallback, slot, Some(hash)),
+                signature: BLSSignature::default(),
+                bitmap: Vec::new(),
+            };
+            assert!(pool
+                .add_message(
+                    bank.epoch_schedule(),
+                    bank.epoch_stakes_map(),
+                    bank.slot(),
+                    &Pubkey::new_unique(),
+                    &BLSMessage::Certificate(cert),
+                    &mut events,
+                )
+                .is_ok());
+        }
+        let cert = CertificateMessage {
+            certificate: Certificate::new(CertificateType::FinalizeFast, 11, Some(hash)),
+            signature: BLSSignature::default(),
+            bitmap: Vec::new(),
+        };
+        assert!(pool
+            .add_message(
+                bank.epoch_schedule(),
+                bank.epoch_stakes_map(),
+                bank.slot(),
+                &Pubkey::new_unique(),
+                &BLSMessage::Certificate(cert),
+                &mut events,
+            )
+            .is_ok());
+        // events should now contain ParentReady for slot 12
+        error!("Events: {:?}", events);
+        assert!(events
+            .iter()
+            .any(|event| matches!(event, VotorEvent::ParentReady {
+            slot: 12,
+            parent_block: (11, h)
+        } if h == &hash)));
     }
 }

--- a/votor/src/certificate_pool/parent_ready_tracker.rs
+++ b/votor/src/certificate_pool/parent_ready_tracker.rs
@@ -84,8 +84,8 @@ impl ParentReadyTracker {
         }
     }
 
-    /// Adds a new notar-fallback certificate
-    pub fn add_new_notar_fallback(
+    /// Adds a new notarize fallback certificate, we can use Notarize/NotarizeFallback/FastFinalize
+    pub fn add_new_notar_fallback_or_equivalent(
         &mut self,
         block @ (slot, _): Block,
         events: &mut Vec<VotorEvent>,
@@ -258,7 +258,7 @@ mod tests {
 
         for i in 1..2 * NUM_CONSECUTIVE_LEADER_SLOTS {
             let block = (i, Hash::new_unique());
-            tracker.add_new_notar_fallback(block, &mut events);
+            tracker.add_new_notar_fallback_or_equivalent(block, &mut events);
             assert_eq!(tracker.highest_parent_ready(), i + 1);
             assert!(tracker.parent_ready(i + 1, block));
         }
@@ -271,7 +271,7 @@ mod tests {
         let mut events = vec![];
         let block = (1, Hash::new_unique());
 
-        tracker.add_new_notar_fallback(block, &mut events);
+        tracker.add_new_notar_fallback_or_equivalent(block, &mut events);
         tracker.add_new_skip(1, &mut events);
         tracker.add_new_skip(2, &mut events);
         tracker.add_new_skip(3, &mut events);
@@ -291,7 +291,7 @@ mod tests {
         tracker.add_new_skip(3, &mut events);
         tracker.add_new_skip(2, &mut events);
 
-        tracker.add_new_notar_fallback(block, &mut events);
+        tracker.add_new_notar_fallback_or_equivalent(block, &mut events);
         assert!(tracker.parent_ready(4, block));
         assert!(!tracker.parent_ready(4, genesis));
 
@@ -322,7 +322,7 @@ mod tests {
         assert_eq!(tracker.highest_parent_ready(), root_slot + 3);
 
         let block = (root_slot + 4, Hash::new_unique());
-        tracker.add_new_notar_fallback(block, &mut events);
+        tracker.add_new_notar_fallback_or_equivalent(block, &mut events);
         assert!(tracker.parent_ready(root_slot + 3, root_block));
         assert!(tracker.parent_ready(root_slot + 5, block));
         assert_eq!(tracker.highest_parent_ready(), root_slot + 5);
@@ -361,7 +361,7 @@ mod tests {
             BlockProductionParent::ParentNotReady
         );
 
-        tracker.add_new_notar_fallback((4, Hash::new_unique()), &mut events);
+        tracker.add_new_notar_fallback_or_equivalent((4, Hash::new_unique()), &mut events);
         assert_eq!(tracker.highest_parent_ready(), 5);
         assert_eq!(
             tracker.block_production_parent(4),
@@ -372,7 +372,7 @@ mod tests {
             tracker.block_production_parent(8),
             BlockProductionParent::ParentNotReady
         );
-        tracker.add_new_notar_fallback((64, Hash::new_unique()), &mut events);
+        tracker.add_new_notar_fallback_or_equivalent((64, Hash::new_unique()), &mut events);
         assert_eq!(tracker.highest_parent_ready(), 65);
         assert_eq!(
             tracker.block_production_parent(8),


### PR DESCRIPTION
NotarizeFallback/Notarize/FinalizeFast all tell us that (slot, hash) is notarized, so they should all count in ParentReadyTracker.

This is especially a problem in standstill handling after https://github.com/anza-xyz/alpenglow/issues/347, since we don't send out NotarizeFallback certs for highest finalized slot any more. (So now our local-cluster tests hangs a lot.)
