### PR TITLE
feat: replace spl-token-2022 with spl-token-2022-interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,7 +519,7 @@ dependencies = [
  "solana-vote-program",
  "solana-votor",
  "spl-generic-token",
- "spl-token-2022",
+ "spl-token-2022-interface",
  "symlink",
  "tempfile",
  "test-case",
@@ -6884,7 +6884,7 @@ dependencies = [
  "spl-generic-token",
  "spl-pod",
  "spl-token",
- "spl-token-2022",
+ "spl-token-2022-interface",
  "spl-token-group-interface",
  "spl-token-metadata-interface",
  "thiserror 2.0.12",
@@ -8298,9 +8298,9 @@ version = "3.0.0"
 
 [[package]]
 name = "solana-curve25519"
-version = "2.2.15"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def3cfe5279edb64fc39111cff6dcf77b01fbfba2c02c13ced41e6a48baf4cbe"
+checksum = "b162f50499b391b785d57b2f2c73e3b9754d88fd4894bef444960b00bda8dcca"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -9158,8 +9158,6 @@ dependencies = [
  "solana-votor-messages",
  "spl-generic-token",
  "spl-pod",
- "spl-token",
- "spl-token-2022",
  "static_assertions",
  "strum",
  "strum_macros",
@@ -10200,7 +10198,7 @@ dependencies = [
  "spl-generic-token",
  "spl-pod",
  "spl-token",
- "spl-token-2022",
+ "spl-token-2022-interface",
  "stream-cancel",
  "symlink",
  "test-case",
@@ -10641,12 +10639,6 @@ dependencies = [
  "solana-precompile-error",
  "solana-sdk-ids",
 ]
-
-[[package]]
-name = "solana-security-txt"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
 
 [[package]]
 name = "solana-seed-derivable"
@@ -11726,7 +11718,7 @@ dependencies = [
  "spl-associated-token-account-interface",
  "spl-memo",
  "spl-token",
- "spl-token-2022",
+ "spl-token-2022-interface",
  "spl-token-confidential-transfer-proof-extraction",
  "spl-token-group-interface",
  "spl-token-metadata-interface",
@@ -12254,9 +12246,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-sdk"
-version = "2.2.15"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15045540c315a9b8ea056323e73320e76098dfdaac9e65b1b33fe9c2f3c9b9e1"
+checksum = "3bb171c0f76c420a7cb6aabbe5fa85a1a009d5bb4009189c43e1a03aff9446d7"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
@@ -12266,7 +12258,6 @@ dependencies = [
  "curve25519-dalek 4.1.3",
  "itertools 0.12.1",
  "js-sys",
- "lazy_static",
  "merlin",
  "num-derive",
  "num-traits",
@@ -12440,29 +12431,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spl-elgamal-registry"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65edfeed09cd4231e595616aa96022214f9c9d2be02dea62c2b30d5695a6833a"
-dependencies = [
- "bytemuck",
- "solana-account-info",
- "solana-cpi",
- "solana-instruction",
- "solana-msg",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-pubkey",
- "solana-rent",
- "solana-sdk-ids",
- "solana-system-interface",
- "solana-sysvar",
- "solana-zk-sdk 2.2.15",
- "spl-pod",
- "spl-token-confidential-transfer-proof-extraction",
-]
-
-[[package]]
 name = "spl-generic-token"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12517,56 +12485,7 @@ dependencies = [
  "solana-program-error",
  "solana-program-option",
  "solana-pubkey",
- "solana-zk-sdk 2.2.15",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-program-error"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdebc8b42553070b75aa5106f071fef2eb798c64a7ec63375da4b1f058688c6"
-dependencies = [
- "num-derive",
- "num-traits",
- "solana-decode-error",
- "solana-msg",
- "solana-program-error",
- "spl-program-error-derive",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-program-error-derive"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2539e259c66910d78593475540e8072f0b10f0f61d7607bbf7593899ed52d0"
-dependencies = [
- "proc-macro2",
- "quote",
- "sha2 0.10.9",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "spl-tlv-account-resolution"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1408e961215688715d5a1063cbdcf982de225c45f99c82b4f7d7e1dd22b998d7"
-dependencies = [
- "bytemuck",
- "num-derive",
- "num-traits",
- "solana-account-info",
- "solana-decode-error",
- "solana-instruction",
- "solana-msg",
- "solana-program-error",
- "solana-pubkey",
- "spl-discriminator",
- "spl-pod",
- "spl-program-error",
- "spl-type-length-value",
+ "solana-zk-sdk 2.3.7",
  "thiserror 2.0.12",
 ]
 
@@ -12599,10 +12518,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "spl-token-2022"
-version = "8.0.1"
+name = "spl-token-2022-interface"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f0dfbb079eebaee55e793e92ca5f433744f4b71ee04880bfd6beefba5973e5"
+checksum = "62d7ae2ee6b856f8ddcbdc3b3a9f4d2141582bbe150f93e5298ee97e0251fa04"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -12610,66 +12529,40 @@ dependencies = [
  "num-traits",
  "num_enum",
  "solana-account-info",
- "solana-clock",
- "solana-cpi",
  "solana-decode-error",
  "solana-instruction",
  "solana-msg",
- "solana-native-token",
- "solana-program-entrypoint",
  "solana-program-error",
- "solana-program-memory",
  "solana-program-option",
  "solana-program-pack",
  "solana-pubkey",
- "solana-rent",
  "solana-sdk-ids",
- "solana-security-txt",
- "solana-system-interface",
- "solana-sysvar",
- "solana-zk-sdk 2.2.15",
- "spl-elgamal-registry",
- "spl-memo",
+ "solana-zk-sdk 2.3.7",
  "spl-pod",
- "spl-token",
- "spl-token-confidential-transfer-ciphertext-arithmetic",
  "spl-token-confidential-transfer-proof-extraction",
  "spl-token-confidential-transfer-proof-generation",
  "spl-token-group-interface",
  "spl-token-metadata-interface",
- "spl-transfer-hook-interface",
  "spl-type-length-value",
  "thiserror 2.0.12",
 ]
 
 [[package]]
-name = "spl-token-confidential-transfer-ciphertext-arithmetic"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ab20faf7b5edaa79acd240e0f21d5a2ef936aa99ed98f698573a2825b299c4"
-dependencies = [
- "base64 0.22.1",
- "bytemuck",
- "solana-curve25519 2.2.15",
- "solana-zk-sdk 2.2.15",
-]
-
-[[package]]
 name = "spl-token-confidential-transfer-proof-extraction"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe2629860ff04c17bafa9ba4bed8850a404ecac81074113e1f840dbd0ebb7bd6"
+checksum = "512c85bdbbb4cbcc2038849a9e164c958b16541f252b53ea1a3933191c0a4a1a"
 dependencies = [
  "bytemuck",
  "solana-account-info",
- "solana-curve25519 2.2.15",
+ "solana-curve25519 2.3.7",
  "solana-instruction",
  "solana-instructions-sysvar",
  "solana-msg",
  "solana-program-error",
  "solana-pubkey",
  "solana-sdk-ids",
- "solana-zk-sdk 2.2.15",
+ "solana-zk-sdk 2.3.7",
  "spl-pod",
  "thiserror 2.0.12",
 ]
@@ -12681,7 +12574,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae5b124840d4aed474cef101d946a798b806b46a509ee4df91021e1ab1cef3ef"
 dependencies = [
  "curve25519-dalek 4.1.3",
- "solana-zk-sdk 2.2.15",
+ "solana-zk-sdk 2.3.7",
  "thiserror 2.0.12",
 ]
 
@@ -12721,31 +12614,6 @@ dependencies = [
  "solana-pubkey",
  "spl-discriminator",
  "spl-pod",
- "spl-type-length-value",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-transfer-hook-interface"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7e905b849b6aba63bde8c4badac944ebb6c8e6e14817029cbe1bc16829133bd"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive",
- "num-traits",
- "solana-account-info",
- "solana-cpi",
- "solana-decode-error",
- "solana-instruction",
- "solana-msg",
- "solana-program-error",
- "solana-pubkey",
- "spl-discriminator",
- "spl-pod",
- "spl-program-error",
- "spl-tlv-account-resolution",
  "spl-type-length-value",
  "thiserror 2.0.12",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -589,8 +589,8 @@ spl-instruction-padding = "0.3.0"
 spl-memo = "6.0.0"
 spl-pod = "0.5.1"
 spl-token = "8.0.0"
-spl-token-2022 = "8.0.1"
-spl-token-confidential-transfer-proof-extraction = "0.3.0"
+spl-token-2022-interface = "1.0.0"
+spl-token-confidential-transfer-proof-extraction = "0.4.0"
 spl-token-group-interface = "0.6.0"
 spl-token-metadata-interface = "0.7.0"
 static_assertions = "1.1.0"
@@ -670,7 +670,7 @@ crossbeam-epoch = { git = "https://github.com/anza-xyz/crossbeam", rev = "fd279d
 #  * spl-memo
 #  * spl-pod
 #  * spl-token
-#  * spl-token-2022
+#  * spl-token-2022-interface
 #  * spl-token-metadata-interface
 #
 # They, in turn, depend on a number of crates that we also include directly

--- a/account-decoder/Cargo.toml
+++ b/account-decoder/Cargo.toml
@@ -46,7 +46,7 @@ solana-sysvar = { workspace = true }
 solana-vote-interface = { workspace = true, features = ["bincode"] }
 spl-generic-token = { workspace = true }
 spl-token = { workspace = true, features = ["no-entrypoint"] }
-spl-token-2022 = { workspace = true, features = ["no-entrypoint"] }
+spl-token-2022-interface = { workspace = true }
 spl-token-group-interface = { workspace = true }
 spl-token-metadata-interface = { workspace = true }
 thiserror = { workspace = true }

--- a/account-decoder/src/parse_account_data.rs
+++ b/account-decoder/src/parse_account_data.rs
@@ -13,7 +13,7 @@ use {
     solana_sdk_ids::{
         address_lookup_table, bpf_loader_upgradeable, config, stake, system_program, sysvar, vote,
     },
-    spl_token_2022::extension::{
+    spl_token_2022_interface::extension::{
         interest_bearing_mint::InterestBearingConfig, scaled_ui_amount::ScaledUiAmountConfig,
     },
     std::collections::HashMap,
@@ -34,7 +34,10 @@ pub static PARSABLE_PROGRAM_IDS: std::sync::LazyLock<HashMap<Pubkey, ParsableAcc
         m.insert(config::id(), ParsableAccount::Config);
         m.insert(system_program::id(), ParsableAccount::Nonce);
         m.insert(spl_token::id(), ParsableAccount::SplToken);
-        m.insert(spl_token_2022::id(), ParsableAccount::SplToken2022);
+        m.insert(
+            spl_token_2022_interface::id(),
+            ParsableAccount::SplToken2022,
+        );
         m.insert(stake::id(), ParsableAccount::Stake);
         m.insert(sysvar::id(), ParsableAccount::Sysvar);
         m.insert(vote::id(), ParsableAccount::Vote);

--- a/account-decoder/src/parse_token.rs
+++ b/account-decoder/src/parse_token.rs
@@ -6,7 +6,7 @@ use {
     solana_program_option::COption,
     solana_program_pack::Pack,
     solana_pubkey::Pubkey,
-    spl_token_2022::{
+    spl_token_2022_interface::{
         extension::{BaseStateWithExtensions, StateWithExtensions},
         generic_token_account::GenericTokenAccount,
         state::{Account, AccountState, Mint, Multisig},
@@ -176,7 +176,7 @@ mod test {
         crate::parse_token_extension::{UiMemoTransfer, UiMintCloseAuthority},
         solana_account_decoder_client_types::token::UiExtension,
         spl_pod::optional_keys::OptionalNonZeroPubkey,
-        spl_token_2022::extension::{
+        spl_token_2022_interface::extension::{
             immutable_owner::ImmutableOwner, interest_bearing_mint::InterestBearingConfig,
             memo_transfer::MemoTransfer, mint_close_authority::MintCloseAuthority,
             scaled_ui_amount::ScaledUiAmountConfig, BaseStateWithExtensionsMut, ExtensionType,

--- a/account-decoder/src/parse_token_extension.rs
+++ b/account-decoder/src/parse_token_extension.rs
@@ -11,7 +11,7 @@ use {
     solana_clock::UnixTimestamp,
     solana_program_pack::Pack,
     solana_pubkey::Pubkey,
-    spl_token_2022::{
+    spl_token_2022_interface::{
         extension::{self, BaseState, BaseStateWithExtensions, ExtensionType, StateWithExtensions},
         solana_zk_sdk::encryption::pod::elgamal::PodElGamalPubkey,
     },
@@ -202,8 +202,9 @@ fn convert_mint_close_authority(
 fn convert_default_account_state(
     default_account_state: extension::default_account_state::DefaultAccountState,
 ) -> UiDefaultAccountState {
-    let account_state = spl_token_2022::state::AccountState::try_from(default_account_state.state)
-        .unwrap_or_default();
+    let account_state =
+        spl_token_2022_interface::state::AccountState::try_from(default_account_state.state)
+            .unwrap_or_default();
     UiDefaultAccountState {
         account_state: convert_account_state(account_state),
     }

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -112,8 +112,6 @@ solana-transaction-status = { workspace = true }
 solana-vote = { workspace = true }
 solana-vote-program = { workspace = true }
 solana-votor-messages = { workspace = true }
-spl-token = { workspace = true, features = ["no-entrypoint"] }
-spl-token-2022 = { workspace = true, features = ["no-entrypoint"] }
 static_assertions = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
 strum_macros = { workspace = true }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5608,7 +5608,7 @@ dependencies = [
  "solana-vote-interface",
  "spl-generic-token",
  "spl-token",
- "spl-token-2022",
+ "spl-token-2022-interface",
  "spl-token-group-interface",
  "spl-token-metadata-interface",
  "thiserror 2.0.12",
@@ -6475,9 +6475,9 @@ version = "3.0.0"
 
 [[package]]
 name = "solana-curve25519"
-version = "2.2.15"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def3cfe5279edb64fc39111cff6dcf77b01fbfba2c02c13ced41e6a48baf4cbe"
+checksum = "b162f50499b391b785d57b2f2c73e3b9754d88fd4894bef444960b00bda8dcca"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -7103,8 +7103,6 @@ dependencies = [
  "solana-vote",
  "solana-vote-program",
  "solana-votor-messages",
- "spl-token",
- "spl-token-2022",
  "static_assertions",
  "strum",
  "strum_macros",
@@ -7914,7 +7912,7 @@ dependencies = [
  "solana-vote-program",
  "spl-generic-token",
  "spl-token",
- "spl-token-2022",
+ "spl-token-2022-interface",
  "stream-cancel",
  "thiserror 2.0.12",
  "tokio",
@@ -9008,12 +9006,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-security-txt"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
-
-[[package]]
 name = "solana-seed-derivable"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9804,7 +9796,7 @@ dependencies = [
  "spl-associated-token-account-interface",
  "spl-memo",
  "spl-token",
- "spl-token-2022",
+ "spl-token-2022-interface",
  "spl-token-group-interface",
  "spl-token-metadata-interface",
  "thiserror 2.0.12",
@@ -10172,9 +10164,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-sdk"
-version = "2.2.15"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15045540c315a9b8ea056323e73320e76098dfdaac9e65b1b33fe9c2f3c9b9e1"
+checksum = "3bb171c0f76c420a7cb6aabbe5fa85a1a009d5bb4009189c43e1a03aff9446d7"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
@@ -10184,7 +10176,6 @@ dependencies = [
  "curve25519-dalek 4.1.3",
  "itertools 0.12.1",
  "js-sys",
- "lazy_static",
  "merlin",
  "num-derive",
  "num-traits",
@@ -10354,29 +10345,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spl-elgamal-registry"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65edfeed09cd4231e595616aa96022214f9c9d2be02dea62c2b30d5695a6833a"
-dependencies = [
- "bytemuck",
- "solana-account-info",
- "solana-cpi",
- "solana-instruction",
- "solana-msg",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-pubkey",
- "solana-rent",
- "solana-sdk-ids",
- "solana-system-interface",
- "solana-sysvar",
- "solana-zk-sdk 2.2.15",
- "spl-pod",
- "spl-token-confidential-transfer-proof-extraction",
-]
-
-[[package]]
 name = "spl-generic-token"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10416,56 +10384,7 @@ dependencies = [
  "solana-program-error",
  "solana-program-option",
  "solana-pubkey",
- "solana-zk-sdk 2.2.15",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-program-error"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdebc8b42553070b75aa5106f071fef2eb798c64a7ec63375da4b1f058688c6"
-dependencies = [
- "num-derive",
- "num-traits",
- "solana-decode-error",
- "solana-msg",
- "solana-program-error",
- "spl-program-error-derive",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-program-error-derive"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2539e259c66910d78593475540e8072f0b10f0f61d7607bbf7593899ed52d0"
-dependencies = [
- "proc-macro2",
- "quote",
- "sha2 0.10.9",
- "syn 2.0.87",
-]
-
-[[package]]
-name = "spl-tlv-account-resolution"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1408e961215688715d5a1063cbdcf982de225c45f99c82b4f7d7e1dd22b998d7"
-dependencies = [
- "bytemuck",
- "num-derive",
- "num-traits",
- "solana-account-info",
- "solana-decode-error",
- "solana-instruction",
- "solana-msg",
- "solana-program-error",
- "solana-pubkey",
- "spl-discriminator",
- "spl-pod",
- "spl-program-error",
- "spl-type-length-value",
+ "solana-zk-sdk 2.3.7",
  "thiserror 2.0.12",
 ]
 
@@ -10498,10 +10417,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "spl-token-2022"
-version = "8.0.1"
+name = "spl-token-2022-interface"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f0dfbb079eebaee55e793e92ca5f433744f4b71ee04880bfd6beefba5973e5"
+checksum = "62d7ae2ee6b856f8ddcbdc3b3a9f4d2141582bbe150f93e5298ee97e0251fa04"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -10509,66 +10428,40 @@ dependencies = [
  "num-traits",
  "num_enum",
  "solana-account-info",
- "solana-clock",
- "solana-cpi",
  "solana-decode-error",
  "solana-instruction",
  "solana-msg",
- "solana-native-token",
- "solana-program-entrypoint",
  "solana-program-error",
- "solana-program-memory",
  "solana-program-option",
  "solana-program-pack",
  "solana-pubkey",
- "solana-rent",
  "solana-sdk-ids",
- "solana-security-txt",
- "solana-system-interface",
- "solana-sysvar",
- "solana-zk-sdk 2.2.15",
- "spl-elgamal-registry",
- "spl-memo",
+ "solana-zk-sdk 2.3.7",
  "spl-pod",
- "spl-token",
- "spl-token-confidential-transfer-ciphertext-arithmetic",
  "spl-token-confidential-transfer-proof-extraction",
  "spl-token-confidential-transfer-proof-generation",
  "spl-token-group-interface",
  "spl-token-metadata-interface",
- "spl-transfer-hook-interface",
  "spl-type-length-value",
  "thiserror 2.0.12",
 ]
 
 [[package]]
-name = "spl-token-confidential-transfer-ciphertext-arithmetic"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ab20faf7b5edaa79acd240e0f21d5a2ef936aa99ed98f698573a2825b299c4"
-dependencies = [
- "base64 0.22.1",
- "bytemuck",
- "solana-curve25519 2.2.15",
- "solana-zk-sdk 2.2.15",
-]
-
-[[package]]
 name = "spl-token-confidential-transfer-proof-extraction"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe2629860ff04c17bafa9ba4bed8850a404ecac81074113e1f840dbd0ebb7bd6"
+checksum = "512c85bdbbb4cbcc2038849a9e164c958b16541f252b53ea1a3933191c0a4a1a"
 dependencies = [
  "bytemuck",
  "solana-account-info",
- "solana-curve25519 2.2.15",
+ "solana-curve25519 2.3.7",
  "solana-instruction",
  "solana-instructions-sysvar",
  "solana-msg",
  "solana-program-error",
  "solana-pubkey",
  "solana-sdk-ids",
- "solana-zk-sdk 2.2.15",
+ "solana-zk-sdk 2.3.7",
  "spl-pod",
  "thiserror 2.0.12",
 ]
@@ -10580,7 +10473,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae5b124840d4aed474cef101d946a798b806b46a509ee4df91021e1ab1cef3ef"
 dependencies = [
  "curve25519-dalek 4.1.3",
- "solana-zk-sdk 2.2.15",
+ "solana-zk-sdk 2.3.7",
  "thiserror 2.0.12",
 ]
 
@@ -10620,31 +10513,6 @@ dependencies = [
  "solana-pubkey",
  "spl-discriminator",
  "spl-pod",
- "spl-type-length-value",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-transfer-hook-interface"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7e905b849b6aba63bde8c4badac944ebb6c8e6e14817029cbe1bc16829133bd"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive",
- "num-traits",
- "solana-account-info",
- "solana-cpi",
- "solana-decode-error",
- "solana-instruction",
- "solana-msg",
- "solana-program-error",
- "solana-pubkey",
- "spl-discriminator",
- "spl-pod",
- "spl-program-error",
- "spl-tlv-account-resolution",
  "spl-type-length-value",
  "thiserror 2.0.12",
 ]

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -266,7 +266,7 @@ name = "bpf_loader"
 #  * spl-memo
 #  * spl-pod
 #  * spl-token
-#  * spl-token-2022
+#  * spl-token-2022-interface
 #  * spl-token-metadata-interface
 #
 # They are included indirectly, for example, `account-decoder` depends on

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -96,7 +96,7 @@ solana-vote = { workspace = true }
 solana-vote-program = { workspace = true }
 spl-generic-token = { workspace = true }
 spl-token = { workspace = true, features = ["no-entrypoint"] }
-spl-token-2022 = { workspace = true, features = ["no-entrypoint"] }
+spl-token-2022-interface = { workspace = true }
 stream-cancel = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/rpc/src/parsed_token_accounts.rs
+++ b/rpc/src/parsed_token_accounts.rs
@@ -11,7 +11,7 @@ use {
     solana_pubkey::Pubkey,
     solana_rpc_client_api::response::RpcKeyedAccount,
     solana_runtime::bank::Bank,
-    spl_token_2022::{
+    spl_token_2022_interface::{
         extension::{
             interest_bearing_mint::InterestBearingConfig, scaled_ui_amount::ScaledUiAmountConfig,
             BaseStateWithExtensions, StateWithExtensions,

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -97,7 +97,7 @@ use {
         token::{SPL_TOKEN_ACCOUNT_MINT_OFFSET, SPL_TOKEN_ACCOUNT_OWNER_OFFSET},
         token_2022::{self, ACCOUNTTYPE_ACCOUNT},
     },
-    spl_token_2022::{
+    spl_token_2022_interface::{
         extension::{
             interest_bearing_mint::InterestBearingConfig, scaled_ui_amount::ScaledUiAmountConfig,
             BaseStateWithExtensions, StateWithExtensions,
@@ -4555,7 +4555,7 @@ pub mod tests {
             vote_state::{self, TowerSync, VoteInit, VoteStateVersions, MAX_LOCKOUT_HISTORY},
         },
         spl_pod::optional_keys::OptionalNonZeroPubkey,
-        spl_token_2022::{
+        spl_token_2022_interface::{
             extension::{
                 immutable_owner::ImmutableOwner, memo_transfer::MemoTransfer,
                 mint_close_authority::MintCloseAuthority, BaseStateWithExtensionsMut,
@@ -8300,8 +8300,8 @@ pub mod tests {
     }
 
     #[test_case(spl_token::id(), None, None; "spl_token")]
-    #[test_case(spl_token_2022::id(), Some(InterestBearingConfig { pre_update_average_rate: 500.into(), current_rate: 500.into(),..Default::default() }), None; "spl_token_2022_with _interest")]
-    #[test_case(spl_token_2022::id(), None, Some(ScaledUiAmountConfig { new_multiplier: 2.0f64.into(), ..Default::default() }); "spl-token-2022 with multiplier")]
+    #[test_case(spl_token_2022_interface::id(), Some(InterestBearingConfig { pre_update_average_rate: 500.into(), current_rate: 500.into(),..Default::default() }), None; "spl_token_2022_with _interest")]
+    #[test_case(spl_token_2022_interface::id(), None, Some(ScaledUiAmountConfig { new_multiplier: 2.0f64.into(), ..Default::default() }); "spl-token-2022 with multiplier")]
     fn test_token_parsing(
         program_id: Pubkey,
         mut interest_bearing_config: Option<InterestBearingConfig>,

--- a/svm/examples/Cargo.lock
+++ b/svm/examples/Cargo.lock
@@ -3107,7 +3107,7 @@ dependencies = [
  "solana-transaction-status",
  "solana-validator-exit",
  "solana-version",
- "spl-token-2022",
+ "spl-token-2022-interface",
  "tokio",
  "tokio-util 0.7.15",
 ]
@@ -5441,7 +5441,7 @@ dependencies = [
  "solana-vote-interface",
  "spl-generic-token",
  "spl-token",
- "spl-token-2022",
+ "spl-token-2022-interface",
  "spl-token-group-interface",
  "spl-token-metadata-interface",
  "thiserror 2.0.12",
@@ -6308,9 +6308,9 @@ version = "3.0.0"
 
 [[package]]
 name = "solana-curve25519"
-version = "2.2.15"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def3cfe5279edb64fc39111cff6dcf77b01fbfba2c02c13ced41e6a48baf4cbe"
+checksum = "b162f50499b391b785d57b2f2c73e3b9754d88fd4894bef444960b00bda8dcca"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -6901,8 +6901,6 @@ dependencies = [
  "solana-vote",
  "solana-vote-program",
  "solana-votor-messages",
- "spl-token",
- "spl-token-2022",
  "static_assertions",
  "strum",
  "strum_macros",
@@ -7712,7 +7710,7 @@ dependencies = [
  "solana-vote-program",
  "spl-generic-token",
  "spl-token",
- "spl-token-2022",
+ "spl-token-2022-interface",
  "stream-cancel",
  "thiserror 2.0.12",
  "tokio",
@@ -8056,12 +8054,6 @@ dependencies = [
  "solana-precompile-error",
  "solana-sdk-ids",
 ]
-
-[[package]]
-name = "solana-security-txt"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
 
 [[package]]
 name = "solana-seed-derivable"
@@ -8890,7 +8882,7 @@ dependencies = [
  "spl-associated-token-account-interface",
  "spl-memo",
  "spl-token",
- "spl-token-2022",
+ "spl-token-2022-interface",
  "spl-token-group-interface",
  "spl-token-metadata-interface",
  "thiserror 2.0.12",
@@ -9255,9 +9247,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-sdk"
-version = "2.2.15"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15045540c315a9b8ea056323e73320e76098dfdaac9e65b1b33fe9c2f3c9b9e1"
+checksum = "3bb171c0f76c420a7cb6aabbe5fa85a1a009d5bb4009189c43e1a03aff9446d7"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
@@ -9267,7 +9259,6 @@ dependencies = [
  "curve25519-dalek 4.1.3",
  "itertools 0.12.1",
  "js-sys",
- "lazy_static",
  "merlin",
  "num-derive",
  "num-traits",
@@ -9437,29 +9428,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spl-elgamal-registry"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65edfeed09cd4231e595616aa96022214f9c9d2be02dea62c2b30d5695a6833a"
-dependencies = [
- "bytemuck",
- "solana-account-info",
- "solana-cpi",
- "solana-instruction",
- "solana-msg",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-pubkey",
- "solana-rent",
- "solana-sdk-ids",
- "solana-system-interface",
- "solana-sysvar",
- "solana-zk-sdk 2.2.15",
- "spl-pod",
- "spl-token-confidential-transfer-proof-extraction",
-]
-
-[[package]]
 name = "spl-generic-token"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9499,56 +9467,7 @@ dependencies = [
  "solana-program-error",
  "solana-program-option",
  "solana-pubkey",
- "solana-zk-sdk 2.2.15",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-program-error"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdebc8b42553070b75aa5106f071fef2eb798c64a7ec63375da4b1f058688c6"
-dependencies = [
- "num-derive",
- "num-traits",
- "solana-decode-error",
- "solana-msg",
- "solana-program-error",
- "spl-program-error-derive",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-program-error-derive"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2539e259c66910d78593475540e8072f0b10f0f61d7607bbf7593899ed52d0"
-dependencies = [
- "proc-macro2",
- "quote",
- "sha2 0.10.9",
- "syn 2.0.96",
-]
-
-[[package]]
-name = "spl-tlv-account-resolution"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1408e961215688715d5a1063cbdcf982de225c45f99c82b4f7d7e1dd22b998d7"
-dependencies = [
- "bytemuck",
- "num-derive",
- "num-traits",
- "solana-account-info",
- "solana-decode-error",
- "solana-instruction",
- "solana-msg",
- "solana-program-error",
- "solana-pubkey",
- "spl-discriminator",
- "spl-pod",
- "spl-program-error",
- "spl-type-length-value",
+ "solana-zk-sdk 2.3.7",
  "thiserror 2.0.12",
 ]
 
@@ -9581,10 +9500,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "spl-token-2022"
-version = "8.0.1"
+name = "spl-token-2022-interface"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f0dfbb079eebaee55e793e92ca5f433744f4b71ee04880bfd6beefba5973e5"
+checksum = "62d7ae2ee6b856f8ddcbdc3b3a9f4d2141582bbe150f93e5298ee97e0251fa04"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -9592,66 +9511,40 @@ dependencies = [
  "num-traits",
  "num_enum",
  "solana-account-info",
- "solana-clock",
- "solana-cpi",
  "solana-decode-error",
  "solana-instruction",
  "solana-msg",
- "solana-native-token",
- "solana-program-entrypoint",
  "solana-program-error",
- "solana-program-memory",
  "solana-program-option",
  "solana-program-pack",
  "solana-pubkey",
- "solana-rent",
  "solana-sdk-ids",
- "solana-security-txt",
- "solana-system-interface",
- "solana-sysvar",
- "solana-zk-sdk 2.2.15",
- "spl-elgamal-registry",
- "spl-memo",
+ "solana-zk-sdk 2.3.7",
  "spl-pod",
- "spl-token",
- "spl-token-confidential-transfer-ciphertext-arithmetic",
  "spl-token-confidential-transfer-proof-extraction",
  "spl-token-confidential-transfer-proof-generation",
  "spl-token-group-interface",
  "spl-token-metadata-interface",
- "spl-transfer-hook-interface",
  "spl-type-length-value",
  "thiserror 2.0.12",
 ]
 
 [[package]]
-name = "spl-token-confidential-transfer-ciphertext-arithmetic"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ab20faf7b5edaa79acd240e0f21d5a2ef936aa99ed98f698573a2825b299c4"
-dependencies = [
- "base64 0.22.1",
- "bytemuck",
- "solana-curve25519 2.2.15",
- "solana-zk-sdk 2.2.15",
-]
-
-[[package]]
 name = "spl-token-confidential-transfer-proof-extraction"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe2629860ff04c17bafa9ba4bed8850a404ecac81074113e1f840dbd0ebb7bd6"
+checksum = "512c85bdbbb4cbcc2038849a9e164c958b16541f252b53ea1a3933191c0a4a1a"
 dependencies = [
  "bytemuck",
  "solana-account-info",
- "solana-curve25519 2.2.15",
+ "solana-curve25519 2.3.7",
  "solana-instruction",
  "solana-instructions-sysvar",
  "solana-msg",
  "solana-program-error",
  "solana-pubkey",
  "solana-sdk-ids",
- "solana-zk-sdk 2.2.15",
+ "solana-zk-sdk 2.3.7",
  "spl-pod",
  "thiserror 2.0.12",
 ]
@@ -9663,7 +9556,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae5b124840d4aed474cef101d946a798b806b46a509ee4df91021e1ab1cef3ef"
 dependencies = [
  "curve25519-dalek 4.1.3",
- "solana-zk-sdk 2.2.15",
+ "solana-zk-sdk 2.3.7",
  "thiserror 2.0.12",
 ]
 
@@ -9703,31 +9596,6 @@ dependencies = [
  "solana-pubkey",
  "spl-discriminator",
  "spl-pod",
- "spl-type-length-value",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-transfer-hook-interface"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7e905b849b6aba63bde8c4badac944ebb6c8e6e14817029cbe1bc16829133bd"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive",
- "num-traits",
- "solana-account-info",
- "solana-cpi",
- "solana-decode-error",
- "solana-instruction",
- "solana-msg",
- "solana-program-error",
- "solana-pubkey",
- "spl-discriminator",
- "spl-pod",
- "spl-program-error",
- "spl-tlv-account-resolution",
  "spl-type-length-value",
  "thiserror 2.0.12",
 ]

--- a/svm/examples/Cargo.toml
+++ b/svm/examples/Cargo.toml
@@ -70,7 +70,7 @@ solana-validator-exit = "2.2.1"
 solana-version = { path = "../../version" }
 spl-associated-token-account-interface = "1.0.0"
 spl-token = "8.0.0"
-spl-token-2022 = "8.0.0"
+spl-token-2022-interface = "1.0.0"
 termcolor = "1.4.1"
 thiserror = "1.0.68"
 tokio = "1.29.1"

--- a/svm/examples/json-rpc/server/Cargo.toml
+++ b/svm/examples/json-rpc/server/Cargo.toml
@@ -54,6 +54,6 @@ solana-transaction-error = { workspace = true }
 solana-transaction-status = { workspace = true }
 solana-validator-exit = { workspace = true }
 solana-version = { workspace = true }
-spl-token-2022 = { workspace = true, features = ["no-entrypoint"] }
+spl-token-2022-interface = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-util = { workspace = true, features = ["codec", "compat"] }

--- a/svm/examples/json-rpc/server/src/rpc_process.rs
+++ b/svm/examples/json-rpc/server/src/rpc_process.rs
@@ -62,7 +62,7 @@ use {
         UiTransactionEncoding,
     },
     solana_validator_exit::Exit,
-    spl_token_2022::{
+    spl_token_2022_interface::{
         extension::{
             interest_bearing_mint::InterestBearingConfig, scaled_ui_amount::ScaledUiAmountConfig,
             BaseStateWithExtensions, StateWithExtensions,

--- a/transaction-status/Cargo.toml
+++ b/transaction-status/Cargo.toml
@@ -45,7 +45,7 @@ solana-vote-interface = { workspace = true }
 spl-associated-token-account-interface = { workspace = true, features = ["borsh"] }
 spl-memo = { workspace = true, features = ["no-entrypoint"] }
 spl-token = { workspace = true, features = ["no-entrypoint"] }
-spl-token-2022 = { workspace = true, features = ["no-entrypoint"] }
+spl-token-2022-interface = { workspace = true }
 spl-token-group-interface = { workspace = true }
 spl-token-metadata-interface = { workspace = true }
 thiserror = { workspace = true }

--- a/transaction-status/src/parse_token.rs
+++ b/transaction-status/src/parse_token.rs
@@ -16,7 +16,7 @@ use {
     solana_message::{compiled_instruction::CompiledInstruction, AccountKeys},
     solana_program_option::COption,
     solana_pubkey::Pubkey,
-    spl_token_2022::{
+    spl_token_2022_interface::{
         extension::ExtensionType,
         instruction::{AuthorityType, TokenInstruction},
     },
@@ -886,8 +886,8 @@ fn map_coption_pubkey(pubkey: COption<Pubkey>) -> Option<String> {
 #[cfg(test)]
 mod test {
     use {
-        super::*, solana_message::Message, solana_pubkey::Pubkey, spl_token_2022::instruction::*,
-        std::iter::repeat_with,
+        super::*, solana_message::Message, solana_pubkey::Pubkey,
+        spl_token_2022_interface::instruction::*, std::iter::repeat_with,
     };
 
     fn test_parse_token(program_id: &Pubkey) {
@@ -1776,13 +1776,14 @@ mod test {
 
     #[test]
     fn test_parse_token_2022() {
-        test_parse_token(&spl_token_2022::id());
+        test_parse_token(&spl_token_2022_interface::id());
     }
 
     #[test]
     fn test_create_native_mint() {
         let payer = Pubkey::new_unique();
-        let create_native_mint_ix = create_native_mint(&spl_token_2022::id(), &payer).unwrap();
+        let create_native_mint_ix =
+            create_native_mint(&spl_token_2022_interface::id(), &payer).unwrap();
         let message = Message::new(&[create_native_mint_ix], None);
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
@@ -1795,7 +1796,7 @@ mod test {
                 instruction_type: "createNativeMint".to_string(),
                 info: json!({
                    "payer": payer.to_string(),
-                   "nativeMint": spl_token_2022::native_mint::id().to_string(),
+                   "nativeMint": spl_token_2022_interface::native_mint::id().to_string(),
                    "systemProgram": solana_sdk_ids::system_program::id().to_string(),
                 })
             }
@@ -2154,6 +2155,6 @@ mod test {
 
     #[test]
     fn test_not_enough_keys_token_2022() {
-        test_token_ix_not_enough_keys(&spl_token_2022::id());
+        test_token_ix_not_enough_keys(&spl_token_2022_interface::id());
     }
 }

--- a/transaction-status/src/parse_token/extension/confidential_mint_burn.rs
+++ b/transaction-status/src/parse_token/extension/confidential_mint_burn.rs
@@ -1,6 +1,6 @@
 use {
     super::*,
-    spl_token_2022::{
+    spl_token_2022_interface::{
         extension::confidential_mint_burn::instruction::*,
         instruction::{decode_instruction_data, decode_instruction_type},
     },
@@ -284,7 +284,7 @@ mod test {
         solana_instruction::{AccountMeta, Instruction},
         solana_message::Message,
         solana_pubkey::Pubkey,
-        spl_token_2022::{
+        spl_token_2022_interface::{
             extension::confidential_mint_burn::instruction::{
                 confidential_burn_with_split_proofs, confidential_mint_with_split_proofs,
                 initialize_mint,
@@ -300,7 +300,7 @@ mod test {
                 },
             },
         },
-        spl_token_confidential_transfer_proof_extraction::instruction::{ProofData, ProofLocation},
+        spl_token_confidential_transfer_proof_extraction::instruction::ProofLocation,
         std::num::NonZero,
     };
 
@@ -320,7 +320,7 @@ mod test {
     #[test]
     fn test_initialize() {
         let instruction = initialize_mint(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &Pubkey::new_unique(),
             &PodElGamalPubkey::default(),
             &PodAeCiphertext::default(),
@@ -332,7 +332,7 @@ mod test {
     #[test]
     fn test_update() {
         let instruction = update_decryptable_supply(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &Pubkey::new_unique(),
             &Pubkey::new_unique(),
             &[],
@@ -347,16 +347,12 @@ mod test {
         for location in [
             ProofLocation::InstructionOffset(
                 NonZero::new(1).unwrap(),
-                ProofData::InstructionData(&CiphertextCiphertextEqualityProofData::zeroed()),
-            ),
-            ProofLocation::InstructionOffset(
-                NonZero::new(1).unwrap(),
-                ProofData::RecordAccount(&Pubkey::new_unique(), 0),
+                &CiphertextCiphertextEqualityProofData::zeroed(),
             ),
             ProofLocation::ContextStateAccount(&Pubkey::new_unique()),
         ] {
             let instructions = rotate_supply_elgamal_pubkey(
-                &spl_token_2022::id(),
+                &spl_token_2022_interface::id(),
                 &Pubkey::new_unique(),
                 &Pubkey::new_unique(),
                 &[],
@@ -374,31 +370,15 @@ mod test {
             (
                 ProofLocation::InstructionOffset(
                     NonZero::new(1).unwrap(),
-                    ProofData::InstructionData(&CiphertextCommitmentEqualityProofData::zeroed()),
+                    &CiphertextCommitmentEqualityProofData::zeroed(),
                 ),
                 ProofLocation::InstructionOffset(
                     NonZero::new(2).unwrap(),
-                    ProofData::InstructionData(
-                        &BatchedGroupedCiphertext3HandlesValidityProofData::zeroed(),
-                    ),
+                    &BatchedGroupedCiphertext3HandlesValidityProofData::zeroed(),
                 ),
                 ProofLocation::InstructionOffset(
                     NonZero::new(3).unwrap(),
-                    ProofData::InstructionData(&BatchedRangeProofU128Data::zeroed()),
-                ),
-            ),
-            (
-                ProofLocation::InstructionOffset(
-                    NonZero::new(1).unwrap(),
-                    ProofData::RecordAccount(&Pubkey::new_unique(), 0),
-                ),
-                ProofLocation::InstructionOffset(
-                    NonZero::new(2).unwrap(),
-                    ProofData::RecordAccount(&Pubkey::new_unique(), 0),
-                ),
-                ProofLocation::InstructionOffset(
-                    NonZero::new(3).unwrap(),
-                    ProofData::RecordAccount(&Pubkey::new_unique(), 0),
+                    &BatchedRangeProofU128Data::zeroed(),
                 ),
             ),
             (
@@ -408,7 +388,7 @@ mod test {
             ),
         ] {
             let instructions = confidential_mint_with_split_proofs(
-                &spl_token_2022::id(),
+                &spl_token_2022_interface::id(),
                 &Pubkey::new_unique(),
                 &Pubkey::new_unique(),
                 &PodElGamalCiphertext::default(),
@@ -431,31 +411,15 @@ mod test {
             (
                 ProofLocation::InstructionOffset(
                     NonZero::new(1).unwrap(),
-                    ProofData::InstructionData(&CiphertextCommitmentEqualityProofData::zeroed()),
+                    &CiphertextCommitmentEqualityProofData::zeroed(),
                 ),
                 ProofLocation::InstructionOffset(
                     NonZero::new(2).unwrap(),
-                    ProofData::InstructionData(
-                        &BatchedGroupedCiphertext3HandlesValidityProofData::zeroed(),
-                    ),
+                    &BatchedGroupedCiphertext3HandlesValidityProofData::zeroed(),
                 ),
                 ProofLocation::InstructionOffset(
                     NonZero::new(3).unwrap(),
-                    ProofData::InstructionData(&BatchedRangeProofU128Data::zeroed()),
-                ),
-            ),
-            (
-                ProofLocation::InstructionOffset(
-                    NonZero::new(1).unwrap(),
-                    ProofData::RecordAccount(&Pubkey::new_unique(), 0),
-                ),
-                ProofLocation::InstructionOffset(
-                    NonZero::new(2).unwrap(),
-                    ProofData::RecordAccount(&Pubkey::new_unique(), 0),
-                ),
-                ProofLocation::InstructionOffset(
-                    NonZero::new(3).unwrap(),
-                    ProofData::RecordAccount(&Pubkey::new_unique(), 0),
+                    &BatchedRangeProofU128Data::zeroed(),
                 ),
             ),
             (
@@ -465,7 +429,7 @@ mod test {
             ),
         ] {
             let instructions = confidential_burn_with_split_proofs(
-                &spl_token_2022::id(),
+                &spl_token_2022_interface::id(),
                 &Pubkey::new_unique(),
                 &Pubkey::new_unique(),
                 &PodAeCiphertext::default(),

--- a/transaction-status/src/parse_token/extension/confidential_transfer.rs
+++ b/transaction-status/src/parse_token/extension/confidential_transfer.rs
@@ -1,6 +1,6 @@
 use {
     super::*,
-    spl_token_2022::{
+    spl_token_2022_interface::{
         extension::confidential_transfer::instruction::*,
         instruction::{decode_instruction_data, decode_instruction_type},
         solana_zk_sdk::encryption::pod::elgamal::PodElGamalPubkey,
@@ -600,7 +600,7 @@ mod test {
         solana_instruction::{AccountMeta, Instruction},
         solana_message::Message,
         solana_pubkey::Pubkey,
-        spl_token_2022::{
+        spl_token_2022_interface::{
             extension::confidential_transfer::instruction::{
                 initialize_mint, inner_configure_account, inner_empty_account, update_mint,
             },
@@ -614,7 +614,7 @@ mod test {
                 },
             },
         },
-        spl_token_confidential_transfer_proof_extraction::instruction::{ProofData, ProofLocation},
+        spl_token_confidential_transfer_proof_extraction::instruction::ProofLocation,
         std::num::NonZero,
     };
 
@@ -634,7 +634,7 @@ mod test {
     #[test]
     fn test_initialize() {
         let instruction = initialize_mint(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &Pubkey::new_unique(),
             Some(Pubkey::new_unique()),
             true,
@@ -647,7 +647,7 @@ mod test {
     #[test]
     fn test_approve() {
         let instruction = approve_account(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &Pubkey::new_unique(),
             &Pubkey::new_unique(),
             &Pubkey::new_unique(),
@@ -660,7 +660,7 @@ mod test {
     #[test]
     fn test_update() {
         let instruction = update_mint(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &Pubkey::new_unique(),
             &Pubkey::new_unique(),
             &[],
@@ -676,16 +676,12 @@ mod test {
         for location in [
             ProofLocation::InstructionOffset(
                 NonZero::new(1).unwrap(),
-                ProofData::InstructionData(&PubkeyValidityProofData::zeroed()),
-            ),
-            ProofLocation::InstructionOffset(
-                NonZero::new(1).unwrap(),
-                ProofData::RecordAccount(&Pubkey::new_unique(), 0),
+                &PubkeyValidityProofData::zeroed(),
             ),
             ProofLocation::ContextStateAccount(&Pubkey::new_unique()),
         ] {
             let instruction = inner_configure_account(
-                &spl_token_2022::id(),
+                &spl_token_2022_interface::id(),
                 &Pubkey::new_unique(),
                 &Pubkey::new_unique(),
                 &PodAeCiphertext::default(),
@@ -704,16 +700,12 @@ mod test {
         for location in [
             ProofLocation::InstructionOffset(
                 NonZero::new(1).unwrap(),
-                ProofData::InstructionData(&ZeroCiphertextProofData::zeroed()),
-            ),
-            ProofLocation::InstructionOffset(
-                NonZero::new(1).unwrap(),
-                ProofData::RecordAccount(&Pubkey::new_unique(), 0),
+                &ZeroCiphertextProofData::zeroed(),
             ),
             ProofLocation::ContextStateAccount(&Pubkey::new_unique()),
         ] {
             let instruction = inner_empty_account(
-                &spl_token_2022::id(),
+                &spl_token_2022_interface::id(),
                 &Pubkey::new_unique(),
                 &Pubkey::new_unique(),
                 &[],
@@ -730,21 +722,11 @@ mod test {
             (
                 ProofLocation::InstructionOffset(
                     NonZero::new(1).unwrap(),
-                    ProofData::InstructionData(&CiphertextCommitmentEqualityProofData::zeroed()),
+                    &CiphertextCommitmentEqualityProofData::zeroed(),
                 ),
                 ProofLocation::InstructionOffset(
                     NonZero::new(3).unwrap(),
-                    ProofData::InstructionData(&BatchedRangeProofU64Data::zeroed()),
-                ),
-            ),
-            (
-                ProofLocation::InstructionOffset(
-                    NonZero::new(1).unwrap(),
-                    ProofData::RecordAccount(&Pubkey::new_unique(), 0),
-                ),
-                ProofLocation::InstructionOffset(
-                    NonZero::new(2).unwrap(),
-                    ProofData::RecordAccount(&Pubkey::new_unique(), 0),
+                    &BatchedRangeProofU64Data::zeroed(),
                 ),
             ),
             (
@@ -753,7 +735,7 @@ mod test {
             ),
         ] {
             let instruction = inner_withdraw(
-                &spl_token_2022::id(),
+                &spl_token_2022_interface::id(),
                 &Pubkey::new_unique(),
                 &Pubkey::new_unique(),
                 1,
@@ -775,31 +757,15 @@ mod test {
             (
                 ProofLocation::InstructionOffset(
                     NonZero::new(1).unwrap(),
-                    ProofData::InstructionData(&CiphertextCommitmentEqualityProofData::zeroed()),
+                    &CiphertextCommitmentEqualityProofData::zeroed(),
                 ),
                 ProofLocation::InstructionOffset(
                     NonZero::new(2).unwrap(),
-                    ProofData::InstructionData(
-                        &BatchedGroupedCiphertext3HandlesValidityProofData::zeroed(),
-                    ),
+                    &BatchedGroupedCiphertext3HandlesValidityProofData::zeroed(),
                 ),
                 ProofLocation::InstructionOffset(
                     NonZero::new(3).unwrap(),
-                    ProofData::InstructionData(&BatchedRangeProofU128Data::zeroed()),
-                ),
-            ),
-            (
-                ProofLocation::InstructionOffset(
-                    NonZero::new(1).unwrap(),
-                    ProofData::RecordAccount(&Pubkey::new_unique(), 0),
-                ),
-                ProofLocation::InstructionOffset(
-                    NonZero::new(2).unwrap(),
-                    ProofData::RecordAccount(&Pubkey::new_unique(), 0),
-                ),
-                ProofLocation::InstructionOffset(
-                    NonZero::new(3).unwrap(),
-                    ProofData::RecordAccount(&Pubkey::new_unique(), 0),
+                    &BatchedRangeProofU128Data::zeroed(),
                 ),
             ),
             (
@@ -809,7 +775,7 @@ mod test {
             ),
         ] {
             let instruction = inner_transfer(
-                &spl_token_2022::id(),
+                &spl_token_2022_interface::id(),
                 &Pubkey::new_unique(),
                 &Pubkey::new_unique(),
                 &Pubkey::new_unique(),
@@ -839,49 +805,23 @@ mod test {
             (
                 ProofLocation::InstructionOffset(
                     NonZero::new(1).unwrap(),
-                    ProofData::InstructionData(&CiphertextCommitmentEqualityProofData::zeroed()),
+                    &CiphertextCommitmentEqualityProofData::zeroed(),
                 ),
                 ProofLocation::InstructionOffset(
                     NonZero::new(2).unwrap(),
-                    ProofData::InstructionData(
-                        &BatchedGroupedCiphertext3HandlesValidityProofData::zeroed(),
-                    ),
+                    &BatchedGroupedCiphertext3HandlesValidityProofData::zeroed(),
                 ),
                 ProofLocation::InstructionOffset(
                     NonZero::new(3).unwrap(),
-                    ProofData::InstructionData(&PercentageWithCapProofData::zeroed()),
+                    &PercentageWithCapProofData::zeroed(),
                 ),
                 ProofLocation::InstructionOffset(
                     NonZero::new(4).unwrap(),
-                    ProofData::InstructionData(
-                        &BatchedGroupedCiphertext2HandlesValidityProofData::zeroed(),
-                    ),
+                    &BatchedGroupedCiphertext2HandlesValidityProofData::zeroed(),
                 ),
                 ProofLocation::InstructionOffset(
                     NonZero::new(5).unwrap(),
-                    ProofData::InstructionData(&BatchedRangeProofU256Data::zeroed()),
-                ),
-            ),
-            (
-                ProofLocation::InstructionOffset(
-                    NonZero::new(1).unwrap(),
-                    ProofData::RecordAccount(&Pubkey::new_unique(), 0),
-                ),
-                ProofLocation::InstructionOffset(
-                    NonZero::new(2).unwrap(),
-                    ProofData::RecordAccount(&Pubkey::new_unique(), 0),
-                ),
-                ProofLocation::InstructionOffset(
-                    NonZero::new(3).unwrap(),
-                    ProofData::RecordAccount(&Pubkey::new_unique(), 0),
-                ),
-                ProofLocation::InstructionOffset(
-                    NonZero::new(4).unwrap(),
-                    ProofData::RecordAccount(&Pubkey::new_unique(), 0),
-                ),
-                ProofLocation::InstructionOffset(
-                    NonZero::new(5).unwrap(),
-                    ProofData::RecordAccount(&Pubkey::new_unique(), 0),
+                    &BatchedRangeProofU256Data::zeroed(),
                 ),
             ),
             (
@@ -893,7 +833,7 @@ mod test {
             ),
         ] {
             let instruction = inner_transfer_with_fee(
-                &spl_token_2022::id(),
+                &spl_token_2022_interface::id(),
                 &Pubkey::new_unique(),
                 &Pubkey::new_unique(),
                 &Pubkey::new_unique(),

--- a/transaction-status/src/parse_token/extension/confidential_transfer_fee.rs
+++ b/transaction-status/src/parse_token/extension/confidential_transfer_fee.rs
@@ -1,6 +1,6 @@
 use {
     super::*,
-    spl_token_2022::{
+    spl_token_2022_interface::{
         extension::confidential_transfer_fee::instruction::*,
         instruction::{decode_instruction_data, decode_instruction_type},
         solana_zk_sdk::encryption::pod::elgamal::PodElGamalPubkey,
@@ -212,7 +212,7 @@ mod test {
         solana_instruction::{AccountMeta, Instruction},
         solana_message::Message,
         solana_pubkey::Pubkey,
-        spl_token_2022::{
+        spl_token_2022_interface::{
             extension::confidential_transfer_fee::instruction::{
                 inner_withdraw_withheld_tokens_from_accounts,
                 inner_withdraw_withheld_tokens_from_mint,
@@ -222,7 +222,7 @@ mod test {
                 zk_elgamal_proof_program::proof_data::CiphertextCiphertextEqualityProofData,
             },
         },
-        spl_token_confidential_transfer_proof_extraction::instruction::{ProofData, ProofLocation},
+        spl_token_confidential_transfer_proof_extraction::instruction::ProofLocation,
         std::num::NonZero,
     };
 
@@ -244,16 +244,12 @@ mod test {
         for location in [
             ProofLocation::InstructionOffset(
                 NonZero::new(1).unwrap(),
-                ProofData::InstructionData(&CiphertextCiphertextEqualityProofData::zeroed()),
-            ),
-            ProofLocation::InstructionOffset(
-                NonZero::new(1).unwrap(),
-                ProofData::RecordAccount(&Pubkey::new_unique(), 0),
+                &CiphertextCiphertextEqualityProofData::zeroed(),
             ),
             ProofLocation::ContextStateAccount(&Pubkey::new_unique()),
         ] {
             let instruction = inner_withdraw_withheld_tokens_from_accounts(
-                &spl_token_2022::id(),
+                &spl_token_2022_interface::id(),
                 &Pubkey::new_unique(),
                 &Pubkey::new_unique(),
                 &PodAeCiphertext::default(),
@@ -272,16 +268,12 @@ mod test {
         for location in [
             ProofLocation::InstructionOffset(
                 NonZero::new(1).unwrap(),
-                ProofData::InstructionData(&CiphertextCiphertextEqualityProofData::zeroed()),
-            ),
-            ProofLocation::InstructionOffset(
-                NonZero::new(1).unwrap(),
-                ProofData::RecordAccount(&Pubkey::new_unique(), 0),
+                &CiphertextCiphertextEqualityProofData::zeroed(),
             ),
             ProofLocation::ContextStateAccount(&Pubkey::new_unique()),
         ] {
             let instruction = inner_withdraw_withheld_tokens_from_mint(
-                &spl_token_2022::id(),
+                &spl_token_2022_interface::id(),
                 &Pubkey::new_unique(),
                 &Pubkey::new_unique(),
                 &PodAeCiphertext::default(),

--- a/transaction-status/src/parse_token/extension/cpi_guard.rs
+++ b/transaction-status/src/parse_token/extension/cpi_guard.rs
@@ -1,6 +1,6 @@
 use {
     super::*,
-    spl_token_2022::{
+    spl_token_2022_interface::{
         extension::cpi_guard::instruction::CpiGuardInstruction,
         instruction::decode_instruction_type,
     },
@@ -42,7 +42,9 @@ mod test {
         super::*,
         solana_message::Message,
         solana_pubkey::Pubkey,
-        spl_token_2022::extension::cpi_guard::instruction::{disable_cpi_guard, enable_cpi_guard},
+        spl_token_2022_interface::extension::cpi_guard::instruction::{
+            disable_cpi_guard, enable_cpi_guard,
+        },
     };
 
     #[test]
@@ -51,8 +53,13 @@ mod test {
 
         // Enable, single owner
         let owner_pubkey = Pubkey::new_unique();
-        let enable_cpi_guard_ix =
-            enable_cpi_guard(&spl_token_2022::id(), &account_pubkey, &owner_pubkey, &[]).unwrap();
+        let enable_cpi_guard_ix = enable_cpi_guard(
+            &spl_token_2022_interface::id(),
+            &account_pubkey,
+            &owner_pubkey,
+            &[],
+        )
+        .unwrap();
         let message = Message::new(&[enable_cpi_guard_ix], None);
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
@@ -75,7 +82,7 @@ mod test {
         let multisig_signer0 = Pubkey::new_unique();
         let multisig_signer1 = Pubkey::new_unique();
         let enable_cpi_guard_ix = enable_cpi_guard(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &account_pubkey,
             &multisig_pubkey,
             &[&multisig_signer0, &multisig_signer1],
@@ -103,8 +110,13 @@ mod test {
         );
 
         // Disable, single owner
-        let enable_cpi_guard_ix =
-            disable_cpi_guard(&spl_token_2022::id(), &account_pubkey, &owner_pubkey, &[]).unwrap();
+        let enable_cpi_guard_ix = disable_cpi_guard(
+            &spl_token_2022_interface::id(),
+            &account_pubkey,
+            &owner_pubkey,
+            &[],
+        )
+        .unwrap();
         let message = Message::new(&[enable_cpi_guard_ix], None);
         let compiled_instruction = &message.instructions[0];
         assert_eq!(
@@ -127,7 +139,7 @@ mod test {
         let multisig_signer0 = Pubkey::new_unique();
         let multisig_signer1 = Pubkey::new_unique();
         let enable_cpi_guard_ix = disable_cpi_guard(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &account_pubkey,
             &multisig_pubkey,
             &[&multisig_signer0, &multisig_signer1],

--- a/transaction-status/src/parse_token/extension/default_account_state.rs
+++ b/transaction-status/src/parse_token/extension/default_account_state.rs
@@ -1,7 +1,7 @@
 use {
     super::*,
     solana_account_decoder::parse_token::convert_account_state,
-    spl_token_2022::extension::default_account_state::instruction::{
+    spl_token_2022_interface::extension::default_account_state::instruction::{
         decode_instruction, DefaultAccountStateInstruction,
     },
 };
@@ -56,7 +56,7 @@ mod test {
         super::*,
         solana_message::Message,
         solana_pubkey::Pubkey,
-        spl_token_2022::{
+        spl_token_2022_interface::{
             extension::default_account_state::instruction::{
                 initialize_default_account_state, update_default_account_state,
             },
@@ -68,7 +68,7 @@ mod test {
     fn test_parse_default_account_state_instruction() {
         let mint_pubkey = Pubkey::new_unique();
         let init_default_account_state_ix = initialize_default_account_state(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &mint_pubkey,
             &AccountState::Frozen,
         )
@@ -93,7 +93,7 @@ mod test {
         // Single mint freeze_authority
         let mint_freeze_authority = Pubkey::new_unique();
         let update_default_account_state_ix = update_default_account_state(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &mint_pubkey,
             &mint_freeze_authority,
             &[],
@@ -123,7 +123,7 @@ mod test {
         let multisig_signer0 = Pubkey::new_unique();
         let multisig_signer1 = Pubkey::new_unique();
         let update_default_account_state_ix = update_default_account_state(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &mint_pubkey,
             &multisig_pubkey,
             &[&multisig_signer0, &multisig_signer1],

--- a/transaction-status/src/parse_token/extension/group_member_pointer.rs
+++ b/transaction-status/src/parse_token/extension/group_member_pointer.rs
@@ -1,6 +1,6 @@
 use {
     super::*,
-    spl_token_2022::{
+    spl_token_2022_interface::{
         extension::group_member_pointer::instruction::*,
         instruction::{decode_instruction_data, decode_instruction_type},
     },
@@ -84,7 +84,7 @@ mod test {
 
         // Initialize variations
         let init_ix = initialize(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &mint_pubkey,
             Some(authority),
             Some(member_address),
@@ -108,7 +108,8 @@ mod test {
             }
         );
 
-        let init_ix = initialize(&spl_token_2022::id(), &mint_pubkey, None, None).unwrap();
+        let init_ix =
+            initialize(&spl_token_2022_interface::id(), &mint_pubkey, None, None).unwrap();
         let mut message = Message::new(&[init_ix], None);
         let compiled_instruction = &mut message.instructions[0];
         assert_eq!(
@@ -127,7 +128,7 @@ mod test {
 
         // Single owner Update
         let update_ix = update(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &mint_pubkey,
             &authority,
             &[],
@@ -157,7 +158,7 @@ mod test {
         let multisig_signer0 = Pubkey::new_unique();
         let multisig_signer1 = Pubkey::new_unique();
         let update_ix = update(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &mint_pubkey,
             &multisig_pubkey,
             &[&multisig_signer0, &multisig_signer1],

--- a/transaction-status/src/parse_token/extension/group_pointer.rs
+++ b/transaction-status/src/parse_token/extension/group_pointer.rs
@@ -1,6 +1,6 @@
 use {
     super::*,
-    spl_token_2022::{
+    spl_token_2022_interface::{
         extension::group_pointer::instruction::*,
         instruction::{decode_instruction_data, decode_instruction_type},
     },
@@ -78,7 +78,7 @@ mod test {
 
         // Initialize variations
         let init_ix = initialize(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &mint_pubkey,
             Some(authority),
             Some(group_address),
@@ -102,7 +102,8 @@ mod test {
             }
         );
 
-        let init_ix = initialize(&spl_token_2022::id(), &mint_pubkey, None, None).unwrap();
+        let init_ix =
+            initialize(&spl_token_2022_interface::id(), &mint_pubkey, None, None).unwrap();
         let mut message = Message::new(&[init_ix], None);
         let compiled_instruction = &mut message.instructions[0];
         assert_eq!(
@@ -121,7 +122,7 @@ mod test {
 
         // Single owner Update
         let update_ix = update(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &mint_pubkey,
             &authority,
             &[],
@@ -151,7 +152,7 @@ mod test {
         let multisig_signer0 = Pubkey::new_unique();
         let multisig_signer1 = Pubkey::new_unique();
         let update_ix = update(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &mint_pubkey,
             &multisig_pubkey,
             &[&multisig_signer0, &multisig_signer1],

--- a/transaction-status/src/parse_token/extension/interest_bearing_mint.rs
+++ b/transaction-status/src/parse_token/extension/interest_bearing_mint.rs
@@ -1,6 +1,6 @@
 use {
     super::*,
-    spl_token_2022::{
+    spl_token_2022_interface::{
         extension::interest_bearing_mint::{
             instruction::{InitializeInstructionData, InterestBearingMintInstruction},
             BasisPoints,

--- a/transaction-status/src/parse_token/extension/memo_transfer.rs
+++ b/transaction-status/src/parse_token/extension/memo_transfer.rs
@@ -1,6 +1,6 @@
 use {
     super::*,
-    spl_token_2022::{
+    spl_token_2022_interface::{
         extension::memo_transfer::instruction::RequiredMemoTransfersInstruction,
         instruction::decode_instruction_type,
     },
@@ -42,7 +42,7 @@ mod test {
         super::*,
         solana_message::Message,
         solana_pubkey::Pubkey,
-        spl_token_2022::extension::memo_transfer::instruction::{
+        spl_token_2022_interface::extension::memo_transfer::instruction::{
             disable_required_transfer_memos, enable_required_transfer_memos,
         },
     };
@@ -54,7 +54,7 @@ mod test {
         // Enable, single owner
         let owner_pubkey = Pubkey::new_unique();
         let enable_memo_transfers_ix = enable_required_transfer_memos(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &account_pubkey,
             &owner_pubkey,
             &[],
@@ -82,7 +82,7 @@ mod test {
         let multisig_signer0 = Pubkey::new_unique();
         let multisig_signer1 = Pubkey::new_unique();
         let enable_memo_transfers_ix = enable_required_transfer_memos(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &account_pubkey,
             &multisig_pubkey,
             &[&multisig_signer0, &multisig_signer1],
@@ -111,7 +111,7 @@ mod test {
 
         // Disable, single owner
         let enable_memo_transfers_ix = disable_required_transfer_memos(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &account_pubkey,
             &owner_pubkey,
             &[],
@@ -139,7 +139,7 @@ mod test {
         let multisig_signer0 = Pubkey::new_unique();
         let multisig_signer1 = Pubkey::new_unique();
         let enable_memo_transfers_ix = disable_required_transfer_memos(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &account_pubkey,
             &multisig_pubkey,
             &[&multisig_signer0, &multisig_signer1],

--- a/transaction-status/src/parse_token/extension/metadata_pointer.rs
+++ b/transaction-status/src/parse_token/extension/metadata_pointer.rs
@@ -1,6 +1,6 @@
 use {
     super::*,
-    spl_token_2022::{
+    spl_token_2022_interface::{
         extension::metadata_pointer::instruction::*,
         instruction::{decode_instruction_data, decode_instruction_type},
     },
@@ -84,7 +84,7 @@ mod test {
 
         // Initialize variations
         let init_ix = initialize(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &mint_pubkey,
             Some(authority),
             Some(metadata_address),
@@ -108,7 +108,8 @@ mod test {
             }
         );
 
-        let init_ix = initialize(&spl_token_2022::id(), &mint_pubkey, None, None).unwrap();
+        let init_ix =
+            initialize(&spl_token_2022_interface::id(), &mint_pubkey, None, None).unwrap();
         let mut message = Message::new(&[init_ix], None);
         let compiled_instruction = &mut message.instructions[0];
         assert_eq!(
@@ -127,7 +128,7 @@ mod test {
 
         // Single owner Update
         let update_ix = update(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &mint_pubkey,
             &authority,
             &[],
@@ -157,7 +158,7 @@ mod test {
         let multisig_signer0 = Pubkey::new_unique();
         let multisig_signer1 = Pubkey::new_unique();
         let update_ix = update(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &mint_pubkey,
             &multisig_pubkey,
             &[&multisig_signer0, &multisig_signer1],

--- a/transaction-status/src/parse_token/extension/mint_close_authority.rs
+++ b/transaction-status/src/parse_token/extension/mint_close_authority.rs
@@ -19,7 +19,7 @@ pub(in crate::parse_token) fn parse_initialize_mint_close_authority_instruction(
 mod test {
     use {
         super::*, serde_json::Value, solana_message::Message, solana_pubkey::Pubkey,
-        spl_token_2022::instruction::*,
+        spl_token_2022_interface::instruction::*,
     };
 
     #[test]
@@ -27,7 +27,7 @@ mod test {
         let mint_pubkey = Pubkey::new_unique();
         let close_authority = Pubkey::new_unique();
         let mint_close_authority_ix = initialize_mint_close_authority(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &mint_pubkey,
             Some(&close_authority),
         )
@@ -50,7 +50,8 @@ mod test {
         );
 
         let mint_close_authority_ix =
-            initialize_mint_close_authority(&spl_token_2022::id(), &mint_pubkey, None).unwrap();
+            initialize_mint_close_authority(&spl_token_2022_interface::id(), &mint_pubkey, None)
+                .unwrap();
         let message = Message::new(&[mint_close_authority_ix], None);
         let compiled_instruction = &message.instructions[0];
         assert_eq!(

--- a/transaction-status/src/parse_token/extension/pausable.rs
+++ b/transaction-status/src/parse_token/extension/pausable.rs
@@ -1,6 +1,6 @@
 use {
     super::*,
-    spl_token_2022::{
+    spl_token_2022_interface::{
         extension::pausable::instruction::{InitializeInstructionData, PausableInstruction},
         instruction::{decode_instruction_data, decode_instruction_type},
     },

--- a/transaction-status/src/parse_token/extension/permanent_delegate.rs
+++ b/transaction-status/src/parse_token/extension/permanent_delegate.rs
@@ -18,7 +18,8 @@ pub(in crate::parse_token) fn parse_initialize_permanent_delegate_instruction(
 #[cfg(test)]
 mod test {
     use {
-        super::*, solana_message::Message, solana_pubkey::Pubkey, spl_token_2022::instruction::*,
+        super::*, solana_message::Message, solana_pubkey::Pubkey,
+        spl_token_2022_interface::instruction::*,
     };
 
     #[test]
@@ -26,7 +27,8 @@ mod test {
         let mint_pubkey = Pubkey::new_unique();
         let delegate = Pubkey::new_unique();
         let permanent_delegate_ix =
-            initialize_permanent_delegate(&spl_token_2022::id(), &mint_pubkey, &delegate).unwrap();
+            initialize_permanent_delegate(&spl_token_2022_interface::id(), &mint_pubkey, &delegate)
+                .unwrap();
         let message = Message::new(&[permanent_delegate_ix], None);
         let compiled_instruction = &message.instructions[0];
         assert_eq!(

--- a/transaction-status/src/parse_token/extension/reallocate.rs
+++ b/transaction-status/src/parse_token/extension/reallocate.rs
@@ -1,4 +1,4 @@
-use {super::*, spl_token_2022::extension::ExtensionType};
+use {super::*, spl_token_2022_interface::extension::ExtensionType};
 
 pub(in crate::parse_token) fn parse_reallocate_instruction(
     extension_types: Vec<ExtensionType>,
@@ -31,7 +31,7 @@ pub(in crate::parse_token) fn parse_reallocate_instruction(
 mod test {
     use {
         super::*, solana_message::Message, solana_pubkey::Pubkey,
-        spl_token_2022::instruction::reallocate,
+        spl_token_2022_interface::instruction::reallocate,
     };
 
     #[test]
@@ -47,7 +47,7 @@ mod test {
         // Single owner
         let owner_pubkey = Pubkey::new_unique();
         let reallocate_ix = reallocate(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &account_pubkey,
             &payer_pubkey,
             &owner_pubkey,
@@ -80,7 +80,7 @@ mod test {
         let multisig_signer0 = Pubkey::new_unique();
         let multisig_signer1 = Pubkey::new_unique();
         let reallocate_ix = reallocate(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &account_pubkey,
             &payer_pubkey,
             &multisig_pubkey,

--- a/transaction-status/src/parse_token/extension/scaled_ui_amount.rs
+++ b/transaction-status/src/parse_token/extension/scaled_ui_amount.rs
@@ -1,6 +1,6 @@
 use {
     super::*,
-    spl_token_2022::{
+    spl_token_2022_interface::{
         extension::scaled_ui_amount::instruction::{
             InitializeInstructionData, ScaledUiAmountMintInstruction,
             UpdateMultiplierInstructionData,

--- a/transaction-status/src/parse_token/extension/token_group.rs
+++ b/transaction-status/src/parse_token/extension/token_group.rs
@@ -90,7 +90,7 @@ mod test {
         // Initialize with an update authority.
         let max_size = 300;
         let ix = spl_token_group_interface::instruction::initialize_group(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &group_address,
             &group_mint,
             &group_mint_authority,
@@ -118,7 +118,7 @@ mod test {
         );
         // Initialize without an update authority.
         let ix = spl_token_group_interface::instruction::initialize_group(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &group_address,
             &group_mint,
             &group_mint_authority,
@@ -148,7 +148,7 @@ mod test {
         // UpdateGroupMaxSize
         let new_max_size = 500;
         let ix = spl_token_group_interface::instruction::update_group_max_size(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &group_address,
             &group_update_authority,
             new_max_size,
@@ -175,7 +175,7 @@ mod test {
         // Update authority to a new authority.
         let new_authority = Pubkey::new_unique();
         let ix = spl_token_group_interface::instruction::update_group_authority(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &group_address,
             &group_update_authority,
             Some(new_authority),
@@ -199,7 +199,7 @@ mod test {
         );
         // Update authority to None.
         let ix = spl_token_group_interface::instruction::update_group_authority(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &group_address,
             &group_update_authority,
             None,
@@ -224,7 +224,7 @@ mod test {
 
         // InitializeMember
         let ix = spl_token_group_interface::instruction::initialize_member(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &member_address,
             &member_mint,
             &member_mint_authority,

--- a/transaction-status/src/parse_token/extension/token_metadata.rs
+++ b/transaction-status/src/parse_token/extension/token_metadata.rs
@@ -119,7 +119,7 @@ mod test {
 
         // Initialize
         let ix = spl_token_metadata_interface::instruction::initialize(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &metadata,
             &update_authority,
             &mint,
@@ -153,7 +153,7 @@ mod test {
         // UpdateField
         // Update one of the fixed fields.
         let ix = spl_token_metadata_interface::instruction::update_field(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &metadata,
             &update_authority,
             spl_token_metadata_interface::state::Field::Uri,
@@ -179,7 +179,7 @@ mod test {
         );
         // Add a new field
         let ix = spl_token_metadata_interface::instruction::update_field(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &metadata,
             &update_authority,
             spl_token_metadata_interface::state::Field::Key("new_field".to_string()),
@@ -206,7 +206,7 @@ mod test {
 
         // RemoveKey
         let ix = spl_token_metadata_interface::instruction::remove_key(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &metadata,
             &update_authority,
             "new_field".to_string(),
@@ -235,7 +235,7 @@ mod test {
         // Update authority to a new authority.
         let new_authority = Pubkey::new_unique();
         let ix = spl_token_metadata_interface::instruction::update_authority(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &metadata,
             &update_authority,
             Some(new_authority).try_into().unwrap(),
@@ -259,7 +259,7 @@ mod test {
         );
         // Update authority to None.
         let ix = spl_token_metadata_interface::instruction::update_authority(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &metadata,
             &update_authority,
             Option::<Pubkey>::None.try_into().unwrap(),
@@ -285,7 +285,7 @@ mod test {
         // Emit
         // Emit with start and end.
         let ix = spl_token_metadata_interface::instruction::emit(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &metadata,
             Some(1),
             Some(2),
@@ -309,7 +309,7 @@ mod test {
         );
         // Emit with only start.
         let ix = spl_token_metadata_interface::instruction::emit(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &metadata,
             Some(1),
             None,
@@ -332,7 +332,7 @@ mod test {
         );
         // Emit with only end.
         let ix = spl_token_metadata_interface::instruction::emit(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &metadata,
             None,
             Some(2),
@@ -355,7 +355,7 @@ mod test {
         );
         // Emit with neither start nor end.
         let ix = spl_token_metadata_interface::instruction::emit(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &metadata,
             None,
             None,

--- a/transaction-status/src/parse_token/extension/transfer_fee.rs
+++ b/transaction-status/src/parse_token/extension/transfer_fee.rs
@@ -1,4 +1,7 @@
-use {super::*, spl_token_2022::extension::transfer_fee::instruction::TransferFeeInstruction};
+use {
+    super::*,
+    spl_token_2022_interface::extension::transfer_fee::instruction::TransferFeeInstruction,
+};
 
 pub(in crate::parse_token) fn parse_transfer_fee_instruction(
     instruction_data: &[u8],
@@ -161,7 +164,7 @@ pub(in crate::parse_token) fn parse_transfer_fee_instruction(
 mod test {
     use {
         super::*, solana_message::Message, solana_pubkey::Pubkey,
-        spl_token_2022::extension::transfer_fee::instruction::*,
+        spl_token_2022_interface::extension::transfer_fee::instruction::*,
     };
 
     #[test]
@@ -174,7 +177,7 @@ mod test {
 
         // InitializeTransferFeeConfig variations
         let init_transfer_fee_config_ix = initialize_transfer_fee_config(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &mint_pubkey,
             Some(&transfer_fee_config_authority),
             Some(&withdraw_withheld_authority),
@@ -203,7 +206,7 @@ mod test {
         );
 
         let init_transfer_fee_config_ix = initialize_transfer_fee_config(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &mint_pubkey,
             None,
             None,
@@ -237,7 +240,7 @@ mod test {
         let decimals = 2;
         let fee = 5;
         let transfer_checked_with_fee_ix = transfer_checked_with_fee(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &account_pubkey,
             &mint_pubkey,
             &recipient,
@@ -284,7 +287,7 @@ mod test {
         let multisig_signer0 = Pubkey::new_unique();
         let multisig_signer1 = Pubkey::new_unique();
         let transfer_checked_with_fee_ix = transfer_checked_with_fee(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &account_pubkey,
             &mint_pubkey,
             &recipient,
@@ -332,7 +335,7 @@ mod test {
 
         // Single authority WithdrawWithheldTokensFromMint
         let withdraw_withheld_tokens_from_mint_ix = withdraw_withheld_tokens_from_mint(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &mint_pubkey,
             &recipient,
             &withdraw_withheld_authority,
@@ -359,7 +362,7 @@ mod test {
 
         // Multisig WithdrawWithheldTokensFromMint
         let withdraw_withheld_tokens_from_mint_ix = withdraw_withheld_tokens_from_mint(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &mint_pubkey,
             &recipient,
             &multisig_pubkey,
@@ -392,7 +395,7 @@ mod test {
         let fee_account0 = Pubkey::new_unique();
         let fee_account1 = Pubkey::new_unique();
         let withdraw_withheld_tokens_from_accounts_ix = withdraw_withheld_tokens_from_accounts(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &mint_pubkey,
             &recipient,
             &withdraw_withheld_authority,
@@ -424,7 +427,7 @@ mod test {
 
         // Multisig WithdrawWithheldTokensFromAccounts
         let withdraw_withheld_tokens_from_accounts_ix = withdraw_withheld_tokens_from_accounts(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &mint_pubkey,
             &recipient,
             &multisig_pubkey,
@@ -460,7 +463,7 @@ mod test {
 
         // HarvestWithheldTokensToMint
         let harvest_withheld_tokens_to_mint_ix = harvest_withheld_tokens_to_mint(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &mint_pubkey,
             &[&fee_account0, &fee_account1],
         )
@@ -487,7 +490,7 @@ mod test {
 
         // Single authority SetTransferFee
         let set_transfer_fee_ix = set_transfer_fee(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &mint_pubkey,
             &transfer_fee_config_authority,
             &[],
@@ -516,7 +519,7 @@ mod test {
 
         // Multisig WithdrawWithheldTokensFromMint
         let set_transfer_fee_ix = set_transfer_fee(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &mint_pubkey,
             &multisig_pubkey,
             &[&multisig_signer0, &multisig_signer1],

--- a/transaction-status/src/parse_token/extension/transfer_hook.rs
+++ b/transaction-status/src/parse_token/extension/transfer_hook.rs
@@ -1,6 +1,6 @@
 use {
     super::*,
-    spl_token_2022::{
+    spl_token_2022_interface::{
         extension::transfer_hook::instruction::*,
         instruction::{decode_instruction_data, decode_instruction_type},
     },
@@ -78,7 +78,7 @@ mod test {
 
         // Initialize variations
         let init_ix = initialize(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &mint_pubkey,
             Some(authority),
             Some(program_id),
@@ -102,7 +102,8 @@ mod test {
             }
         );
 
-        let init_ix = initialize(&spl_token_2022::id(), &mint_pubkey, None, None).unwrap();
+        let init_ix =
+            initialize(&spl_token_2022_interface::id(), &mint_pubkey, None, None).unwrap();
         let mut message = Message::new(&[init_ix], None);
         let compiled_instruction = &mut message.instructions[0];
         assert_eq!(
@@ -121,7 +122,7 @@ mod test {
 
         // Single owner Update
         let update_ix = update(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &mint_pubkey,
             &authority,
             &[],
@@ -151,7 +152,7 @@ mod test {
         let multisig_signer0 = Pubkey::new_unique();
         let multisig_signer1 = Pubkey::new_unique();
         let update_ix = update(
-            &spl_token_2022::id(),
+            &spl_token_2022_interface::id(),
             &mint_pubkey,
             &multisig_pubkey,
             &[&multisig_signer0, &multisig_signer1],

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -105,6 +105,6 @@ solana-program-pack = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-time-utils = { workspace = true }
 spl-generic-token = { workspace = true }
-spl-token-2022 = { workspace = true, features = ["no-entrypoint"] }
+spl-token-2022-interface = { workspace = true }
 tempfile = { workspace = true }
 test-case = { workspace = true }

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -982,7 +982,9 @@ mod tests {
         solana_tpu_client::tpu_client::DEFAULT_TPU_ENABLE_UDP,
         solana_votor::event::VotorEventSender,
         spl_generic_token::token,
-        spl_token_2022::state::{Account as TokenAccount, AccountState as TokenAccountState, Mint},
+        spl_token_2022_interface::state::{
+            Account as TokenAccount, AccountState as TokenAccountState, Mint,
+        },
         std::{collections::HashSet, fs::remove_dir_all, sync::atomic::AtomicBool},
     };
 


### PR DESCRIPTION
#### Problem
We'd like to migrate over to `agave`.

#### Summary of Changes
Step 1 of (?): replace `spl-token-2022` with `spl-token-2022-interface`.

See: https://github.com/anza-xyz/agave/commit/c1ce9db99c644f4bf2d6ee762e36989f6548a54d?diff=unified#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542