### PR TITLE
bug: handle failures to send in retransmit_stage

### DIFF
--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -253,7 +253,7 @@ fn retransmit(
             shred_buf.push(shreds);
         }
         Err(TryRecvError::Disconnected) => {
-            warn!("retransmint_receiver became disconnected.");
+            warn!("retransmit_receiver became disconnected.");
             return Err(());
         }
 


### PR DESCRIPTION
#### Problem
If the receiving end of the channel is dropped, sending on it fails which currently results in a panic.  

#### Summary of Changes
Instead of panicking when that happens, exit the infinite loop more gracefully.
