### PR TITLE
refactor: simplify the type for `additional_listeners`

### DIFF
--- a/core/src/voting_service.rs
+++ b/core/src/voting_service.rs
@@ -281,7 +281,7 @@ impl VotingService {
         let (staked_validator_alpenglow_sockets, _) = staked_validators_cache
             .get_staked_validators_by_slot_with_alpenglow_ports(slot, cluster_info, Instant::now());
         let sockets = additional_listeners
-            .into_iter()
+            .iter()
             .chain(staked_validator_alpenglow_sockets.iter());
 
         // We use send_message in a loop right now because we worry that sending packets too fast

--- a/core/src/voting_service.rs
+++ b/core/src/voting_service.rs
@@ -162,14 +162,14 @@ impl VotingService {
         bank_forks: Arc<RwLock<BankForks>>,
         test_override: Option<VotingServiceOverride>,
     ) -> Self {
-        let (additional_listeners, alpenglow_port_override) = test_override
-            .map(|test_override| {
-                (
-                    Some(test_override.additional_listeners),
-                    Some(test_override.alpenglow_port_override),
-                )
-            })
-            .unwrap_or((None, None));
+        let (additional_listeners, alpenglow_port_override) = match test_override {
+            None => (Vec::new(), None),
+            Some(VotingServiceOverride {
+                additional_listeners,
+                alpenglow_port_override,
+            }) => (additional_listeners, Some(alpenglow_port_override)),
+        };
+
         let thread_hdl = Builder::new()
             .name("solVoteService".to_string())
             .spawn(move || {
@@ -208,7 +208,7 @@ impl VotingService {
                                         vote_history_storage.as_ref(),
                                         bls_op,
                                         connection_cache.clone(),
-                                        additional_listeners.as_ref(),
+                                        &additional_listeners,
                                         &mut staked_validators_cache,
                                     );
                                 }
@@ -267,17 +267,9 @@ impl VotingService {
         cluster_info: &ClusterInfo,
         bls_message: &BLSMessage,
         connection_cache: Arc<ConnectionCache>,
-        additional_listeners: Option<&Vec<SocketAddr>>,
+        additional_listeners: &[SocketAddr],
         staked_validators_cache: &mut StakedValidatorsCache,
     ) {
-        let (staked_validator_alpenglow_sockets, _) = staked_validators_cache
-            .get_staked_validators_by_slot_with_alpenglow_ports(slot, cluster_info, Instant::now());
-
-        let sockets = additional_listeners
-            .map(|v| v.as_slice())
-            .unwrap_or(&[])
-            .iter()
-            .chain(staked_validator_alpenglow_sockets.iter());
         let buf = match serialize(bls_message) {
             Ok(buf) => buf,
             Err(err) => {
@@ -286,15 +278,18 @@ impl VotingService {
             }
         };
 
+        let (staked_validator_alpenglow_sockets, _) = staked_validators_cache
+            .get_staked_validators_by_slot_with_alpenglow_ports(slot, cluster_info, Instant::now());
+        let sockets = additional_listeners
+            .into_iter()
+            .chain(staked_validator_alpenglow_sockets.iter());
+
         // We use send_message in a loop right now because we worry that sending packets too fast
         // will cause a packet spike and overwhelm the network. If we later find out that this is
         // not an issue, we can optimize this by using multi_targret_send or similar methods.
-        for alpenglow_socket in sockets {
-            if let Err(e) = send_message(buf.clone(), alpenglow_socket, &connection_cache) {
-                warn!(
-                    "Failed to send alpenglow message to {}: {:?}",
-                    alpenglow_socket, e
-                );
+        for socket in sockets {
+            if let Err(e) = send_message(buf.clone(), socket, &connection_cache) {
+                warn!("Failed to send alpenglow message to {}: {:?}", socket, e);
             }
         }
     }
@@ -304,7 +299,7 @@ impl VotingService {
         vote_history_storage: &dyn VoteHistoryStorage,
         bls_op: BLSOp,
         connection_cache: Arc<ConnectionCache>,
-        additional_listeners: Option<&Vec<SocketAddr>>,
+        additional_listeners: &[SocketAddr],
         staked_validators_cache: &mut StakedValidatorsCache,
     ) {
         match bls_op {


### PR DESCRIPTION
#### Problem

`Option<&Vec<_>>` is a bit unergonomic to work with.


#### Summary of Changes

Pass `additional_listeners` as a simple slice instead.
