### PR TITLE
genesis: fix alpenglow feature activation

### DIFF
--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -315,9 +315,10 @@ pub fn activate_all_features(genesis_config: &mut GenesisConfig) {
 pub fn do_activate_all_features<const IS_ALPENGLOW: bool>(genesis_config: &mut GenesisConfig) {
     // Activate all features at genesis in development mode
     for feature_id in FeatureSet::default().inactive() {
-        if IS_ALPENGLOW || *feature_id != agave_feature_set::alpenglow::id() {
-            activate_feature(genesis_config, *feature_id);
-        }
+        activate_feature(genesis_config, *feature_id);
+    }
+    if IS_ALPENGLOW {
+        activate_feature(genesis_config, agave_feature_set::alpenglow::id());
     }
 }
 


### PR DESCRIPTION
Since `alpenglow` was removed from `FEATURE_NAMES` we need to activate it separately
