### PR TITLE
[bls-sigverifier, votor-messages] Refactor certificate-to-vote conversion function from bls sigverifier to votor-messages

### DIFF
--- a/core/src/sigverifier/bls_sigverifier.rs
+++ b/core/src/sigverifier/bls_sigverifier.rs
@@ -381,8 +381,9 @@ impl BLSSigVerifier {
         bit_vec: &BitVec<u8, Lsb0>,
         key_to_rank_map: &Arc<BLSPubkeyToRankMap>,
     ) -> Result<(), CertVerifyError> {
-        let original_vote =
-            certificate_to_vote_message_base2(&cert_to_verify.cert_message.certificate);
+        let original_vote = cert_to_verify.cert_message.certificate.to_source_vote() else {
+            return false;
+        };
 
         let Ok(signed_payload) = bincode::serialize(&original_vote) else {
             return Err(CertVerifyError::SerializationFailed);
@@ -409,9 +410,7 @@ impl BLSSigVerifier {
         bit_vec2: &BitVec<u8, Lsb0>,
         key_to_rank_map: &Arc<BLSPubkeyToRankMap>,
     ) -> Result<(), CertVerifyError> {
-        let Some((vote1, vote2)) =
-            certificate_to_vote_messages_base3(&cert_to_verify.cert_message.certificate)
-        else {
+        let Some((vote1, vote2)) = cert_to_verify.cert_message.certificate.to_source_votes() else {
             return Err(CertVerifyError::Base3EncodingOnUnexpectedCert(
                 cert_to_verify.cert_message.certificate.certificate_type(),
             ));
@@ -484,52 +483,6 @@ impl VoteToVerify<'_> {
 struct CertToVerify<'a> {
     cert_message: CertificateMessage,
     packet: PacketRefMut<'a>,
-}
-
-// TODO(sam): These functions should probably live inside the votor or votor-messages crate
-fn certificate_to_vote_message_base2(certificate: &Certificate) -> Vote {
-    match certificate {
-        Certificate::Notarize(slot, hash) => Vote::new_notarization_vote(*slot, *hash),
-
-        Certificate::FinalizeFast(slot, hash) => Vote::new_notarization_vote(*slot, *hash),
-
-        Certificate::Finalize(slot) => Vote::new_finalization_vote(*slot),
-
-        Certificate::NotarizeFallback(slot, hash) => {
-            // In the Base2 path, a NotarizeFallback certificate must have been formed
-            // exclusively from Notarize votes, which populate the first bitmap
-            Vote::new_notarization_vote(*slot, *hash)
-        }
-
-        Certificate::Skip(slot) => {
-            // In the Base2 path, a Skip certificate must have been formed
-            // exclusively from Skip votes, which populate the first bitmap
-            Vote::new_skip_vote(*slot)
-        }
-    }
-}
-
-fn certificate_to_vote_messages_base3(certificate: &Certificate) -> Option<(Vote, Vote)> {
-    match certificate {
-        Certificate::NotarizeFallback(slot, hash) => {
-            // Per the protocol, the first bitmap is for `Notarize` votes and the
-            // second is for `NotarizeFallback` votes
-            let vote1 = Vote::new_notarization_vote(*slot, *hash);
-            let vote2 = Vote::new_notarization_fallback_vote(*slot, *hash);
-            Some((vote1, vote2))
-        }
-
-        Certificate::Skip(slot) => {
-            // Per the protocol, the first bitmap is for `Skip` votes and the
-            // second is for `SkipFallback` votes
-            let vote1 = Vote::new_skip_vote(*slot);
-            let vote2 = Vote::new_skip_fallback_vote(*slot);
-            Some((vote1, vote2))
-        }
-
-        // Other certificate types do not use Base3 encoding.
-        _ => None,
-    }
 }
 
 // Add tests for the BLS signature verifier

--- a/core/src/sigverifier/bls_sigverifier.rs
+++ b/core/src/sigverifier/bls_sigverifier.rs
@@ -22,11 +22,8 @@ use {
     solana_runtime::{bank::Bank, bank_forks::SharableBank, epoch_stakes::BLSPubkeyToRankMap},
     solana_signer_store::{decode, DecodeError},
     solana_streamer::packet::PacketBatch,
-    solana_votor_messages::{
-        consensus_message::{
-            Certificate, CertificateMessage, CertificateType, ConsensusMessage, VoteMessage,
-        },
-        vote::Vote,
+    solana_votor_messages::consensus_message::{
+        CertificateMessage, CertificateType, ConsensusMessage, VoteMessage,
     },
     stats::BLSSigVerifierStats,
     std::{
@@ -381,9 +378,7 @@ impl BLSSigVerifier {
         bit_vec: &BitVec<u8, Lsb0>,
         key_to_rank_map: &Arc<BLSPubkeyToRankMap>,
     ) -> Result<(), CertVerifyError> {
-        let original_vote = cert_to_verify.cert_message.certificate.to_source_vote() else {
-            return false;
-        };
+        let original_vote = cert_to_verify.cert_message.certificate.to_source_vote();
 
         let Ok(signed_payload) = bincode::serialize(&original_vote) else {
             return Err(CertVerifyError::SerializationFailed);

--- a/votor-messages/src/consensus_message.rs
+++ b/votor-messages/src/consensus_message.rs
@@ -143,17 +143,13 @@ impl Certificate {
     /// vote type (e.g., exclusively from `Notarize` or `Skip` votes). For
     /// certificates formed from a mix of two vote types, use the `to_source_votes`
     /// function.
-    pub fn to_source_vote(&self) -> Option<Vote> {
+    pub fn to_source_vote(&self) -> Vote {
         match self {
-            Certificate::Notarize(slot, hash) => Some(Vote::new_notarization_vote(*slot, *hash)),
-            Certificate::FinalizeFast(slot, hash) => {
-                Some(Vote::new_notarization_vote(*slot, *hash))
-            }
-            Certificate::Finalize(slot) => Some(Vote::new_finalization_vote(*slot)),
-            Certificate::NotarizeFallback(slot, hash) => {
-                Some(Vote::new_notarization_vote(*slot, *hash))
-            }
-            Certificate::Skip(slot) => Some(Vote::new_skip_vote(*slot)),
+            Certificate::Notarize(slot, hash) => Vote::new_notarization_vote(*slot, *hash),
+            Certificate::FinalizeFast(slot, hash) => Vote::new_notarization_vote(*slot, *hash),
+            Certificate::Finalize(slot) => Vote::new_finalization_vote(*slot),
+            Certificate::NotarizeFallback(slot, hash) => Vote::new_notarization_vote(*slot, *hash),
+            Certificate::Skip(slot) => Vote::new_skip_vote(*slot),
         }
     }
 

--- a/votor-messages/src/consensus_message.rs
+++ b/votor-messages/src/consensus_message.rs
@@ -130,6 +130,57 @@ impl Certificate {
     pub fn is_critical(&self) -> bool {
         matches!(self, Self::NotarizeFallback(_, _) | Self::Skip(_))
     }
+
+    /// Reconstructs the single source `Vote` payload for this certificate.
+    ///
+    /// This method is used primarily by the signature verifier. For
+    /// certificates formed by aggregating a single type of vote
+    /// (e.g., a `Notarize` certificate from `Notarize` votes), this function
+    /// reconstructs the canonical message payload that was signed by validators.
+    ///
+    /// For `NotarizeFallback` and `Skip` certificates, this function returns the
+    /// appropriate payload *only* if the certificate was formed from a single
+    /// vote type (e.g., exclusively from `Notarize` or `Skip` votes). For
+    /// certificates formed from a mix of two vote types, use the `to_source_votes`
+    /// function.
+    pub fn to_source_vote(&self) -> Option<Vote> {
+        match self {
+            Certificate::Notarize(slot, hash) => Some(Vote::new_notarization_vote(*slot, *hash)),
+            Certificate::FinalizeFast(slot, hash) => {
+                Some(Vote::new_notarization_vote(*slot, *hash))
+            }
+            Certificate::Finalize(slot) => Some(Vote::new_finalization_vote(*slot)),
+            Certificate::NotarizeFallback(slot, hash) => {
+                Some(Vote::new_notarization_vote(*slot, *hash))
+            }
+            Certificate::Skip(slot) => Some(Vote::new_skip_vote(*slot)),
+        }
+    }
+
+    /// Reconstructs the two distinct source `Vote` payloads for this certificate.
+    ///
+    /// This method is primarily used by the signature verifier for certificates that
+    /// can be formed by aggregating two different types of votes. For example, a
+    /// `NotarizeFallback` certificate accepts both `Notarize` and `NotarizeFallback`.
+    ///
+    /// It reconstructs both potential message payloads that were signed by validators, which
+    /// the verifier uses to check the single aggregate signature.
+    pub fn to_source_votes(&self) -> Option<(Vote, Vote)> {
+        match self {
+            Certificate::NotarizeFallback(slot, hash) => {
+                let vote1 = Vote::new_notarization_vote(*slot, *hash);
+                let vote2 = Vote::new_notarization_fallback_vote(*slot, *hash);
+                Some((vote1, vote2))
+            }
+            Certificate::Skip(slot) => {
+                let vote1 = Vote::new_skip_vote(*slot);
+                let vote2 = Vote::new_skip_fallback_vote(*slot);
+                Some((vote1, vote2))
+            }
+            // Other certificate types do not use Base3 encoding.
+            _ => None,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
#### Problem
The certificate-to-vote conversion functions that currently exists in the bls sigverifier module more naturally belongs to the `solana-votor-messages` crate.

#### Summary of Changes
I refactored the certificate-to-vote conversion function from the bls sigverifier to votor-messages.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
