### PR TITLE
wip, feat(votor): fast leader handover - milestone 1

### DIFF
--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -407,6 +407,9 @@ pub fn start_loop(config: BlockCreationLoopConfig) {
             );
         }
 
+        // TODO(ksn): we should periodically be checking for new leader windows to get the skip
+        // timer from a ParentReady.
+        //
         // Wait for the voting loop to notify us
         let LeaderWindowInfo {
             start_slot,

--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -12,7 +12,7 @@ use {
         },
         event::VotorEvent,
         vote_to_certificate_ids, Certificate, Stake, VoteType,
-        MAX_ENTRIES_PER_PUBKEY_FOR_NOTARIZE_LITE, MAX_ENTRIES_PER_PUBKEY_FOR_OTHER_TYPES,
+        MAX_ENTRIES_PER_PUBKEY_FOR_NOTARIZE_FALLBACK, MAX_ENTRIES_PER_PUBKEY_FOR_OTHER_TYPES,
     },
     crossbeam_channel::Sender,
     log::{error, trace},
@@ -166,7 +166,7 @@ impl ConsensusPool {
     fn new_vote_pool(vote_type: VoteType) -> VotePoolType {
         match vote_type {
             VoteType::NotarizeFallback => VotePoolType::DuplicateBlockVotePool(
-                DuplicateBlockVotePool::new(MAX_ENTRIES_PER_PUBKEY_FOR_NOTARIZE_LITE),
+                DuplicateBlockVotePool::new(MAX_ENTRIES_PER_PUBKEY_FOR_NOTARIZE_FALLBACK),
             ),
             VoteType::Notarize => VotePoolType::DuplicateBlockVotePool(
                 DuplicateBlockVotePool::new(MAX_ENTRIES_PER_PUBKEY_FOR_OTHER_TYPES),

--- a/votor/src/consensus_pool/parent_ready_tracker.rs
+++ b/votor/src/consensus_pool/parent_ready_tracker.rs
@@ -13,7 +13,7 @@
 //! a block with parent `b` in slot `s` will have their block finalized.
 
 use {
-    crate::{event::VotorEvent, MAX_ENTRIES_PER_PUBKEY_FOR_NOTARIZE_LITE},
+    crate::{event::VotorEvent, MAX_ENTRIES_PER_PUBKEY_FOR_NOTARIZE_FALLBACK},
     solana_clock::{Slot, NUM_CONSECUTIVE_LEADER_SLOTS},
     solana_pubkey::Pubkey,
     solana_votor_messages::consensus_message::Block,
@@ -103,7 +103,7 @@ impl ParentReadyTracker {
             self.my_pubkey
         );
         status.notar_fallbacks.push(block);
-        assert!(status.notar_fallbacks.len() <= MAX_ENTRIES_PER_PUBKEY_FOR_NOTARIZE_LITE);
+        assert!(status.notar_fallbacks.len() <= MAX_ENTRIES_PER_PUBKEY_FOR_NOTARIZE_FALLBACK);
 
         // Add this block as valid parent to skip connected future blocks
         for s in slot.saturating_add(1).. {

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -360,7 +360,7 @@ impl ConsensusPoolService {
             .leader_schedule_cache
             .slot_leader_at(*highest_parent_ready, Some(&root_bank))
         else {
-            error!("Unable to compute the leader at slot {highest_parent_ready}. Something is wrong, exiting");
+            error!("Unable to compute the leader at slot {highest_parent_ready}. Something is wrong; exiting");
             ctx.exit.store(true, Ordering::Relaxed);
             return;
         };
@@ -374,7 +374,7 @@ impl ConsensusPoolService {
 
         if (start_slot..=end_slot).any(|s| ctx.blockstore.has_existing_shreds_for_slot(s)) {
             warn!(
-                "{my_pubkey}: We have already produced shreds in the window {start_slot}-{end_slot}, \
+                "{my_pubkey}: We have already produced shreds in the window {start_slot}-{end_slot}; \
                     skipping production of our leader window"
             );
             return;
@@ -386,7 +386,7 @@ impl ConsensusPoolService {
         {
             BlockProductionParent::MissedWindow => {
                 warn!(
-                    "{my_pubkey}: Leader slot {start_slot} has already been certified, \
+                    "{my_pubkey}: Leader slot {start_slot} has already been certified; \
                     skipping production of {start_slot}-{end_slot}"
                 );
                 ConsensusPoolServiceStats::incr_u16(&mut stats.parent_ready_missed_window);

--- a/votor/src/lib.rs
+++ b/votor/src/lib.rs
@@ -98,7 +98,7 @@ pub fn vote_to_certificate_ids(vote: &Vote) -> Vec<Certificate> {
 }
 
 pub const MAX_ENTRIES_PER_PUBKEY_FOR_OTHER_TYPES: usize = 1;
-pub const MAX_ENTRIES_PER_PUBKEY_FOR_NOTARIZE_LITE: usize = 3;
+pub const MAX_ENTRIES_PER_PUBKEY_FOR_NOTARIZE_FALLBACK: usize = 3;
 
 pub const SAFE_TO_NOTAR_MIN_NOTARIZE_ONLY: f64 = 0.4;
 pub const SAFE_TO_NOTAR_MIN_NOTARIZE_FOR_NOTARIZE_OR_SKIP: f64 = 0.2;


### PR DESCRIPTION
#### Problem
This PR implements fast leader handover, up to Milestone 1. See https://github.com/anza-xyz/alpenglow/issues/293 for more detail.

This is still work in progress.

**Milestone 1**
Modify Entry to allow the dissemination of a "special reset indicator." If slot s's proposer receives a ParentReady notification with associated (s', hash) that doesn't match the block parent that is optimistically being built upon, triggering a parent change, then the proposer will disseminate this "special reset indicator." Naturally, all transactions disseminated up to the special reset (call these "optimistic transactions") will not affect state.

In Milestone 1, the proposer simply stops including further transactions. We essentially have an empty block. Launching Milestone 1 is very undesirable, since the leader from s - 1 can clearly impact block rewards for the following leader.

**Milestone 2**
Allow the proposer to include transactions that build upon the revised parent after the special reset.

In Milestone 2, we do NOT re-submit optimistic transactions to the scheduler. Milestone 2 is still undesirable, since e.g., transactions with high priority fee that were optimistically disseminated would now no longer be included in the block.

**Milestone 3**
In addition to the features in Milestone 2, we re-submit optimistic transactions to the scheduler.