### PR TITLE
Rename send_vote_time_us to send_votes_batch_time_us

### DIFF
--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -177,16 +177,16 @@ impl EventHandler {
                 .stats
                 .incr_event_with_timing(stats_event, event_processing_time.as_us());
 
-            let mut send_vote_time = Measure::start("send_vote");
+            let mut send_votes_batch_time = Measure::start("send_votes_batch");
             for vote in votes {
                 local_context.stats.incr_vote(&vote);
                 vctx.bls_sender.send(vote).map_err(|_| SendError(()))?;
             }
-            send_vote_time.stop();
-            local_context.stats.send_vote_time_us = local_context
+            send_votes_batch_time.stop();
+            local_context.stats.send_votes_batch_time_us = local_context
                 .stats
-                .send_vote_time_us
-                .saturating_add(send_vote_time.as_us() as u32);
+                .send_votes_batch_time_us
+                .saturating_add(send_votes_batch_time.as_us() as u32);
             local_context.stats.maybe_report();
         }
 

--- a/votor/src/event_handler/stats.rs
+++ b/votor/src/event_handler/stats.rs
@@ -69,7 +69,7 @@ pub(crate) struct EventHandlerStats {
     pub(crate) receive_event_time_us: u32,
 
     // Amount of time spent sending votes.
-    pub(crate) send_vote_time_us: u32,
+    pub(crate) send_votes_batch_time_us: u32,
 
     // Number of times we saw each event and time spent processing the event.
     received_events_count_and_timing: HashMap<StatsEvent, EventCountAndTime>,
@@ -133,7 +133,7 @@ impl EventHandlerStats {
             set_root_count: 0,
             timeout_set: 0,
             receive_event_time_us: 0,
-            send_vote_time_us: 0,
+            send_votes_batch_time_us: 0,
             received_events_count_and_timing: HashMap::new(),
             sent_votes: HashMap::new(),
             slot_tracking_map: BTreeMap::new(),
@@ -235,7 +235,11 @@ impl EventHandlerStats {
                 self.receive_event_time_us as i64,
                 i64
             ),
-            ("send_vote_time_us", self.send_vote_time_us as i64, i64),
+            (
+                "send_votes_batch_time_us",
+                self.send_votes_batch_time_us as i64,
+                i64
+            ),
         );
         for (vote_type, count) in &self.sent_votes {
             datapoint_info!(


### PR DESCRIPTION
#### Problem
`send_vote_time` is a misleading name since it indicates the time it took to send a single vote.
This is rather a vector of votes in the way this is implemented

#### Summary of Changes
Rename `send_vote_time` to `send_votes_batch_time`
