### PR TITLE
Tell stake program to decode VoteStateV4 account if is_alpenglow is true.

### DIFF
--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -288,16 +288,29 @@ fn add_validator_accounts(
             )
         };
 
-        genesis_config.add_account(
-            *stake_pubkey,
-            stake_state::create_account(
-                authorized_pubkey.unwrap_or(identity_pubkey),
-                vote_pubkey,
-                &vote_account,
-                rent,
-                stake_lamports,
-            ),
-        );
+        if is_alpenglow {
+            genesis_config.add_account(
+                *stake_pubkey,
+                stake_state::create_alpenglow_account(
+                    authorized_pubkey.unwrap_or(identity_pubkey),
+                    vote_pubkey,
+                    &vote_account,
+                    rent,
+                    stake_lamports,
+                ),
+            );
+        } else {
+            genesis_config.add_account(
+                *stake_pubkey,
+                stake_state::create_account(
+                    authorized_pubkey.unwrap_or(identity_pubkey),
+                    vote_pubkey,
+                    &vote_account,
+                    rent,
+                    stake_lamports,
+                ),
+            );
+        }
         genesis_config.add_account(*vote_pubkey, vote_account);
     }
     Ok(())


### PR DESCRIPTION
- When is_alpenglow is true for genesis program, we create VoteStateV4 vote account, tell stake programs to decode VoteStateV4 account rather than VoteStateV3 ones.
