### PR TITLE
[core] Re-organize batches for bls-sigverify bench

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -232,6 +232,7 @@ name = "ed25519_sigverify"
 
 [[bench]]
 name = "bls_sigverify"
+harness = false
 
 [[bench]]
 name = "receive_and_buffer"

--- a/core/benches/bls_sigverify.rs
+++ b/core/benches/bls_sigverify.rs
@@ -1,11 +1,13 @@
 #![allow(clippy::arithmetic_side_effects)]
 
 use {
-    criterion::{criterion_group, criterion_main, Bencher, Criterion},
-    crossbeam_channel::{unbounded, Receiver, Sender},
+    criterion::{criterion_group, criterion_main, BatchSize, Criterion, Throughput},
+    crossbeam_channel::unbounded,
     solana_bls_signatures::signature::Signature as BlsSignature,
-    solana_core::{sigverifier::bls_sigverifier::BLSSigVerifier, sigverify_stage::SigVerifyStage},
+    solana_core::{sigverifier::bls_sigverifier::BLSSigVerifier, sigverify_stage::SigVerifier},
+    solana_hash::Hash,
     solana_perf::packet::{Packet, PacketBatch, PinnedPacketBatch},
+    solana_pubkey::Pubkey,
     solana_runtime::{
         bank::Bank,
         bank_forks::BankForks,
@@ -13,38 +15,34 @@ use {
             create_genesis_config_with_alpenglow_vote_accounts, ValidatorVoteKeypairs,
         },
     },
+    solana_votor::consensus_pool::vote_certificate_builder::VoteCertificateBuilder,
     solana_votor_messages::{
-        consensus_message::{ConsensusMessage, VoteMessage},
+        consensus_message::{Certificate, ConsensusMessage, VoteMessage},
         vote::Vote,
     },
-    std::time::{Duration, Instant},
+    std::sync::Arc,
 };
 
-struct BenchSetup {
-    stage: SigVerifyStage,
-    packet_sender: Sender<PacketBatch>,
-    consensus_message_receiver: Receiver<ConsensusMessage>,
-    validator_keypairs: Vec<ValidatorVoteKeypairs>,
+const BENCH_SLOT: u64 = 70;
+// TODO(sam): use a small number for now to emulate the current test cluster
+const NUM_VALIDATORS: usize = 100;
+
+struct BenchEnvironment {
+    verifier: BLSSigVerifier,
+    validator_keypairs: Arc<Vec<ValidatorVoteKeypairs>>,
 }
 
-enum InvalidVoteRatio {
-    AllValid,
-    OneInvalid,
-    TwentyPercentInvalid,
-    // TODO(sam): add more test cases
-}
+fn setup_environment() -> BenchEnvironment {
+    let (verified_votes_s, _) = unbounded();
+    let (consensus_msg_s, _) = unbounded();
 
-fn setup_bls_sigverify_stage() -> BenchSetup {
-    const NUM_VALIDATORS: usize = 100;
+    let validator_keypairs: Arc<Vec<_>> = Arc::new(
+        (0..NUM_VALIDATORS)
+            .map(|_| ValidatorVoteKeypairs::new_rand())
+            .collect(),
+    );
 
-    let (packet_s, packet_r) = unbounded();
-    let (consensus_msg_s, consensus_msg_r) = unbounded();
-    let (verified_votes_s, _verified_votes_r) = unbounded();
-
-    let validator_keypairs: Vec<_> = (0..NUM_VALIDATORS)
-        .map(|_| ValidatorVoteKeypairs::new_rand())
-        .collect();
-    let stakes_vec = vec![1_000; validator_keypairs.len()];
+    let stakes_vec: Vec<_> = (0..NUM_VALIDATORS).map(|i| (10000 - i) as u64).collect();
     let genesis = create_genesis_config_with_alpenglow_vote_accounts(
         1_000_000_000,
         &validator_keypairs,
@@ -52,121 +50,211 @@ fn setup_bls_sigverify_stage() -> BenchSetup {
     );
 
     let bank0 = Bank::new_for_tests(&genesis.genesis_config);
-    let bank_forks = BankForks::new_rw_arc(bank0);
-    let root_bank = bank_forks.read().unwrap().sharable_root_bank();
+    // Ensure the bank slot is high enough so votes are not considered ancient.
+    let root_bank = Bank::new_from_parent(Arc::new(bank0), &Pubkey::default(), BENCH_SLOT - 1);
+    let bank_forks = BankForks::new_rw_arc(root_bank);
+    let sharable_root_bank = bank_forks.read().unwrap().sharable_root_bank();
+    let verifier = BLSSigVerifier::new(sharable_root_bank, verified_votes_s, consensus_msg_s);
 
-    let verifier = BLSSigVerifier::new(root_bank, verified_votes_s, consensus_msg_s);
-    let stage = SigVerifyStage::new(packet_r, verifier, "solBlsSigVerBench", "bench");
-
-    BenchSetup {
-        stage,
-        packet_sender: packet_s,
-        consensus_message_receiver: consensus_msg_r,
+    BenchEnvironment {
+        verifier,
         validator_keypairs,
     }
 }
 
-fn gen_vote_batches(
-    validator_keypairs: &[ValidatorVoteKeypairs],
-    num_packets: usize,
-    invalid_ratio: &InvalidVoteRatio,
-) -> Vec<PacketBatch> {
-    let vote = Vote::new_skip_vote(42);
-    let valid_vote_payload = bincode::serialize(&vote).expect("Failed to serialize vote");
-    let invalid_vote_payload =
-        bincode::serialize(&Vote::new_skip_vote(99)).expect("Failed to serialize invalid vote");
+fn message_to_packet(msg: &ConsensusMessage) -> Packet {
+    let mut packet = Packet::default();
+    packet.populate_packet(None, msg).unwrap();
+    packet
+}
 
-    let packets: Vec<_> = (0..num_packets)
+fn create_base2_cert_message(env: &BenchEnvironment, slot: u64, hash: Hash) -> ConsensusMessage {
+    let num_signers = (NUM_VALIDATORS * 67) / 100; // 67% quorum
+    let certificate = Certificate::Notarize(slot, hash);
+    let original_vote = certificate.to_source_vote();
+    let payload = bincode::serialize(&original_vote).unwrap();
+
+    let vote_messages: Vec<VoteMessage> = (0..num_signers)
         .map(|i| {
-            let rank = (i % validator_keypairs.len()) as u16;
-            let validator_keypair = &validator_keypairs[rank as usize];
-            let bls_keypair = &validator_keypair.bls_keypair;
-
-            let is_invalid = match invalid_ratio {
-                InvalidVoteRatio::AllValid => false,
-                InvalidVoteRatio::OneInvalid => i == 1,
-                // Making every 5th packet invalid to achieve a 20% invalid ratio
-                InvalidVoteRatio::TwentyPercentInvalid => i % 5 == 0,
-            };
-
-            let signature: BlsSignature = if is_invalid {
-                bls_keypair.sign(&invalid_vote_payload).into()
-            } else {
-                bls_keypair.sign(&valid_vote_payload).into()
-            };
-
-            let consensus_message = ConsensusMessage::Vote(VoteMessage {
-                vote,
-                signature,
-                rank,
-            });
-
-            let mut packet = Packet::default();
-            packet.populate_packet(None, &consensus_message).unwrap();
-            packet
+            let signature = env.validator_keypairs[i].bls_keypair.sign(&payload);
+            VoteMessage {
+                vote: original_vote,
+                signature: signature.into(),
+                rank: i as u16,
+            }
         })
         .collect();
 
-    packets
-        .chunks(192)
-        .map(|chunk| PinnedPacketBatch::new(chunk.to_vec()).into())
-        .collect()
+    let mut builder = VoteCertificateBuilder::new(certificate);
+    builder.aggregate(&vote_messages).unwrap();
+    let cert_message = builder.build().unwrap();
+    ConsensusMessage::Certificate(cert_message)
 }
 
-fn bench_bls_sigverify_stage(b: &mut Bencher, invalid_ratio: InvalidVoteRatio) {
-    let setup = setup_bls_sigverify_stage();
-    let BenchSetup {
-        stage,
-        packet_sender,
-        consensus_message_receiver,
-        validator_keypairs,
-    } = setup;
+fn create_base3_cert_message(env: &BenchEnvironment, slot: u64, hash: Hash) -> ConsensusMessage {
+    let certificate = Certificate::NotarizeFallback(slot, hash);
 
-    const NUM_PACKETS: usize = 4096;
+    let vote1 = Vote::new_notarization_vote(slot, hash);
+    let payload1 = bincode::serialize(&vote1).unwrap();
+    let vote2 = Vote::new_notarization_fallback_vote(slot, hash);
+    let payload2 = bincode::serialize(&vote2).unwrap();
 
-    b.iter(move || {
-        let batches = gen_vote_batches(&validator_keypairs, NUM_PACKETS, &invalid_ratio);
-        let mut sent_len = 0;
-        for batch in batches {
-            sent_len += batch.len();
-            packet_sender.send(batch).unwrap();
-        }
+    let mut all_vote_messages = Vec::new();
 
-        let expected_len = match invalid_ratio {
-            InvalidVoteRatio::AllValid => sent_len,
-            InvalidVoteRatio::OneInvalid => sent_len - 1,
-            InvalidVoteRatio::TwentyPercentInvalid => sent_len - (sent_len / 5),
-        };
-        let mut received_len = 0;
-        let start = Instant::now();
-        loop {
-            if consensus_message_receiver.try_recv().is_ok() {
-                received_len += 1;
-                if received_len >= expected_len {
-                    break;
-                }
-            }
-            if start.elapsed() > Duration::from_secs(10) {
-                panic!("benchmark timed out");
-            }
-        }
+    // Define a split quorum: e.g., 40% sign Vote 1, 30% sign Vote 2 (Total 70%)
+    let split1 = (NUM_VALIDATORS * 40) / 100;
+    let split2 = (NUM_VALIDATORS * 70) / 100;
+
+    // Signers for Vote 1
+    for i in 0..split1 {
+        let signature = env.validator_keypairs[i].bls_keypair.sign(&payload1);
+        all_vote_messages.push(VoteMessage {
+            vote: vote1,
+            signature: signature.into(),
+            rank: i as u16,
+        });
+    }
+    // Signers for Vote 2
+    for i in split1..split2 {
+        let signature = env.validator_keypairs[i].bls_keypair.sign(&payload2);
+        all_vote_messages.push(VoteMessage {
+            vote: vote2,
+            signature: signature.into(),
+            rank: i as u16,
+        });
+    }
+
+    let mut builder = VoteCertificateBuilder::new(certificate);
+    builder.aggregate(&all_vote_messages).unwrap();
+    let cert_message = builder.build().unwrap();
+    ConsensusMessage::Certificate(cert_message)
+}
+
+// Scenario 1: One batch with two votes.
+fn generate_two_votes_batch(env: &BenchEnvironment) -> Vec<PacketBatch> {
+    // Use Notarization votes as in the original hardcoded data structure.
+    let vote = Vote::new_notarization_vote(BENCH_SLOT, Hash::new_unique());
+    let payload = bincode::serialize(&vote).unwrap();
+
+    // Vote 1 (Signed by Rank 0)
+    let kp1 = &env.validator_keypairs[0].bls_keypair;
+    let sig1: BlsSignature = kp1.sign(&payload).into();
+    let msg1 = ConsensusMessage::Vote(VoteMessage {
+        vote,
+        signature: sig1,
+        rank: 0,
     });
 
-    stage.join().unwrap();
+    // Vote 2 (Signed by Rank 1)
+    let kp2 = &env.validator_keypairs[1].bls_keypair;
+    let sig2: BlsSignature = kp2.sign(&payload).into();
+    let msg2 = ConsensusMessage::Vote(VoteMessage {
+        vote,
+        signature: sig2,
+        rank: 1,
+    });
+
+    let packets = vec![message_to_packet(&msg1), message_to_packet(&msg2)];
+    vec![PinnedPacketBatch::new(packets).into()]
 }
 
-fn bench_bls(c: &mut Criterion) {
+// Scenario 2: One batch with a single vote.
+fn generate_single_vote_batch(env: &BenchEnvironment) -> Vec<PacketBatch> {
+    // Use a Finalization vote as in the original hardcoded data structure.
+    let vote = Vote::new_finalization_vote(BENCH_SLOT);
+    let payload = bincode::serialize(&vote).unwrap();
+
+    // Vote 1 (Signed by Rank 0)
+    let kp = &env.validator_keypairs[0].bls_keypair;
+    let sig: BlsSignature = kp.sign(&payload).into();
+    let msg = ConsensusMessage::Vote(VoteMessage {
+        vote,
+        signature: sig,
+        rank: 0,
+    });
+
+    let packets = vec![message_to_packet(&msg)];
+    vec![PinnedPacketBatch::new(packets).into()]
+}
+
+// Scenario 3: A batch with a single certificate.
+fn generate_single_cert_batch(env: &BenchEnvironment) -> Vec<PacketBatch> {
+    let hash = Hash::new_unique();
+    // Generate a Base2 certificate
+    let msg = create_base2_cert_message(env, BENCH_SLOT, hash);
+    let packets = vec![message_to_packet(&msg)];
+    vec![PinnedPacketBatch::new(packets).into()]
+}
+
+// Scenario 4: A batch with two certificates (one Base2, one Base3).
+fn generate_two_certs_batch(env: &BenchEnvironment) -> Vec<PacketBatch> {
+    let hash1 = Hash::new_unique();
+    let hash2 = Hash::new_unique();
+
+    // Cert 1 (Base2 - Notarize)
+    let msg1 = create_base2_cert_message(env, BENCH_SLOT, hash1);
+    // Cert 2 (Base3 - NotarizeFallback)
+    let msg2 = create_base3_cert_message(env, BENCH_SLOT + 1, hash2);
+
+    let packets = vec![message_to_packet(&msg1), message_to_packet(&msg2)];
+    vec![PinnedPacketBatch::new(packets).into()]
+}
+
+fn bench_votes(c: &mut Criterion) {
     solana_logger::setup();
-    c.bench_function("bls_sigverify_stage_all_valid", |b| {
-        bench_bls_sigverify_stage(b, InvalidVoteRatio::AllValid);
+    let env = setup_environment();
+    let mut group = c.benchmark_group("verify_votes");
+
+    // Benchmark Scenario 1: Two votes in one batch
+    group.throughput(Throughput::Elements(2));
+    group.bench_function("dynamic/two_votes_batch", |b| {
+        b.iter_batched(
+            || generate_two_votes_batch(&env),
+            |batches| env.verifier.verify_batches(batches, 2),
+            BatchSize::SmallInput,
+        );
     });
-    c.bench_function("bls_sigverify_stage_one_invalid", |b| {
-        bench_bls_sigverify_stage(b, InvalidVoteRatio::OneInvalid);
+
+    // Benchmark Scenario 2: Single vote in one batch
+    group.throughput(Throughput::Elements(1));
+    group.bench_function("dynamic/single_vote_batch", |b| {
+        b.iter_batched(
+            || generate_single_vote_batch(&env),
+            |batches| env.verifier.verify_batches(batches, 1),
+            BatchSize::SmallInput,
+        );
     });
-    c.bench_function("bls_sigverify_stage_20p_invalid", |b| {
-        bench_bls_sigverify_stage(b, InvalidVoteRatio::TwentyPercentInvalid);
-    });
+
+    group.finish();
 }
 
-criterion_group!(benches, bench_bls);
+fn bench_certificates(c: &mut Criterion) {
+    solana_logger::setup();
+    let env = setup_environment();
+    let mut group = c.benchmark_group("verify_certificates");
+
+    // Benchmark Scenario 3: Single certificate batch (Base2)
+    group.throughput(Throughput::Elements(1));
+    group.bench_function("dynamic/single_cert_batch_base2", |b| {
+        b.iter_batched(
+            || generate_single_cert_batch(&env),
+            |batches| env.verifier.verify_batches(batches, 1),
+            BatchSize::SmallInput,
+        );
+    });
+
+    // Benchmark Scenario 4: Two certificates batch (Base2 + Base3)
+    group.throughput(Throughput::Elements(2));
+    group.bench_function("dynamic/two_certs_batch_base2_base3", |b| {
+        b.iter_batched(
+            || generate_two_certs_batch(&env),
+            |batches| env.verifier.verify_batches(batches, 2),
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_votes, bench_certificates);
 criterion_main!(benches);

--- a/core/benches/bls_sigverify.rs
+++ b/core/benches/bls_sigverify.rs
@@ -206,6 +206,7 @@ fn bench_votes(c: &mut Criterion) {
     let mut group = c.benchmark_group("verify_votes");
 
     // Benchmark Scenario 1: Two votes in one batch
+    // (about 20% of the non-zero votes in the test-cluster consist of a single vote)
     group.throughput(Throughput::Elements(2));
     group.bench_function("dynamic/two_votes_batch", |b| {
         b.iter_batched(
@@ -216,6 +217,7 @@ fn bench_votes(c: &mut Criterion) {
     });
 
     // Benchmark Scenario 2: Single vote in one batch
+    // (about 80% of the non-zero votes in the test-cluster consist of a single vote)
     group.throughput(Throughput::Elements(1));
     group.bench_function("dynamic/single_vote_batch", |b| {
         b.iter_batched(

--- a/core/benches/bls_sigverify.rs
+++ b/core/benches/bls_sigverify.rs
@@ -25,7 +25,7 @@ use {
 
 const BENCH_SLOT: u64 = 70;
 // TODO(sam): use a small number for now to emulate the current test cluster
-const NUM_VALIDATORS: usize = 100;
+const NUM_VALIDATORS: usize = 50;
 
 struct BenchEnvironment {
     verifier: BLSSigVerifier,


### PR DESCRIPTION
#### Summary of Changes

I used the logs in the current alpenglow test cluster re-organize the batches for testing in the bls-sigverify bench logic.

I first attempted to hard-code some of the vote and certificate batches in the benches, but it was hard to set up the test because the vote and certificate messages do not contain the actual validator keypairs. So I updated the code so that the bench logic freshly generates vote and certificate messages that model the batch of votes and certificate messages seen commonly in the logs. 