### PR TITLE
feat: actually dump alpenglow metrics

### DIFF
--- a/votor/src/consensus_metrics.rs
+++ b/votor/src/consensus_metrics.rs
@@ -1,7 +1,7 @@
 use {
     histogram::Histogram,
     solana_clock::{Epoch, Slot},
-    solana_metrics::{datapoint::DataPoint, submit},
+    solana_metrics::datapoint_info,
     solana_pubkey::Pubkey,
     solana_votor_messages::vote::Vote,
     std::{
@@ -170,86 +170,44 @@ impl ConsensusMetrics {
     fn end_of_epoch_reporting(&mut self) {
         for (addr, metrics) in &self.node_metrics {
             let addr = addr.to_string();
-            let mut datapoint = DataPoint::new("votor_consensus_metrics");
-            datapoint.add_tag("address", &addr);
+            datapoint_info!("votor_consensus_metrics",
+                "address" => addr,
+                ("notar_vote_count", metrics.notar.entries(), i64),
+                ("notar_vote_mean", metrics.notar.mean().ok(), Option<i64>),
+                ("notar_vote_stddev", metrics.notar.stddev(), Option<i64>),
+                ("notar_vote_maximum", metrics.notar.maximum().ok(), Option<i64>),
 
-            datapoint.add_field_u64("notar_vote_count", metrics.notar.entries());
-            if let Ok(v) = metrics.notar.mean() {
-                datapoint.add_field_u64("notar_vote_mean", v);
-            }
-            if let Some(v) = metrics.notar.stddev() {
-                datapoint.add_field_u64("notar_vote_stddev", v);
-            }
-            if let Ok(v) = metrics.notar.maximum() {
-                datapoint.add_field_u64("notar_vote_maximum", v);
-            }
+                ("notar_fallback_vote_count", metrics.notar_fallback.entries(), i64),
+                ("notar_fallback_vote_mean", metrics.notar_fallback.mean().ok(), Option<i64>),
+                ("notar_fallback_vote_stddev", metrics.notar_fallback.stddev(), Option<i64>),
+                ("notar_fallback_vote_maximum", metrics.notar_fallback.maximum().ok(), Option<i64>),
 
-            datapoint.add_field_u64(
-                "notar_fallback_vote_count",
-                metrics.notar_fallback.entries(),
+                ("skip_vote_count", metrics.skip.entries(), i64),
+                ("skip_vote_mean", metrics.skip.mean().ok(), Option<i64>),
+                ("skip_vote_stddev", metrics.skip.stddev(), Option<i64>),
+                ("skip_vote_maximum", metrics.skip.maximum().ok(), Option<i64>),
+
+                ("skip_fallback_vote_count", metrics.skip_fallback.entries(), i64),
+                ("skip_fallback_vote_mean", metrics.skip_fallback.mean().ok(), Option<i64>),
+                ("skip_fallback_vote_stddev", metrics.skip_fallback.stddev(), Option<i64>),
+                ("skip_fallback_vote_maximum", metrics.skip_fallback.maximum().ok(), Option<i64>),
+
+                ("finalize_vote_count", metrics.final_.entries(), i64),
+                ("finalize_vote_mean", metrics.final_.mean().ok(), Option<i64>),
+                ("finalize_vote_stddev", metrics.final_.stddev(), Option<i64>),
+                ("finalize_vote_maximum", metrics.final_.maximum().ok(), Option<i64>),
             );
-            if let Ok(v) = metrics.notar_fallback.mean() {
-                datapoint.add_field_u64("notar_fallback_vote_mean", v);
-            }
-            if let Some(v) = metrics.notar_fallback.stddev() {
-                datapoint.add_field_u64("notar_fallback_vote_stddev", v);
-            }
-            if let Ok(v) = metrics.notar_fallback.maximum() {
-                datapoint.add_field_u64("notar_fallback_vote_maximum", v);
-            }
-
-            datapoint.add_field_u64("skip_vote_count", metrics.skip.entries());
-            if let Ok(v) = metrics.skip.mean() {
-                datapoint.add_field_u64("skip_vote_mean", v);
-            }
-            if let Some(v) = metrics.skip.stddev() {
-                datapoint.add_field_u64("skip_vote_stddev", v);
-            }
-            if let Ok(v) = metrics.skip.maximum() {
-                datapoint.add_field_u64("skip_vote_maximum", v);
-            }
-
-            datapoint.add_field_u64("skip_fallback_vote_count", metrics.skip_fallback.entries());
-            if let Ok(v) = metrics.skip_fallback.mean() {
-                datapoint.add_field_u64("skip_fallback_vote_mean", v);
-            }
-            if let Some(v) = metrics.skip_fallback.stddev() {
-                datapoint.add_field_u64("skip_fallback_vote_stddev", v);
-            }
-            if let Ok(v) = metrics.skip_fallback.maximum() {
-                datapoint.add_field_u64("skip_fallback_vote_maximum", v);
-            }
-
-            datapoint.add_field_u64("finalize_vote_count", metrics.final_.entries());
-            if let Ok(v) = metrics.final_.mean() {
-                datapoint.add_field_u64("finalize_vote_mean", v);
-            }
-            if let Some(v) = metrics.final_.stddev() {
-                datapoint.add_field_u64("finalize_vote_stddev", v);
-            }
-            if let Ok(v) = metrics.final_.maximum() {
-                datapoint.add_field_u64("finalize_vote_maximum", v);
-            }
-
-            submit(datapoint, log::Level::Info);
         }
 
         for (addr, histogram) in &self.leader_metrics {
             let addr = addr.to_string();
-            let mut datapoint = DataPoint::new("votor_consensus_metrics");
-            datapoint.add_tag("address", &addr);
-
-            datapoint.add_field_u64("blocks_seen_count", histogram.entries());
-            if let Ok(v) = histogram.mean() {
-                datapoint.add_field_u64("blocks_seen_mean", v);
-            }
-            if let Some(v) = histogram.stddev() {
-                datapoint.add_field_u64("blocks_seen_stddev", v);
-            }
-            if let Ok(v) = histogram.maximum() {
-                datapoint.add_field_u64("blocks_seen_maximum", v);
-            }
-            submit(datapoint, log::Level::Info);
+            datapoint_info!("votor_consensus_metrics",
+                "address" => addr,
+                ("blocks_seen_vote_count", histogram.entries(), i64),
+                ("blocks_seen_vote_mean", histogram.mean().ok(), Option<i64>),
+                ("blocks_seen_vote_stddev", histogram.stddev(), Option<i64>),
+                ("blocks_seen_vote_maximum", histogram.maximum().ok(), Option<i64>),
+            );
         }
 
         self.node_metrics.clear();


### PR DESCRIPTION
Closes: #408 

In the earlier PR, we collected the metrics but did not actually dump them.  In this PR, we are also dumping the metrics.

The `Datapoint` API is quite restrictive requiring `&'static str` for various arguments forcing a lot of code duplication.  On my long list of issues to explore is to see if we can make the `Datapoint` API a bit more friendlier to use.