### PR TITLE
refactor: improves consensus related metrics

### DIFF
--- a/votor/src/consensus_metrics.rs
+++ b/votor/src/consensus_metrics.rs
@@ -181,29 +181,29 @@ impl ConsensusMetrics {
             datapoint_info!("consensus_vote_metrics",
                 "address" => addr,
                 ("notar_vote_count", metrics.notar.entries(), i64),
-                ("notar_vote_mean", metrics.notar.mean().ok(), Option<i64>),
-                ("notar_vote_stddev", metrics.notar.stddev(), Option<i64>),
-                ("notar_vote_maximum", metrics.notar.maximum().ok(), Option<i64>),
+                ("notar_vote_us_mean", metrics.notar.mean().ok(), Option<i64>),
+                ("notar_vote_us_stddev", metrics.notar.stddev(), Option<i64>),
+                ("notar_vote_us_maximum", metrics.notar.maximum().ok(), Option<i64>),
 
                 ("notar_fallback_vote_count", metrics.notar_fallback.entries(), i64),
-                ("notar_fallback_vote_mean", metrics.notar_fallback.mean().ok(), Option<i64>),
-                ("notar_fallback_vote_stddev", metrics.notar_fallback.stddev(), Option<i64>),
-                ("notar_fallback_vote_maximum", metrics.notar_fallback.maximum().ok(), Option<i64>),
+                ("notar_fallback_vote_us_mean", metrics.notar_fallback.mean().ok(), Option<i64>),
+                ("notar_fallback_vote_us_stddev", metrics.notar_fallback.stddev(), Option<i64>),
+                ("notar_fallback_vote_us_maximum", metrics.notar_fallback.maximum().ok(), Option<i64>),
 
                 ("skip_vote_count", metrics.skip.entries(), i64),
-                ("skip_vote_mean", metrics.skip.mean().ok(), Option<i64>),
-                ("skip_vote_stddev", metrics.skip.stddev(), Option<i64>),
-                ("skip_vote_maximum", metrics.skip.maximum().ok(), Option<i64>),
+                ("skip_vote_us_mean", metrics.skip.mean().ok(), Option<i64>),
+                ("skip_vote_us_stddev", metrics.skip.stddev(), Option<i64>),
+                ("skip_vote_us_maximum", metrics.skip.maximum().ok(), Option<i64>),
 
                 ("skip_fallback_vote_count", metrics.skip_fallback.entries(), i64),
-                ("skip_fallback_vote_mean", metrics.skip_fallback.mean().ok(), Option<i64>),
-                ("skip_fallback_vote_stddev", metrics.skip_fallback.stddev(), Option<i64>),
-                ("skip_fallback_vote_maximum", metrics.skip_fallback.maximum().ok(), Option<i64>),
+                ("skip_fallback_vote_us_mean", metrics.skip_fallback.mean().ok(), Option<i64>),
+                ("skip_fallback_vote_us_stddev", metrics.skip_fallback.stddev(), Option<i64>),
+                ("skip_fallback_vote_us_maximum", metrics.skip_fallback.maximum().ok(), Option<i64>),
 
                 ("finalize_vote_count", metrics.final_.entries(), i64),
-                ("finalize_vote_mean", metrics.final_.mean().ok(), Option<i64>),
-                ("finalize_vote_stddev", metrics.final_.stddev(), Option<i64>),
-                ("finalize_vote_maximum", metrics.final_.maximum().ok(), Option<i64>),
+                ("finalize_vote_us_mean", metrics.final_.mean().ok(), Option<i64>),
+                ("finalize_vote_us_stddev", metrics.final_.stddev(), Option<i64>),
+                ("finalize_vote_us_maximum", metrics.final_.maximum().ok(), Option<i64>),
             );
         }
 
@@ -212,14 +212,14 @@ impl ConsensusMetrics {
             datapoint_info!("consensus_block_hash_seen_metrics",
                 "address" => addr,
                 ("block_hash_seen_count", histogram.entries(), i64),
-                ("block_hash_seen_mean", histogram.mean().ok(), Option<i64>),
-                ("block_hash_seen_stddev", histogram.stddev(), Option<i64>),
-                ("block_hash_seen_maximum", histogram.maximum().ok(), Option<i64>),
+                ("block_hash_seen_us_mean", histogram.mean().ok(), Option<i64>),
+                ("block_hash_seen_us_stddev", histogram.stddev(), Option<i64>),
+                ("block_hash_seen_us_maximum", histogram.maximum().ok(), Option<i64>),
             );
         }
 
         datapoint_info!(
-            "consensus_metrics",
+            "consensus_metrics_internals",
             ("start_of_slot_count", self.start_of_slot.len(), i64),
             (
                 "metrics_recording_failed",


### PR DESCRIPTION
- rewords the `block_hash_seen` metrics
- add `_us` to the timing related metrics
- creates two classes of metrics (one for votes and one for block hash seen) so that the addresses tags for the two are not getting mixed up.
- adds metrics for how many failures there were and how many times `start_of_slot` was called