### PR TITLE
Rename AlpenglowCommitment to Commitment to keep in sync with Agave.

### DIFF
--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -10,7 +10,10 @@ use {
         bank::Bank,
         commitment::{BlockCommitment, BlockCommitmentCache, CommitmentSlots, VOTE_THRESHOLD_SIZE},
     },
-    solana_votor::commitment::{AlpenglowCommitmentAggregationData, AlpenglowCommitmentType},
+    solana_votor::commitment::{
+        CommitmentAggregationData as AlpenglowCommitmentAggregationData,
+        CommitmentType as AlpenglowCommitmentType,
+    },
     std::{
         cmp::max,
         collections::HashMap,

--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         certificate_limits_and_vote_types,
-        commitment::AlpenglowCommitmentError,
+        commitment::CommitmentError,
         conflicting_types,
         consensus_pool::{
             parent_ready_tracker::ParentReadyTracker,
@@ -81,8 +81,8 @@ pub enum AddVoteError {
     InvalidRank(u16),
 }
 
-impl From<AlpenglowCommitmentError> for AddVoteError {
-    fn from(_: AlpenglowCommitmentError) -> Self {
+impl From<CommitmentError> for AddVoteError {
+    fn from(_: CommitmentError) -> Self {
         AddVoteError::ChannelDisconnected("CommitmentSender".to_string())
     }
 }

--- a/votor/src/voting_utils.rs
+++ b/votor/src/voting_utils.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        commitment::{AlpenglowCommitmentAggregationData, AlpenglowCommitmentError},
+        commitment::{CommitmentAggregationData, CommitmentError},
         consensus_metrics::ConsensusMetrics,
         vote_history::{VoteHistory, VoteHistoryError},
         vote_history_storage::{SavedVoteHistory, SavedVoteHistoryVersions},
@@ -104,7 +104,7 @@ pub enum VoteError {
     ConsensusPoolError(#[from] SendError<()>),
 
     #[error("Commitment sender error {0}")]
-    CommitmentSenderError(#[from] AlpenglowCommitmentError),
+    CommitmentSenderError(#[from] CommitmentError),
 
     #[error("Saved vote history error {0}")]
     SavedVoteHistoryError(#[from] VoteHistoryError),
@@ -121,7 +121,7 @@ pub struct VotingContext {
     pub has_new_vote_been_rooted: bool,
     pub own_vote_sender: Sender<ConsensusMessage>,
     pub bls_sender: Sender<BLSOp>,
-    pub commitment_sender: Sender<AlpenglowCommitmentAggregationData>,
+    pub commitment_sender: Sender<CommitmentAggregationData>,
     pub wait_to_vote_slot: Option<u64>,
     pub sharable_banks: SharableBanks,
     pub consensus_metrics: Arc<PlRwLock<ConsensusMetrics>>,

--- a/votor/src/votor.rs
+++ b/votor/src/votor.rs
@@ -42,7 +42,7 @@
 //!
 use {
     crate::{
-        commitment::AlpenglowCommitmentAggregationData,
+        commitment::CommitmentAggregationData,
         consensus_metrics::ConsensusMetrics,
         consensus_pool_service::{ConsensusPoolContext, ConsensusPoolService},
         event::{LeaderWindowInfo, VotorEventReceiver, VotorEventSender},
@@ -111,7 +111,7 @@ pub struct VotorConfig {
     // Senders / Notifiers
     pub snapshot_controller: Option<Arc<SnapshotController>>,
     pub bls_sender: Sender<BLSOp>,
-    pub commitment_sender: Sender<AlpenglowCommitmentAggregationData>,
+    pub commitment_sender: Sender<CommitmentAggregationData>,
     pub drop_bank_sender: Sender<Vec<BankWithScheduler>>,
     pub bank_notification_sender: Option<BankNotificationSenderConfig>,
     pub leader_window_notifier: Arc<LeaderWindowNotifier>,


### PR DESCRIPTION
#### Problem
We renamed AlpenglowCommitment to Commitment when upstreaming to Agave, should do the same here.