### PR TITLE
Fix event_handler coverage test by changing timeout.

### DIFF
--- a/votor/src/common.rs
+++ b/votor/src/common.rs
@@ -97,7 +97,12 @@ pub(crate) const DELTA_BLOCK: Duration = Duration::from_millis(400);
 pub(crate) const DELTA_TIMEOUT: Duration = DELTA.checked_mul(3).unwrap();
 
 /// Timeout for standstill detection mechanism.
+#[cfg(not(test))]
 pub(crate) const DELTA_STANDSTILL: Duration = Duration::from_millis(10_000);
+
+/// Shorter timeout for standstill detection mechanism during tests.
+#[cfg(test)]
+pub(crate) const DELTA_STANDSTILL: Duration = Duration::from_millis(10);
 
 /// Returns the Duration for when the `SkipTimer` should be set for for the given slot in the leader window.
 #[inline]


### PR DESCRIPTION
#### Problem
The original event_handler tests were reverted because they failed coverage tests on ci machine.

#### Summary of Changes
- We can directly call `handle_event`, but that won't work in the future if we somehow add some code outside handle_event, blindly testing input/output on the event loop is still ideal because it is ignorant of internal implementation
- When I did revert of 8243 (https://github.com/anza-xyz/agave/pull/8251), I set the timeout to 50ms and the test passed. To be extra careful, I'm setting the timeout to 100ms now, and I'll test it on ci machine for a few days (https://github.com/anza-xyz/agave/pull/8304) to see that coverage tests keep passing
- Also reworked a few delay related items to make sure we don't actually wait that long in tests
