### PR TITLE
feat: improvements to `ConsensusMetrics` based on observed data

### DIFF
--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -244,17 +244,24 @@ impl EventHandler {
             // Block has completed replay
             VotorEvent::Block(CompletedBlock { slot, bank }) => {
                 debug_assert!(bank.is_frozen());
-                vctx.consensus_metrics.record_start_of_slot(slot);
-                match vctx
-                    .consensus_metrics
-                    .record_block_hash_seen(*bank.collector_id(), slot)
                 {
-                    Ok(()) => (),
-                    Err(err) => {
-                        error!("{my_pubkey}: recording block on slot {slot} failed with {err:?}");
+                    let mut metrics_guard = vctx.consensus_metrics.write();
+                    metrics_guard.record_start_of_slot(slot);
+                    if slot == first_of_consecutive_leader_slots(slot) {
+                        // all slots except the first in the window would typically start when the block is seen so the recording would essentially record 0.
+                        // hence we skip it.
+                        match metrics_guard.record_block_hash_seen(*bank.collector_id(), slot) {
+                            Ok(()) => (),
+                            Err(err) => {
+                                error!(
+                                    "{my_pubkey}: recording block on slot {slot} failed with \
+                                     {err:?}"
+                                );
+                            }
+                        }
                     }
+                    metrics_guard.maybe_new_epoch(bank.epoch());
                 }
-                vctx.consensus_metrics.maybe_new_epoch(bank.epoch());
                 let (block, parent_block) = Self::get_block_parent_block(&bank);
                 info!("{my_pubkey}: Block {block:?} parent {parent_block:?}");
                 if Self::try_notar(
@@ -311,7 +318,7 @@ impl EventHandler {
 
             // Received a parent ready notification for `slot`
             VotorEvent::ParentReady { slot, parent_block } => {
-                vctx.consensus_metrics.record_start_of_slot(slot);
+                vctx.consensus_metrics.write().record_start_of_slot(slot);
                 Self::handle_parent_ready_event(
                     slot,
                     parent_block,
@@ -336,6 +343,7 @@ impl EventHandler {
                 info!("{my_pubkey}: Timeout {slot}");
                 if slot != last_of_consecutive_leader_slots(slot) {
                     vctx.consensus_metrics
+                        .write()
                         .record_start_of_slot(slot.saturating_add(1));
                 }
                 if vctx.vote_history.voted(slot) {
@@ -402,11 +410,6 @@ impl EventHandler {
             // We have finalized this block consider it for rooting
             VotorEvent::Finalized(block, is_fast_finalization) => {
                 info!("{my_pubkey}: Finalized {block:?} fast: {is_fast_finalization}");
-                let (slot, _) = block;
-                if slot != last_of_consecutive_leader_slots(slot) {
-                    vctx.consensus_metrics
-                        .record_start_of_slot(slot.saturating_add(1));
-                }
                 finalized_blocks.insert(block);
                 Self::check_rootable_blocks(
                     my_pubkey,
@@ -864,7 +867,7 @@ mod tests {
         let exit = Arc::new(AtomicBool::new(false));
         let start = Arc::new((Mutex::new(true), Condvar::new()));
         let (event_sender, event_receiver) = unbounded();
-        let consensus_metrics = ConsensusMetrics::new(0);
+        let consensus_metrics = Arc::new(PlRwLock::new(ConsensusMetrics::new(0)));
         let timer_manager = Arc::new(PlRwLock::new(TimerManager::new(
             event_sender.clone(),
             exit.clone(),

--- a/votor/src/votor.rs
+++ b/votor/src/votor.rs
@@ -188,7 +188,9 @@ impl Votor {
             vote_history_storage,
         };
 
-        let consensus_metrics = ConsensusMetrics::new(sharable_banks.root().epoch());
+        let consensus_metrics = Arc::new(PlRwLock::new(ConsensusMetrics::new(
+            sharable_banks.root().epoch(),
+        )));
         let voting_context = VotingContext {
             vote_history,
             vote_account_pubkey: vote_account,
@@ -201,7 +203,7 @@ impl Votor {
             commitment_sender: commitment_sender.clone(),
             wait_to_vote_slot,
             sharable_banks: sharable_banks.clone(),
-            consensus_metrics,
+            consensus_metrics: consensus_metrics.clone(),
         };
 
         let root_context = RootContext {
@@ -238,6 +240,7 @@ impl Votor {
             bls_sender,
             event_sender,
             commitment_sender,
+            consensus_metrics,
         };
 
         let event_handler = EventHandler::new(event_handler_context);


### PR DESCRIPTION
https://anza-xyz.slack.com/archives/C06GZ20BPQB/p1759399012138259?thread_ts=1759232075.506819&cid=C06GZ20BPQB also contains more information.

This PR does the following:

- does not start the the next slot when the finalization cert for the current slot is seen as this is too early.
- only records `block_hash_seen` for the first slot in the window as for the other slots, the metric should be approximately 0
- previously a node was only recording its own vote.  Moved the vote recording to a different place where hopefully it will record votes from all nodes including self
