### PR TITLE
Replace numbers in consensus_pool_service stats with Saturating<usize>.

### DIFF
--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -91,11 +91,11 @@ impl ConsensusPoolService {
         if new_finalized_slot.is_some() {
             // Reset standstill timer
             *standstill_timer = Instant::now();
-            ConsensusPoolServiceStats::incr_u16(&mut stats.new_finalized_slot);
+            stats.new_finalized_slot += 1;
         }
         let bank = sharable_banks.root();
         consensus_pool.prune_old_state(bank.slot());
-        ConsensusPoolServiceStats::incr_u64(&mut stats.prune_old_state_called);
+        stats.prune_old_state_called += 1;
         // Send new certificates to peers
         Self::send_certificates(bls_sender, new_certificates_to_send, stats)
     }
@@ -112,7 +112,7 @@ impl ConsensusPoolService {
                 certificate: certificate.clone(),
             }) {
                 Ok(_) => {
-                    ConsensusPoolServiceStats::incr_u16(&mut stats.certificates_sent);
+                    stats.certificates_sent += 1;
                 }
                 Err(TrySendError::Disconnected(_)) => {
                     return Err(AddVoteError::ChannelDisconnected(
@@ -120,8 +120,7 @@ impl ConsensusPoolService {
                     ));
                 }
                 Err(TrySendError::Full(_)) => {
-                    let dropped = certificates_to_send.len().saturating_sub(i) as u16;
-                    stats.certificates_dropped = stats.certificates_dropped.saturating_add(dropped);
+                    stats.certificates_dropped += certificates_to_send.len().saturating_sub(i);
                     return Err(AddVoteError::VotingServiceQueueFull);
                 }
             }
@@ -140,10 +139,10 @@ impl ConsensusPoolService {
     ) -> Result<(), AddVoteError> {
         match message {
             ConsensusMessage::Certificate(_) => {
-                ConsensusPoolServiceStats::incr_u32(&mut stats.received_certificates);
+                stats.received_certificates += 1;
             }
             ConsensusMessage::Vote(_) => {
-                ConsensusPoolServiceStats::incr_u32(&mut stats.received_votes);
+                stats.received_votes += 1;
             }
         }
         let root_bank = ctx.sharable_banks.root();
@@ -281,7 +280,7 @@ impl ConsensusPoolService {
                     Err(e) => {
                         // This is a non critical error, a duplicate vote for example
                         trace!("{}: unable to push vote into pool {}", &my_pubkey, e);
-                        ConsensusPoolServiceStats::incr_u32(&mut stats.add_message_failed);
+                        stats.add_message_failed += 1;
                     }
                 }
             }
@@ -385,7 +384,7 @@ impl ConsensusPoolService {
                     "{my_pubkey}: Leader slot {start_slot} has already been certified, skipping \
                      production of {start_slot}-{end_slot}"
                 );
-                ConsensusPoolServiceStats::incr_u16(&mut stats.parent_ready_missed_window);
+                stats.parent_ready_missed_window += 1;
             }
             BlockProductionParent::ParentNotReady => {
                 // This can't happen, place holder depending on how we hook up optimistic
@@ -403,7 +402,7 @@ impl ConsensusPoolService {
                     // TODO: we can just remove this
                     skip_timer: Instant::now(),
                 }));
-                ConsensusPoolServiceStats::incr_u16(&mut stats.parent_ready_produce_window);
+                stats.parent_ready_produce_window += 1;
             }
         }
     }

--- a/votor/src/consensus_pool_service/stats.rs
+++ b/votor/src/consensus_pool_service/stats.rs
@@ -1,96 +1,87 @@
 use {
-    solana_metrics::datapoint_info,
-    std::time::{Duration, Instant},
+    solana_metrics::create_datapoint,
+    std::{
+        num::Saturating,
+        time::{Duration, Instant},
+    },
 };
 
 const STATS_REPORT_INTERVAL: Duration = Duration::from_secs(10);
 
 #[derive(Debug)]
 pub(crate) struct ConsensusPoolServiceStats {
-    pub(crate) add_message_failed: u32,
-    pub(crate) certificates_sent: u16,
-    pub(crate) certificates_dropped: u16,
-    pub(crate) new_finalized_slot: u16,
-    pub(crate) parent_ready_missed_window: u16,
-    pub(crate) parent_ready_produce_window: u16,
-    pub(crate) received_votes: u32,
-    pub(crate) received_certificates: u32,
+    pub(crate) add_message_failed: Saturating<usize>,
+    pub(crate) certificates_sent: Saturating<usize>,
+    pub(crate) certificates_dropped: Saturating<usize>,
+    pub(crate) new_finalized_slot: Saturating<usize>,
+    pub(crate) parent_ready_missed_window: Saturating<usize>,
+    pub(crate) parent_ready_produce_window: Saturating<usize>,
+    pub(crate) received_votes: Saturating<usize>,
+    pub(crate) received_certificates: Saturating<usize>,
     pub(crate) standstill: bool,
-    pub(crate) prune_old_state_called: u64,
+    pub(crate) prune_old_state_called: Saturating<usize>,
     last_request_time: Instant,
 }
 
 impl ConsensusPoolServiceStats {
     pub fn new() -> Self {
         Self {
-            add_message_failed: 0,
-            certificates_sent: 0,
-            certificates_dropped: 0,
-            new_finalized_slot: 0,
-            parent_ready_missed_window: 0,
-            parent_ready_produce_window: 0,
-            received_votes: 0,
-            received_certificates: 0,
+            add_message_failed: Saturating(0),
+            certificates_sent: Saturating(0),
+            certificates_dropped: Saturating(0),
+            new_finalized_slot: Saturating(0),
+            parent_ready_missed_window: Saturating(0),
+            parent_ready_produce_window: Saturating(0),
+            received_votes: Saturating(0),
+            received_certificates: Saturating(0),
             standstill: false,
-            prune_old_state_called: 0,
+            prune_old_state_called: Saturating(0),
             last_request_time: Instant::now(),
         }
     }
 
-    pub fn incr_u16(value: &mut u16) {
-        *value = value.saturating_add(1);
-    }
-
-    pub fn incr_u32(value: &mut u32) {
-        *value = value.saturating_add(1);
-    }
-
-    pub fn incr_u64(value: &mut u64) {
-        *value = value.saturating_add(1);
-    }
-
-    fn reset(&mut self) {
-        self.add_message_failed = 0;
-        self.certificates_sent = 0;
-        self.certificates_dropped = 0;
-        self.new_finalized_slot = 0;
-        self.parent_ready_missed_window = 0;
-        self.parent_ready_produce_window = 0;
-        self.received_votes = 0;
-        self.received_certificates = 0;
-        self.standstill = false;
-        self.prune_old_state_called = 0;
-        self.last_request_time = Instant::now();
-    }
-
     fn report(&self) {
-        datapoint_info!(
-            "consensus_pool_service",
-            ("add_message_failed", self.add_message_failed, i64),
-            ("certificates_sent", self.certificates_sent, i64),
-            ("certificates_dropped", self.certificates_dropped, i64),
-            ("new_finalized_slot", self.new_finalized_slot, i64),
+        let &Self {
+            add_message_failed: Saturating(add_message_failed),
+            certificates_sent: Saturating(certificates_sent),
+            certificates_dropped: Saturating(certificates_dropped),
+            new_finalized_slot: Saturating(new_finalized_slot),
+            parent_ready_missed_window: Saturating(parent_ready_missed_window),
+            parent_ready_produce_window: Saturating(parent_ready_produce_window),
+            received_votes: Saturating(received_votes),
+            received_certificates: Saturating(received_certificates),
+            standstill,
+            prune_old_state_called: Saturating(prune_old_state_called),
+            ..
+        } = self;
+        let datapoint = create_datapoint!(
+            @point "consensus_pool_service",
+            ("add_message_failed", add_message_failed, i64),
+            ("certificates_sent", certificates_sent, i64),
+            ("certificates_dropped", certificates_dropped, i64),
+            ("new_finalized_slot", new_finalized_slot, i64),
             (
                 "parent_ready_missed_window",
-                self.parent_ready_missed_window,
+                parent_ready_missed_window,
                 i64
             ),
             (
                 "parent_ready_produce_window",
-                self.parent_ready_produce_window,
+                parent_ready_produce_window,
                 i64
             ),
-            ("received_votes", self.received_votes, i64),
-            ("received_certificates", self.received_certificates, i64),
-            ("standstill", self.standstill, i64),
-            ("prune_old_state_called", self.prune_old_state_called, i64),
+            ("received_votes", received_votes, i64),
+            ("received_certificates", received_certificates, i64),
+            ("standstill", standstill, i64),
+            ("prune_old_state_called", prune_old_state_called, i64),
         );
+        solana_metrics::submit(datapoint, log::Level::Info);
     }
 
     pub fn maybe_report(&mut self) {
         if self.last_request_time.elapsed() >= STATS_REPORT_INTERVAL {
             self.report();
-            self.reset();
+            *self = Self::new();
         }
     }
 }

--- a/votor/src/consensus_pool_service/stats.rs
+++ b/votor/src/consensus_pool_service/stats.rs
@@ -1,5 +1,5 @@
 use {
-    solana_metrics::create_datapoint,
+    solana_metrics::datapoint_info,
     std::{
         num::Saturating,
         time::{Duration, Instant},
@@ -54,8 +54,8 @@ impl ConsensusPoolServiceStats {
             prune_old_state_called: Saturating(prune_old_state_called),
             ..
         } = self;
-        let datapoint = create_datapoint!(
-            @point "consensus_pool_service",
+        datapoint_info!(
+            "consensus_pool_service",
             ("add_message_failed", add_message_failed, i64),
             ("certificates_sent", certificates_sent, i64),
             ("certificates_dropped", certificates_dropped, i64),
@@ -72,10 +72,9 @@ impl ConsensusPoolServiceStats {
             ),
             ("received_votes", received_votes, i64),
             ("received_certificates", received_certificates, i64),
-            ("standstill", standstill, i64),
+            ("standstill", standstill, bool),
             ("prune_old_state_called", prune_old_state_called, i64),
         );
-        solana_metrics::submit(datapoint, log::Level::Info);
     }
 
     pub fn maybe_report(&mut self) {


### PR DESCRIPTION
Replace u16/u32/u64 with Saturating<usize> so we can get rid of incr functions.
