### PR TITLE
feat: keep older vote messages for leaders in consensus pool

### DIFF
--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -185,8 +185,12 @@ impl ConsensusPoolService {
         let mut events = vec![];
         let mut my_pubkey = ctx.cluster_info.id();
         let root_bank = ctx.sharable_banks.root();
-        let mut consensus_pool =
-            ConsensusPool::new_from_root_bank(my_pubkey, &root_bank, ctx.consensus_metrics.clone());
+        let mut consensus_pool = ConsensusPool::new_from_root_bank(
+            my_pubkey,
+            &root_bank,
+            ctx.consensus_metrics.clone(),
+            ctx.leader_schedule_cache.clone(),
+        );
 
         // Wait until migration has completed
         info!("{}: Certificate pool loop initialized", &my_pubkey);


### PR DESCRIPTION
#### Problem

If we discard vote messages for any slots earlier than root slot, then the node that will be the leader in 8 slots will not be able to include them in the certs for rewards.

#### Summary of Changes

Similar to https://github.com/anza-xyz/alpenglow/pull/513, this updates the consensus pool to keep older votes.

Part of #406 