### PR TITLE
Add clone and filter for alpenglow to vote accounts

### DIFF
--- a/vote/src/vote_account.rs
+++ b/vote/src/vote_account.rs
@@ -1064,7 +1064,7 @@ mod tests {
             MIN_STAKE_FOR_STAKED_ACCOUNT,
             &identity_balances,
         );
-        assert!(filtered.len() <= num_alpenglow_nodes);
+        assert_eq!(filtered.len(), num_alpenglow_nodes);
         // Check that all filtered accounts have bls pubkey
         for (_pubkey, (_stake, vote_account)) in filtered.vote_accounts.iter() {
             assert!(vote_account


### PR DESCRIPTION
#### Summary of Changes
Implement `clone_and_filter_for_alpenglow` for Alpenglow VAT:
- Filter out any vote accounts without BLS pubkey
- Given `minimum_identity_account_balance` and `identity_account_balances`, filter out any vote account without required balance
- If we have more than `max_vote_accounts` vote accounts after above filtering, sort by stake and truncate
- If any vote account in the resulting list has the same stake as any truncated vote account, just remove this vote account as well (A and B have the same stake amount, it's unfair to keep A in and kick B out just because of Pubkey difference, because that can be grinded)
- If we end up with an empty list (could happen if everyone in the world has the same stake, happens in tests, doesn't happen in real world), log a warning