### PR TITLE
wip: type for slice root

### DIFF
--- a/gossip/src/duplicate_shred.rs
+++ b/gossip/src/duplicate_shred.rs
@@ -344,6 +344,7 @@ pub(crate) mod tests {
         solana_hash::Hash,
         solana_keypair::Keypair,
         solana_ledger::shred::{ProcessShredsStats, ReedSolomonCache, Shredder},
+        solana_runtime::bank::SliceRoot,
         solana_signature::Signature,
         solana_signer::Signer,
         solana_system_transaction::transfer,
@@ -457,7 +458,7 @@ pub(crate) mod tests {
             &entries,
             is_last_in_slot,
             // chained_merkle_root
-            Some(Hash::new_from_array(rng.gen())),
+            Some(SliceRoot(Hash::new_from_array(rng.gen()))),
             next_shred_index,
             next_code_index, // next_code_index
             &ReedSolomonCache::default(),

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -9,6 +9,7 @@ use {
     serde::{Deserialize, Deserializer, Serialize, Serializer},
     solana_clock::{Slot, UnixTimestamp},
     solana_hash::Hash,
+    solana_runtime::bank::SliceRoot,
     std::{
         collections::BTreeSet,
         ops::{Range, RangeBounds},
@@ -396,7 +397,7 @@ pub(crate) struct ErasureConfig {
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct MerkleRootMeta {
     /// The merkle root, `None` for legacy shreds
-    merkle_root: Option<Hash>,
+    merkle_root: Option<SliceRoot>,
     /// The first received shred index
     first_received_shred_index: u32,
     /// The shred type of the first received shred
@@ -872,7 +873,7 @@ impl MerkleRootMeta {
         }
     }
 
-    pub(crate) fn merkle_root(&self) -> Option<Hash> {
+    pub(crate) fn merkle_root(&self) -> Option<SliceRoot> {
         self.merkle_root
     }
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -2228,7 +2228,7 @@ pub fn process_single_slot(
         result?
     }
 
-    let block_id = blockstore
+    let chained_merkle_id = blockstore
         .check_last_fec_set_and_get_block_id(slot, bank.hash(), false, &bank.feature_set)
         .inspect_err(|err| {
             warn!("slot {slot} failed last fec set checks: {err}");
@@ -2243,7 +2243,7 @@ pub fn process_single_slot(
                 );
             }
         })?;
-    bank.set_block_id(block_id);
+    bank.set_chained_merkle_id(chained_merkle_id);
     bank.freeze(); // all banks handled by this routine are created from complete slots
 
     if let Some(slot_callback) = &opts.slot_callback {

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -74,6 +74,7 @@ use {
     solana_hash::Hash,
     solana_perf::packet::PacketRef,
     solana_pubkey::Pubkey,
+    solana_runtime::bank::SliceRoot,
     solana_sha256_hasher::hashv,
     solana_signature::{Signature, SIGNATURE_BYTES},
     static_assertions::const_assert_eq,
@@ -383,11 +384,11 @@ impl Shred {
     dispatch!(fn set_signature(&mut self, signature: Signature));
     dispatch!(fn signed_data(&self) -> Result<Hash, Error>);
 
-    dispatch!(pub fn chained_merkle_root(&self) -> Result<Hash, Error>);
+    dispatch!(pub fn chained_merkle_root(&self) -> Result<SliceRoot, Error>);
     dispatch!(pub(crate) fn retransmitter_signature(&self) -> Result<Signature, Error>);
 
     dispatch!(pub fn into_payload(self) -> Payload);
-    dispatch!(pub fn merkle_root(&self) -> Result<Hash, Error>);
+    dispatch!(pub fn merkle_root(&self) -> Result<SliceRoot, Error>);
     dispatch!(pub fn payload(&self) -> &Payload);
     dispatch!(pub fn sanitize(&self) -> Result<(), Error>);
 
@@ -916,7 +917,7 @@ mod tests {
         is_last_in_slot: bool,
     ) -> Result<Vec<merkle::Shred>, Error> {
         let thread_pool = ThreadPoolBuilder::new().num_threads(2).build().unwrap();
-        let chained_merkle_root = chained.then(|| Hash::new_from_array(rng.gen()));
+        let chained_merkle_root = chained.then(|| SliceRoot(Hash::new_from_array(rng.gen())));
         let parent_offset = rng.gen_range(1..=u16::try_from(slot).unwrap_or(u16::MAX));
         let parent_slot = slot.checked_sub(u64::from(parent_offset)).unwrap();
         let mut data = vec![0u8; data_size];
@@ -1529,7 +1530,7 @@ mod tests {
                 &keypair,
                 &data,
                 false,
-                Some(Hash::default()),
+                Some(SliceRoot(Hash::default())),
                 64,
                 64,
                 &reed_solomon_cache,

--- a/ledger/src/shred/shred_code.rs
+++ b/ledger/src/shred/shred_code.rs
@@ -9,6 +9,7 @@ use {
     },
     solana_hash::Hash,
     solana_packet::PACKET_DATA_SIZE,
+    solana_runtime::bank::SliceRoot,
     solana_signature::Signature,
     static_assertions::const_assert_eq,
 };
@@ -38,13 +39,13 @@ impl ShredCode {
         shred.signed_data()
     }
 
-    pub(super) fn chained_merkle_root(&self) -> Result<Hash, Error> {
+    pub(super) fn chained_merkle_root(&self) -> Result<SliceRoot, Error> {
         match self {
             Self::Merkle(shred) => shred.chained_merkle_root(),
         }
     }
 
-    pub(super) fn merkle_root(&self) -> Result<Hash, Error> {
+    pub(super) fn merkle_root(&self) -> Result<SliceRoot, Error> {
         match self {
             Self::Merkle(shred) => shred.merkle_root(),
         }

--- a/ledger/src/shred/shred_data.rs
+++ b/ledger/src/shred/shred_data.rs
@@ -10,6 +10,7 @@ use {
     },
     solana_clock::Slot,
     solana_hash::Hash,
+    solana_runtime::bank::SliceRoot,
     solana_signature::Signature,
 };
 
@@ -34,13 +35,13 @@ impl ShredData {
         shred.signed_data()
     }
 
-    pub(super) fn chained_merkle_root(&self) -> Result<Hash, Error> {
+    pub(super) fn chained_merkle_root(&self) -> Result<SliceRoot, Error> {
         match self {
             Self::Merkle(shred) => shred.chained_merkle_root(),
         }
     }
 
-    pub(super) fn merkle_root(&self) -> Result<Hash, Error> {
+    pub(super) fn merkle_root(&self) -> Result<SliceRoot, Error> {
         match self {
             Self::Merkle(shred) => shred.merkle_root(),
         }

--- a/ledger/src/shredder.rs
+++ b/ledger/src/shredder.rs
@@ -10,6 +10,7 @@ use {
     solana_hash::Hash,
     solana_keypair::Keypair,
     solana_rayon_threadlimit::get_thread_count,
+    solana_runtime::bank::SliceRoot,
     std::{
         fmt::Debug,
         sync::{Arc, OnceLock, RwLock},
@@ -69,7 +70,7 @@ impl Shredder {
         keypair: &Keypair,
         entries: &[Entry],
         is_last_in_slot: bool,
-        chained_merkle_root: Option<Hash>,
+        chained_merkle_root: Option<SliceRoot>,
         next_shred_index: u32,
         next_code_index: u32,
         reed_solomon_cache: &ReedSolomonCache,
@@ -98,7 +99,7 @@ impl Shredder {
         keypair: &Keypair,
         data: &[u8],
         is_last_in_slot: bool,
-        chained_merkle_root: Option<Hash>,
+        chained_merkle_root: Option<SliceRoot>,
         next_shred_index: u32,
         next_code_index: u32,
         reed_solomon_cache: &ReedSolomonCache,
@@ -128,7 +129,7 @@ impl Shredder {
         keypair: &Keypair,
         entries: &[Entry],
         is_last_in_slot: bool,
-        chained_merkle_root: Option<Hash>,
+        chained_merkle_root: Option<SliceRoot>,
         next_shred_index: u32,
         next_code_index: u32,
         reed_solomon_cache: &ReedSolomonCache,
@@ -204,7 +205,7 @@ impl Shredder {
             keypair,
             &[],
             true,
-            Some(Hash::default()),
+            Some(SliceRoot(Hash::default())),
             0,
             0,
             &reed_solomon_cache,
@@ -308,9 +309,9 @@ mod tests {
             &keypair,
             &entries,
             is_last_in_slot,
-            Some(Hash::new_from_array(rand::thread_rng().gen())), // chained_merkle_root
-            start_index,                                          // next_shred_index
-            start_index,                                          // next_code_index
+            Some(SliceRoot(Hash::new_from_array(rand::thread_rng().gen()))), // chained_merkle_root
+            start_index,                                                     // next_shred_index
+            start_index,                                                     // next_code_index
             &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         );
@@ -394,9 +395,9 @@ mod tests {
             &keypair,
             &entries,
             is_last_in_slot,
-            Some(Hash::new_from_array(rand::thread_rng().gen())), // chained_merkle_root
-            369,                                                  // next_shred_index
-            776,                                                  // next_code_index
+            Some(SliceRoot(Hash::new_from_array(rand::thread_rng().gen()))), // chained_merkle_root
+            369,                                                             // next_shred_index
+            776,                                                             // next_code_index
             &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         );
@@ -426,9 +427,9 @@ mod tests {
             &keypair,
             &entries,
             is_last_in_slot,
-            Some(Hash::new_from_array(rand::thread_rng().gen())), // chained_merkle_root
-            0,                                                    // next_shred_index
-            0,                                                    // next_code_index
+            Some(SliceRoot(Hash::new_from_array(rand::thread_rng().gen()))), // chained_merkle_root
+            0,                                                               // next_shred_index
+            0,                                                               // next_code_index
             &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         );
@@ -463,9 +464,9 @@ mod tests {
             &keypair,
             &entries,
             is_last_in_slot,
-            Some(Hash::new_from_array(rand::thread_rng().gen())), // chained_merkle_root
-            0,                                                    // next_shred_index
-            0,                                                    // next_code_index
+            Some(SliceRoot(Hash::new_from_array(rand::thread_rng().gen()))), // chained_merkle_root
+            0,                                                               // next_shred_index
+            0,                                                               // next_code_index
             &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         );
@@ -510,9 +511,9 @@ mod tests {
             &keypair,
             &entries,
             is_last_in_slot,
-            Some(Hash::new_from_array(rand::thread_rng().gen())), // chained_merkle_root
-            0,                                                    // next_shred_index
-            0,                                                    // next_code_index
+            Some(SliceRoot(Hash::new_from_array(rand::thread_rng().gen()))), // chained_merkle_root
+            0,                                                               // next_shred_index
+            0,                                                               // next_code_index
             &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         );
@@ -560,9 +561,9 @@ mod tests {
             &keypair,
             &entries,
             is_last_in_slot,
-            Some(Hash::new_from_array(rand::thread_rng().gen())), // chained_merkle_root
-            0,                                                    // next_shred_index
-            0,                                                    // next_code_index
+            Some(SliceRoot(Hash::new_from_array(rand::thread_rng().gen()))), // chained_merkle_root
+            0,                                                               // next_shred_index
+            0,                                                               // next_code_index
             &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         );
@@ -594,9 +595,9 @@ mod tests {
             &keypair,
             &entries,
             is_last_in_slot,
-            Some(Hash::new_from_array(rand::thread_rng().gen())), // chained_merkle_root
-            start_index,                                          // next_shred_index
-            start_index,                                          // next_code_index
+            Some(SliceRoot(Hash::new_from_array(rand::thread_rng().gen()))), // chained_merkle_root
+            start_index,                                                     // next_shred_index
+            start_index,                                                     // next_code_index
             &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         );

--- a/ledger/src/wire_format_tests.rs
+++ b/ledger/src/wire_format_tests.rs
@@ -47,8 +47,8 @@ mod tests {
         );
         println!(
             "Shred merkle root {:X?}, chained root {:X?}, rtx_sign {:X?}",
-            merkle_root.map(|v| v.as_ref().to_vec()),
-            chained_merkle_root.map(|v| v.as_ref().to_vec()),
+            merkle_root.map(|v| v.0.as_ref().to_vec()),
+            chained_merkle_root.map(|v| v.0.as_ref().to_vec()),
             rtx_sign.map(|v| v.as_ref().to_vec())
         );
         println!(

--- a/ledger/tests/shred.rs
+++ b/ledger/tests/shred.rs
@@ -8,6 +8,7 @@ use {
         self, max_entries_per_n_shred, recover, verify_test_data_shred, ProcessShredsStats,
         ReedSolomonCache, Shred, ShredData, Shredder, DATA_SHREDS_PER_FEC_BLOCK,
     },
+    solana_runtime::bank::SliceRoot,
     solana_signer::Signer,
     solana_system_transaction as system_transaction,
     std::{
@@ -32,7 +33,7 @@ fn test_multi_fec_block_coding(is_last_in_slot: bool) {
     let keypair1 = Keypair::new();
     let tx0 = system_transaction::transfer(&keypair0, &keypair1.pubkey(), 1, Hash::default());
     let entry = Entry::new(&Hash::default(), 1, vec![tx0]);
-    let chained_merkle_root = Some(Hash::default());
+    let chained_merkle_root = Some(SliceRoot(Hash::default()));
     let merkle_capacity = ShredData::capacity(Some((6, true, is_last_in_slot))).unwrap();
     let num_entries =
         max_entries_per_n_shred(&entry, num_data_shreds as u64, Some(merkle_capacity));
@@ -202,7 +203,7 @@ fn setup_different_sized_fec_blocks(
     let tx0 = system_transaction::transfer(&keypair0, &keypair1.pubkey(), 1, Hash::default());
     let entry = Entry::new(&Hash::default(), 1, vec![tx0]);
     let merkle_capacity = ShredData::capacity(Some((6, true, true))).unwrap();
-    let chained_merkle_root = Some(Hash::default());
+    let chained_merkle_root = Some(SliceRoot(Hash::default()));
 
     assert!(DATA_SHREDS_PER_FEC_BLOCK > 2);
     let num_shreds_per_iter = DATA_SHREDS_PER_FEC_BLOCK;

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -12440,15 +12440,32 @@ fn test_startup_from_snapshot_after_precompile_transition() {
 }
 
 #[test]
-fn test_parent_block_id() {
+fn test_parent_alpenglow_block_id() {
     // Setup parent bank and populate block ID.
     let (genesis_config, _mint_keypair) = create_genesis_config(100_000);
     let parent_bank = Arc::new(Bank::new_for_tests(&genesis_config));
-    let parent_block_id = Some(Hash::new_unique());
-    parent_bank.set_block_id(parent_block_id);
+    let parent_alpenglow_block_id = Some(AlpenglowBlockId(Hash::new_unique()));
+    parent_bank.set_alpenglow_block_id(parent_alpenglow_block_id);
 
     // Create child from parent and ensure parent block ID links back to the
     // expected value.
     let child_bank = Bank::new_from_parent(parent_bank, &Pubkey::new_unique(), 1);
-    assert_eq!(parent_block_id, child_bank.parent_block_id());
+    assert_eq!(
+        parent_alpenglow_block_id,
+        child_bank.parent_alpenglow_block_id()
+    );
+}
+
+#[test]
+fn test_parent_chained_merkle_id() {
+    // Setup parent bank and populate chained merkle.
+    let (genesis_config, _mint_keypair) = create_genesis_config(100_000);
+    let parent_bank = Arc::new(Bank::new_for_tests(&genesis_config));
+    let parent_chained_merkle = Some(SliceRoot(Hash::new_unique()));
+    parent_bank.set_chained_merkle_id(parent_chained_merkle);
+
+    // Create child from parent and ensure parent chained merkle links back to the
+    // expected value.
+    let child_bank = Bank::new_from_parent(parent_bank, &Pubkey::new_unique(), 1);
+    assert_eq!(parent_chained_merkle, child_bank.parent_chained_merkle_id());
 }

--- a/votor-messages/src/consensus_message.rs
+++ b/votor-messages/src/consensus_message.rs
@@ -5,13 +5,14 @@ use {
     solana_bls_signatures::Signature as BLSSignature,
     solana_clock::Slot,
     solana_hash::Hash,
+    solana_runtime::bank::SliceRoot,
 };
 
 /// The seed used to derive the BLS keypair
 pub const BLS_KEYPAIR_DERIVE_SEED: &[u8; 9] = b"alpenglow";
 
 /// Block, a (slot, hash) tuple
-pub type Block = (Slot, Hash);
+pub type Block = (Slot, SliceRoot);
 
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 /// BLS vote message, we need rank to look up pubkey

--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -136,7 +136,10 @@ impl ConsensusPool {
     pub fn new_from_root_bank(my_pubkey: Pubkey, bank: &Bank) -> Self {
         // To account for genesis and snapshots we allow default block id until
         // block id can be serialized  as part of the snapshot
-        let root_block = (bank.slot(), bank.block_id().unwrap_or_default());
+        let root_block = (
+            bank.slot(),
+            bank.chained_merkle_id().map(|sr| sr.0).unwrap_or_default(),
+        );
         let parent_ready_tracker = ParentReadyTracker::new(my_pubkey, root_block);
 
         Self {

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -198,7 +198,13 @@ impl ConsensusPoolService {
         let mut standstill_timer = Instant::now();
 
         // Kick off parent ready
-        let root_block = (root_bank.slot(), root_bank.block_id().unwrap_or_default());
+        let root_block = (
+            root_bank.slot(),
+            root_bank
+                .chained_merkle_id()
+                .map(|sr| sr.0)
+                .unwrap_or_default(),
+        );
         let mut highest_parent_ready = root_bank.slot();
         events.push(VotorEvent::ParentReady {
             slot: root_bank.slot().checked_add(1).unwrap(),

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -492,7 +492,7 @@ impl EventHandler {
             // We haven't finished replay for the block, so we can't trigger parent ready
             return None;
         }
-        if bank.block_id() != Some(block_id) {
+        if bank.chained_merkle_id() != Some(block_id) {
             // We have a different block id for the slot, repair should kick in later
             return None;
         }


### PR DESCRIPTION
#### Problem
Hash type is ubiquitous and a bit abused. For example, sometimes there's a comment next to some argument clarifying the the Hash type means slice merkle root. This makes it hard to introduce the double merkle block id and check for correctness.

#### Summary of Changes
Distinguish slice merkle roots with a new type.
Simplified the way the merkle tree implementation is indexed.