### PR TITLE
block component: `Entries` -> `EntryBatch`

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -4119,7 +4119,7 @@ impl Blockstore {
                         // TODO(karthik): if Alpenglow flag is disabled, return an error on special
                         // EntryBatches.
                         BlockComponent::from_bytes(&payload)
-                            .map(|eb| eb.entries().to_vec())
+                            .map(|eb| eb.entry_batch().to_vec())
                             .map_err(|e| {
                                 BlockstoreError::InvalidShredData(Box::new(
                                     bincode::ErrorKind::Custom(format!(


### PR DESCRIPTION
#### Problem
Folks refer to "entry batches" all the time, but we don't have an `EntryBatch` struct.

#### Summary of Changes
Rename `Entries` -> `EntryBatch`.