### PR TITLE
Cherry-pick: VoteStateV4 support #8017, #8077, #8120, #8178, #8191

### DIFF
--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -355,8 +355,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
     // vote account
     let default_bootstrap_validator_lamports = &(500 * LAMPORTS_PER_SOL)
-        .max(VoteStateV3::get_rent_exempt_reserve(&rent))
-        .max(rent.minimum_balance(VoteStateV3::size_of()).max(1))
+        .max(rent.minimum_balance(VoteStateV3::size_of()))
         .to_string();
 
     // stake account

--- a/programs/vote/benches/vote_instructions.rs
+++ b/programs/vote/benches/vote_instructions.rs
@@ -124,7 +124,7 @@ fn create_accounts() -> (Slot, SlotHashes, Vec<TransactionAccount>, Vec<AccountM
 
 fn create_test_account() -> (Pubkey, AccountSharedData) {
     let rent = Rent::default();
-    let balance = VoteStateV3::get_rent_exempt_reserve(&rent);
+    let balance = rent.minimum_balance(VoteStateV3::size_of());
     let vote_pubkey = solana_pubkey::new_rand();
     (
         vote_pubkey,

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -19,6 +19,7 @@ fn process_authorize_with_seed_instruction(
     invoke_context: &InvokeContext,
     instruction_context: &InstructionContext,
     vote_account: &mut BorrowedInstructionAccount,
+    target_version: vote_state::VoteStateTargetVersion,
     new_authority: &Pubkey,
     authorization_type: VoteAuthorize,
     current_authority_derived_key_owner: &Pubkey,
@@ -41,6 +42,7 @@ fn process_authorize_with_seed_instruction(
     };
     vote_state::authorize(
         vote_account,
+        target_version,
         new_authority,
         authorization_type,
         &expected_authority_keys,
@@ -64,6 +66,9 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
         return Err(InstructionError::InvalidAccountOwner);
     }
 
+    // Determine the target vote state version to use for all operations.
+    let target_version = vote_state::TEMP_HARDCODED_TARGET_VERSION;
+
     let signers = instruction_context.get_signers()?;
     match limited_deserialize(data, solana_packet::PACKET_DATA_SIZE as u64)? {
         VoteInstruction::InitializeAccount(vote_init) => {
@@ -74,12 +79,19 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             }
             let clock =
                 get_sysvar_with_account_check::clock(invoke_context, &instruction_context, 2)?;
-            vote_state::initialize_account(&mut me, &vote_init, &signers, &clock)
+            vote_state::initialize_account(&mut me, target_version, &vote_init, &signers, &clock)
         }
         VoteInstruction::Authorize(voter_pubkey, vote_authorize) => {
             let clock =
                 get_sysvar_with_account_check::clock(invoke_context, &instruction_context, 1)?;
-            vote_state::authorize(&mut me, &voter_pubkey, vote_authorize, &signers, &clock)
+            vote_state::authorize(
+                &mut me,
+                target_version,
+                &voter_pubkey,
+                vote_authorize,
+                &signers,
+                &clock,
+            )
         }
         VoteInstruction::AuthorizeWithSeed(args) => {
             instruction_context.check_number_of_instruction_accounts(3)?;
@@ -87,6 +99,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 invoke_context,
                 &instruction_context,
                 &mut me,
+                target_version,
                 &args.new_authority,
                 args.authorization_type,
                 &args.current_authority_derived_key_owner,
@@ -103,6 +116,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 invoke_context,
                 &instruction_context,
                 &mut me,
+                target_version,
                 new_authority,
                 args.authorization_type,
                 &args.current_authority_derived_key_owner,
@@ -112,13 +126,14 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
         VoteInstruction::UpdateValidatorIdentity => {
             instruction_context.check_number_of_instruction_accounts(2)?;
             let node_pubkey = instruction_context.get_key_of_instruction_account(1)?;
-            vote_state::update_validator_identity(&mut me, node_pubkey, &signers)
+            vote_state::update_validator_identity(&mut me, target_version, node_pubkey, &signers)
         }
         VoteInstruction::UpdateCommission(commission) => {
             let sysvar_cache = invoke_context.get_sysvar_cache();
 
             vote_state::update_commission(
                 &mut me,
+                target_version,
                 commission,
                 &signers,
                 sysvar_cache.get_epoch_schedule()?.as_ref(),
@@ -136,7 +151,14 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             )?;
             let clock =
                 get_sysvar_with_account_check::clock(invoke_context, &instruction_context, 2)?;
-            vote_state::process_vote_with_account(&mut me, &slot_hashes, &clock, &vote, &signers)
+            vote_state::process_vote_with_account(
+                &mut me,
+                target_version,
+                &slot_hashes,
+                &clock,
+                &vote,
+                &signers,
+            )
         }
         VoteInstruction::UpdateVoteState(vote_state_update)
         | VoteInstruction::UpdateVoteStateSwitch(vote_state_update, _) => {
@@ -148,6 +170,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             let clock = sysvar_cache.get_clock()?;
             vote_state::process_vote_state_update(
                 &mut me,
+                target_version,
                 slot_hashes.slot_hashes(),
                 &clock,
                 vote_state_update,
@@ -164,6 +187,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             let clock = sysvar_cache.get_clock()?;
             vote_state::process_vote_state_update(
                 &mut me,
+                target_version,
                 slot_hashes.slot_hashes(),
                 &clock,
                 vote_state_update,
@@ -177,6 +201,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             let clock = sysvar_cache.get_clock()?;
             vote_state::process_tower_sync(
                 &mut me,
+                target_version,
                 slot_hashes.slot_hashes(),
                 &clock,
                 tower_sync,
@@ -192,6 +217,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             vote_state::withdraw(
                 &instruction_context,
                 0,
+                target_version,
                 lamports,
                 1,
                 &signers,
@@ -207,7 +233,14 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             }
             let clock =
                 get_sysvar_with_account_check::clock(invoke_context, &instruction_context, 1)?;
-            vote_state::authorize(&mut me, voter_pubkey, vote_authorize, &signers, &clock)
+            vote_state::authorize(
+                &mut me,
+                target_version,
+                voter_pubkey,
+                vote_authorize,
+                &signers,
+                &clock,
+            )
         }
     }
 });
@@ -345,7 +378,7 @@ mod tests {
 
     fn create_test_account() -> (Pubkey, AccountSharedData) {
         let rent = Rent::default();
-        let balance = VoteStateV3::get_rent_exempt_reserve(&rent);
+        let balance = rent.minimum_balance(VoteStateV3::size_of());
         let vote_pubkey = solana_pubkey::new_rand();
         (
             vote_pubkey,

--- a/programs/vote/src/vote_state/handler.rs
+++ b/programs/vote/src/vote_state/handler.rs
@@ -10,16 +10,20 @@
 //! getter and setter API around vote state, for all operations required by the
 //! vote program.
 
-#[cfg(test)]
-use solana_vote_interface::state::Lockout;
 use {
-    solana_clock::{Clock, Epoch, Slot},
+    solana_clock::{Clock, Epoch, Slot, UnixTimestamp},
     solana_instruction::error::InstructionError,
     solana_pubkey::Pubkey,
     solana_transaction_context::BorrowedInstructionAccount,
     solana_vote_interface::{
+        authorized_voters::AuthorizedVoters,
         error::VoteError,
-        state::{LandedVote, VoteInit, VoteState1_14_11, VoteStateV3, VoteStateVersions},
+        state::{
+            BlockTimestamp, LandedVote, Lockout, VoteInit, VoteState1_14_11, VoteStateV3,
+            VoteStateV4, VoteStateVersions, BLS_PUBLIC_KEY_COMPRESSED_SIZE,
+            MAX_EPOCH_CREDITS_HISTORY, MAX_LOCKOUT_HISTORY, VOTE_CREDITS_GRACE_SLOTS,
+            VOTE_CREDITS_MAXIMUM_PER_SLOT,
+        },
     },
     std::collections::VecDeque,
 };
@@ -31,6 +35,8 @@ pub trait VoteStateHandle {
     fn authorized_withdrawer(&self) -> &Pubkey;
 
     fn set_authorized_withdrawer(&mut self, authorized_withdrawer: Pubkey);
+
+    fn authorized_voters(&self) -> &AuthorizedVoters;
 
     fn set_new_authorized_voter<F>(
         &mut self,
@@ -61,7 +67,10 @@ pub trait VoteStateHandle {
 
     fn set_votes(&mut self, votes: VecDeque<LandedVote>);
 
-    fn contains_slot(&self, slot: Slot) -> bool;
+    /// Returns if the vote state contains a vote for the slot `candidate_slot`
+    fn contains_slot(&self, candidate_slot: Slot) -> bool;
+
+    fn last_lockout(&self) -> Option<&Lockout>;
 
     fn last_voted_slot(&self) -> Option<Slot>;
 
@@ -71,25 +80,176 @@ pub trait VoteStateHandle {
 
     fn current_epoch(&self) -> Epoch;
 
-    fn epoch_credits_last(&self) -> Option<&(Epoch, u64, u64)>;
+    fn epoch_credits(&self) -> &Vec<(Epoch, u64, u64)>;
 
-    fn credits_for_vote_at_index(&self, index: usize) -> u64;
+    fn epoch_credits_mut(&mut self) -> &mut Vec<(Epoch, u64, u64)>;
 
-    fn increment_credits(&mut self, epoch: Epoch, credits: u64);
+    fn last_timestamp(&self) -> &BlockTimestamp;
 
-    fn process_timestamp(&mut self, slot: Slot, timestamp: i64) -> Result<(), VoteError>;
-
-    fn process_next_vote_slot(&mut self, next_vote_slot: Slot, epoch: Epoch, current_slot: Slot);
+    fn set_last_timestamp(&mut self, timestamp: BlockTimestamp);
 
     fn set_vote_account_state(
         self,
         vote_account: &mut BorrowedInstructionAccount,
     ) -> Result<(), InstructionError>;
+
+    fn credits_for_vote_at_index(&self, index: usize) -> u64 {
+        let latency = self
+            .votes()
+            .get(index)
+            .map_or(0, |landed_vote| landed_vote.latency);
+
+        // If latency is 0, this means that the Lockout was created and stored from a software version that did not
+        // store vote latencies; in this case, 1 credit is awarded
+        if latency == 0 {
+            1
+        } else {
+            match latency.checked_sub(VOTE_CREDITS_GRACE_SLOTS) {
+                None | Some(0) => {
+                    // latency was <= VOTE_CREDITS_GRACE_SLOTS, so maximum credits are awarded
+                    VOTE_CREDITS_MAXIMUM_PER_SLOT as u64
+                }
+
+                Some(diff) => {
+                    // diff = latency - VOTE_CREDITS_GRACE_SLOTS, and diff > 0
+                    // Subtract diff from VOTE_CREDITS_MAXIMUM_PER_SLOT which is the number of credits to award
+                    match VOTE_CREDITS_MAXIMUM_PER_SLOT.checked_sub(diff) {
+                        // If diff >= VOTE_CREDITS_MAXIMUM_PER_SLOT, 1 credit is awarded
+                        None | Some(0) => 1,
+
+                        Some(credits) => credits as u64,
+                    }
+                }
+            }
+        }
+    }
+
+    fn increment_credits(&mut self, epoch: Epoch, credits: u64) {
+        // increment credits, record by epoch
+
+        // never seen a credit
+        if self.epoch_credits().is_empty() {
+            self.epoch_credits_mut().push((epoch, 0, 0));
+        } else if epoch != self.epoch_credits().last().unwrap().0 {
+            let (_, credits, prev_credits) = *self.epoch_credits().last().unwrap();
+
+            if credits != prev_credits {
+                // if credits were earned previous epoch
+                // append entry at end of list for the new epoch
+                self.epoch_credits_mut().push((epoch, credits, credits));
+            } else {
+                // else just move the current epoch
+                self.epoch_credits_mut().last_mut().unwrap().0 = epoch;
+            }
+
+            // Remove too old epoch_credits
+            if self.epoch_credits().len() > MAX_EPOCH_CREDITS_HISTORY {
+                self.epoch_credits_mut().remove(0);
+            }
+        }
+
+        self.epoch_credits_mut().last_mut().unwrap().1 = self
+            .epoch_credits()
+            .last()
+            .unwrap()
+            .1
+            .saturating_add(credits);
+    }
+
+    fn process_timestamp(&mut self, slot: Slot, timestamp: UnixTimestamp) -> Result<(), VoteError> {
+        let last_timestamp = self.last_timestamp();
+        if (slot < last_timestamp.slot || timestamp < last_timestamp.timestamp)
+            || (slot == last_timestamp.slot
+                && &BlockTimestamp { slot, timestamp } != last_timestamp
+                && last_timestamp.slot != 0)
+        {
+            return Err(VoteError::TimestampTooOld);
+        }
+        self.set_last_timestamp(BlockTimestamp { slot, timestamp });
+        Ok(())
+    }
+
+    fn pop_expired_votes(&mut self, next_vote_slot: Slot) {
+        while let Some(vote) = self.last_lockout() {
+            if !vote.is_locked_out_at_slot(next_vote_slot) {
+                self.votes_mut().pop_back();
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn double_lockouts(&mut self) {
+        let stack_depth = self.votes().len();
+        for (i, v) in self.votes_mut().iter_mut().enumerate() {
+            // Don't increase the lockout for this vote until we get more confirmations
+            // than the max number of confirmations this vote has seen
+            if stack_depth
+                > i.checked_add(v.confirmation_count() as usize).expect(
+                    "`confirmation_count` and tower_size should be bounded by \
+                     `MAX_LOCKOUT_HISTORY`",
+                )
+            {
+                v.lockout.increase_confirmation_count(1);
+            }
+        }
+    }
+
+    fn process_next_vote_slot(&mut self, next_vote_slot: Slot, epoch: Epoch, current_slot: Slot) {
+        // Ignore votes for slots earlier than we already have votes for
+        if self
+            .last_voted_slot()
+            .is_some_and(|last_voted_slot| next_vote_slot <= last_voted_slot)
+        {
+            return;
+        }
+
+        self.pop_expired_votes(next_vote_slot);
+
+        let landed_vote = LandedVote {
+            latency: compute_vote_latency(next_vote_slot, current_slot),
+            lockout: Lockout::new(next_vote_slot),
+        };
+
+        // Once the stack is full, pop the oldest lockout and distribute rewards
+        if self.votes().len() == MAX_LOCKOUT_HISTORY {
+            let credits = self.credits_for_vote_at_index(0);
+            let landed_vote = self.votes_mut().pop_front().unwrap();
+            self.set_root_slot(Some(landed_vote.slot()));
+
+            self.increment_credits(epoch, credits);
+        }
+        self.votes_mut().push_back(landed_vote);
+        self.double_lockouts();
+    }
+
+    #[cfg(test)]
+    fn credits(&self) -> u64 {
+        if self.epoch_credits().is_empty() {
+            0
+        } else {
+            self.epoch_credits().last().unwrap().1
+        }
+    }
+
+    #[cfg(test)]
+    fn nth_recent_lockout(&self, position: usize) -> Option<&Lockout> {
+        if position < self.votes().len() {
+            let pos = self
+                .votes()
+                .len()
+                .checked_sub(position)
+                .and_then(|pos| pos.checked_sub(1))?;
+            self.votes().get(pos).map(|vote| &vote.lockout)
+        } else {
+            None
+        }
+    }
 }
 
 impl VoteStateHandle for VoteStateV3 {
     fn is_uninitialized(&self) -> bool {
-        self.is_uninitialized()
+        self.authorized_voters.is_empty()
     }
 
     fn authorized_withdrawer(&self) -> &Pubkey {
@@ -98,6 +258,10 @@ impl VoteStateHandle for VoteStateV3 {
 
     fn set_authorized_withdrawer(&mut self, authorized_withdrawer: Pubkey) {
         self.authorized_withdrawer = authorized_withdrawer;
+    }
+
+    fn authorized_voters(&self) -> &AuthorizedVoters {
+        &self.authorized_voters
     }
 
     fn set_new_authorized_voter<F>(
@@ -110,14 +274,67 @@ impl VoteStateHandle for VoteStateV3 {
     where
         F: Fn(Pubkey) -> Result<(), InstructionError>,
     {
-        self.set_new_authorized_voter(authorized_pubkey, current_epoch, target_epoch, verify)
+        let epoch_authorized_voter = self.get_and_update_authorized_voter(current_epoch)?;
+        verify(epoch_authorized_voter)?;
+
+        // The offset in slots `n` on which the target_epoch
+        // (default value `DEFAULT_LEADER_SCHEDULE_SLOT_OFFSET`) is
+        // calculated is the number of slots available from the
+        // first slot `S` of an epoch in which to set a new voter for
+        // the epoch at `S` + `n`
+        if self.authorized_voters.contains(target_epoch) {
+            return Err(VoteError::TooSoonToReauthorize.into());
+        }
+
+        // Get the latest authorized_voter
+        let (latest_epoch, latest_authorized_pubkey) = self
+            .authorized_voters
+            .last()
+            .ok_or(InstructionError::InvalidAccountData)?;
+
+        // If we're not setting the same pubkey as authorized pubkey again,
+        // then update the list of prior voters to mark the expiration
+        // of the old authorized pubkey
+        if latest_authorized_pubkey != authorized_pubkey {
+            // Update the epoch ranges of authorized pubkeys that will be expired
+            let epoch_of_last_authorized_switch =
+                self.prior_voters.last().map(|range| range.2).unwrap_or(0);
+
+            // target_epoch must:
+            // 1) Be monotonically increasing due to the clock always
+            //    moving forward
+            // 2) not be equal to latest epoch otherwise this
+            //    function would have returned TooSoonToReauthorize error
+            //    above
+            if target_epoch <= *latest_epoch {
+                return Err(InstructionError::InvalidAccountData);
+            }
+
+            // Commit the new state
+            self.prior_voters.append((
+                *latest_authorized_pubkey,
+                epoch_of_last_authorized_switch,
+                target_epoch,
+            ));
+        }
+
+        self.authorized_voters
+            .insert(target_epoch, *authorized_pubkey);
+
+        Ok(())
     }
 
     fn get_and_update_authorized_voter(
         &mut self,
         current_epoch: Epoch,
     ) -> Result<Pubkey, InstructionError> {
-        self.get_and_update_authorized_voter(current_epoch)
+        let pubkey = self
+            .authorized_voters
+            .get_and_cache_authorized_voter_for_epoch(current_epoch)
+            .ok_or(InstructionError::InvalidAccountData)?;
+        self.authorized_voters
+            .purge_authorized_voters(current_epoch);
+        Ok(pubkey)
     }
 
     fn commission(&self) -> u8 {
@@ -148,12 +365,18 @@ impl VoteStateHandle for VoteStateV3 {
         self.votes = votes;
     }
 
-    fn contains_slot(&self, slot: Slot) -> bool {
-        self.contains_slot(slot)
+    fn contains_slot(&self, candidate_slot: Slot) -> bool {
+        self.votes
+            .binary_search_by(|vote| vote.slot().cmp(&candidate_slot))
+            .is_ok()
+    }
+
+    fn last_lockout(&self) -> Option<&Lockout> {
+        self.votes.back().map(|vote| &vote.lockout)
     }
 
     fn last_voted_slot(&self) -> Option<Slot> {
-        self.last_voted_slot()
+        self.last_lockout().map(|v| v.slot())
     }
 
     fn root_slot(&self) -> Option<Slot> {
@@ -165,27 +388,27 @@ impl VoteStateHandle for VoteStateV3 {
     }
 
     fn current_epoch(&self) -> Epoch {
-        self.current_epoch()
+        if self.epoch_credits.is_empty() {
+            0
+        } else {
+            self.epoch_credits.last().unwrap().0
+        }
     }
 
-    fn epoch_credits_last(&self) -> Option<&(Epoch, u64, u64)> {
-        self.epoch_credits.last()
+    fn epoch_credits(&self) -> &Vec<(Epoch, u64, u64)> {
+        &self.epoch_credits
     }
 
-    fn credits_for_vote_at_index(&self, index: usize) -> u64 {
-        self.credits_for_vote_at_index(index)
+    fn epoch_credits_mut(&mut self) -> &mut Vec<(Epoch, u64, u64)> {
+        &mut self.epoch_credits
     }
 
-    fn increment_credits(&mut self, epoch: Epoch, credits: u64) {
-        self.increment_credits(epoch, credits)
+    fn last_timestamp(&self) -> &BlockTimestamp {
+        &self.last_timestamp
     }
 
-    fn process_timestamp(&mut self, slot: Slot, timestamp: i64) -> Result<(), VoteError> {
-        self.process_timestamp(slot, timestamp)
-    }
-
-    fn process_next_vote_slot(&mut self, next_vote_slot: Slot, epoch: Epoch, current_slot: Slot) {
-        self.process_next_vote_slot(next_vote_slot, epoch, current_slot)
+    fn set_last_timestamp(&mut self, timestamp: BlockTimestamp) {
+        self.last_timestamp = timestamp;
     }
 
     fn set_vote_account_state(
@@ -211,15 +434,221 @@ impl VoteStateHandle for VoteStateV3 {
     }
 }
 
+impl VoteStateHandle for VoteStateV4 {
+    fn is_uninitialized(&self) -> bool {
+        // As per SIMD-0185, v4 is always initialized.
+        false
+    }
+
+    fn authorized_withdrawer(&self) -> &Pubkey {
+        &self.authorized_withdrawer
+    }
+
+    fn set_authorized_withdrawer(&mut self, authorized_withdrawer: Pubkey) {
+        self.authorized_withdrawer = authorized_withdrawer;
+    }
+
+    fn authorized_voters(&self) -> &AuthorizedVoters {
+        &self.authorized_voters
+    }
+
+    fn set_new_authorized_voter<F>(
+        &mut self,
+        authorized_pubkey: &Pubkey,
+        current_epoch: Epoch,
+        target_epoch: Epoch,
+        verify: F,
+    ) -> Result<(), InstructionError>
+    where
+        F: Fn(Pubkey) -> Result<(), InstructionError>,
+    {
+        // Similar to the v3 implementation, but with no `prior_voters` field.
+
+        let epoch_authorized_voter = self.get_and_update_authorized_voter(current_epoch)?;
+        verify(epoch_authorized_voter)?;
+
+        // The offset in slots `n` on which the target_epoch
+        // (default value `DEFAULT_LEADER_SCHEDULE_SLOT_OFFSET`) is
+        // calculated is the number of slots available from the
+        // first slot `S` of an epoch in which to set a new voter for
+        // the epoch at `S` + `n`
+        if self.authorized_voters.contains(target_epoch) {
+            return Err(VoteError::TooSoonToReauthorize.into());
+        }
+
+        self.authorized_voters
+            .insert(target_epoch, *authorized_pubkey);
+
+        Ok(())
+    }
+
+    fn get_and_update_authorized_voter(
+        &mut self,
+        current_epoch: Epoch,
+    ) -> Result<Pubkey, InstructionError> {
+        let pubkey = self
+            .authorized_voters
+            .get_and_cache_authorized_voter_for_epoch(current_epoch)
+            .ok_or(InstructionError::InvalidAccountData)?;
+        // Per SIMD-0185, v4 retains voters for `current_epoch - 1` through
+        // `current_epoch + 2`. Only purge entries for epochs less than
+        // `current_epoch - 1`.
+        self.authorized_voters
+            .purge_authorized_voters(current_epoch.saturating_sub(1));
+        Ok(pubkey)
+    }
+
+    fn commission(&self) -> u8 {
+        (self.inflation_rewards_commission_bps / 100) as u8
+    }
+
+    #[allow(clippy::arithmetic_side_effects)]
+    fn set_commission(&mut self, commission: u8) {
+        // Safety: u16::MAX > u8::MAX * 100
+        self.inflation_rewards_commission_bps = (commission as u16) * 100;
+    }
+
+    fn node_pubkey(&self) -> &Pubkey {
+        &self.node_pubkey
+    }
+
+    fn set_node_pubkey(&mut self, node_pubkey: Pubkey) {
+        self.node_pubkey = node_pubkey;
+    }
+
+    fn votes(&self) -> &VecDeque<LandedVote> {
+        &self.votes
+    }
+
+    fn votes_mut(&mut self) -> &mut VecDeque<LandedVote> {
+        &mut self.votes
+    }
+
+    fn set_votes(&mut self, votes: VecDeque<LandedVote>) {
+        self.votes = votes;
+    }
+
+    fn contains_slot(&self, candidate_slot: Slot) -> bool {
+        self.votes
+            .binary_search_by(|vote| vote.slot().cmp(&candidate_slot))
+            .is_ok()
+    }
+
+    fn last_lockout(&self) -> Option<&Lockout> {
+        self.votes.back().map(|vote| &vote.lockout)
+    }
+
+    fn last_voted_slot(&self) -> Option<Slot> {
+        self.last_lockout().map(|v| v.slot())
+    }
+
+    fn root_slot(&self) -> Option<Slot> {
+        self.root_slot
+    }
+
+    fn set_root_slot(&mut self, root_slot: Option<Slot>) {
+        self.root_slot = root_slot;
+    }
+
+    fn current_epoch(&self) -> Epoch {
+        if self.epoch_credits.is_empty() {
+            0
+        } else {
+            self.epoch_credits.last().unwrap().0
+        }
+    }
+
+    fn epoch_credits(&self) -> &Vec<(Epoch, u64, u64)> {
+        &self.epoch_credits
+    }
+
+    fn epoch_credits_mut(&mut self) -> &mut Vec<(Epoch, u64, u64)> {
+        &mut self.epoch_credits
+    }
+
+    fn last_timestamp(&self) -> &BlockTimestamp {
+        &self.last_timestamp
+    }
+
+    fn set_last_timestamp(&mut self, timestamp: BlockTimestamp) {
+        self.last_timestamp = timestamp;
+    }
+
+    fn set_vote_account_state(
+        self,
+        vote_account: &mut BorrowedInstructionAccount,
+    ) -> Result<(), InstructionError> {
+        // If the account is not large enough to store the vote state, then attempt a realloc to make it large enough.
+        // The realloc can only proceed if the vote account has balance sufficient for rent exemption at the new size.
+        if (vote_account.get_data().len() < VoteStateV4::size_of())
+            && (!vote_account.is_rent_exempt_at_data_length(VoteStateV4::size_of())
+                || vote_account
+                    .set_data_length(VoteStateV4::size_of())
+                    .is_err())
+        {
+            // Unlike with conversions to v3, we will not gracefully default to
+            // storing a v1_14_11. Instead, throw an error, as per SIMD-0185.
+            return Err(InstructionError::AccountNotRentExempt);
+        }
+        // Vote account is large enough to store the newest version of vote state
+        vote_account.set_state(&VoteStateVersions::V4(Box::new(self)))
+    }
+}
+
+/// Default block revenue commission rate in basis points (100%) per SIMD-0185.
+const DEFAULT_BLOCK_REVENUE_COMMISSION_BPS: u16 = 10_000;
+
+/// Create a new VoteStateV4 from `VoteInit` with proper SIMD-0185 defaults.
+/// Note this is a temporary substitute for `VoteStateV4::new`.
+#[allow(clippy::arithmetic_side_effects)]
+pub(crate) fn create_new_vote_state_v4(
+    vote_pubkey: &Pubkey,
+    vote_init: &VoteInit,
+    clock: &Clock,
+) -> VoteStateV4 {
+    VoteStateV4 {
+        node_pubkey: vote_init.node_pubkey,
+        authorized_voters: AuthorizedVoters::new(clock.epoch, vote_init.authorized_voter),
+        authorized_withdrawer: vote_init.authorized_withdrawer,
+        inflation_rewards_commission_bps: (vote_init.commission as u16) * 100, // u16::MAX > u8::MAX * 100
+        // Per SIMD-0185, set default collectors and commission
+        inflation_rewards_collector: *vote_pubkey,
+        block_revenue_collector: vote_init.node_pubkey,
+        block_revenue_commission_bps: DEFAULT_BLOCK_REVENUE_COMMISSION_BPS,
+        ..VoteStateV4::default()
+    }
+}
+
+/// (Alpenglow) Create a test-only `VoteStateV4` with the provided values.
+pub(crate) fn create_new_vote_state_v4_for_tests(
+    node_pubkey: &Pubkey,
+    authorized_voter: &Pubkey,
+    authorized_withdrawer: &Pubkey,
+    bls_pubkey_compressed: Option<[u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE]>,
+    inflation_rewards_commission_bps: u16,
+) -> VoteStateV4 {
+    VoteStateV4 {
+        node_pubkey: *node_pubkey,
+        authorized_voters: AuthorizedVoters::new(0, *authorized_voter),
+        authorized_withdrawer: *authorized_withdrawer,
+        bls_pubkey_compressed,
+        inflation_rewards_commission_bps,
+        ..VoteStateV4::default()
+    }
+}
+
 /// The target version to convert all deserialized vote state into.
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum VoteStateTargetVersion {
     V3,
+    V4,
     // New vote state versions will be added here...
 }
 
 #[derive(Clone, Debug, PartialEq)]
 enum TargetVoteState {
     V3(VoteStateV3),
+    V4(VoteStateV4),
     // New vote state versions will be added here...
 }
 
@@ -237,18 +666,28 @@ impl VoteStateHandle for VoteStateHandler {
     fn is_uninitialized(&self) -> bool {
         match &self.target_state {
             TargetVoteState::V3(v3) => v3.is_uninitialized(),
+            TargetVoteState::V4(v4) => v4.is_uninitialized(),
         }
     }
 
     fn authorized_withdrawer(&self) -> &Pubkey {
         match &self.target_state {
             TargetVoteState::V3(v3) => v3.authorized_withdrawer(),
+            TargetVoteState::V4(v4) => v4.authorized_withdrawer(),
         }
     }
 
     fn set_authorized_withdrawer(&mut self, authorized_withdrawer: Pubkey) {
         match &mut self.target_state {
             TargetVoteState::V3(v3) => v3.set_authorized_withdrawer(authorized_withdrawer),
+            TargetVoteState::V4(v4) => v4.set_authorized_withdrawer(authorized_withdrawer),
+        }
+    }
+
+    fn authorized_voters(&self) -> &AuthorizedVoters {
+        match &self.target_state {
+            TargetVoteState::V3(v3) => v3.authorized_voters(),
+            TargetVoteState::V4(v4) => v4.authorized_voters(),
         }
     }
 
@@ -266,6 +705,9 @@ impl VoteStateHandle for VoteStateHandler {
             TargetVoteState::V3(v3) => {
                 v3.set_new_authorized_voter(authorized_pubkey, current_epoch, target_epoch, verify)
             }
+            TargetVoteState::V4(v4) => {
+                v4.set_new_authorized_voter(authorized_pubkey, current_epoch, target_epoch, verify)
+            }
         }
     }
 
@@ -275,110 +717,126 @@ impl VoteStateHandle for VoteStateHandler {
     ) -> Result<Pubkey, InstructionError> {
         match &mut self.target_state {
             TargetVoteState::V3(v3) => v3.get_and_update_authorized_voter(current_epoch),
+            TargetVoteState::V4(v4) => v4.get_and_update_authorized_voter(current_epoch),
         }
     }
 
     fn commission(&self) -> u8 {
         match &self.target_state {
             TargetVoteState::V3(v3) => v3.commission(),
+            TargetVoteState::V4(v4) => v4.commission(),
         }
     }
 
     fn set_commission(&mut self, commission: u8) {
         match &mut self.target_state {
             TargetVoteState::V3(v3) => v3.set_commission(commission),
+            TargetVoteState::V4(v4) => v4.set_commission(commission),
         }
     }
 
     fn node_pubkey(&self) -> &Pubkey {
         match &self.target_state {
             TargetVoteState::V3(v3) => v3.node_pubkey(),
+            TargetVoteState::V4(v4) => v4.node_pubkey(),
         }
     }
 
     fn set_node_pubkey(&mut self, node_pubkey: Pubkey) {
         match &mut self.target_state {
             TargetVoteState::V3(v3) => v3.set_node_pubkey(node_pubkey),
+            TargetVoteState::V4(v4) => v4.set_node_pubkey(node_pubkey),
         }
     }
 
     fn votes(&self) -> &VecDeque<LandedVote> {
         match &self.target_state {
             TargetVoteState::V3(v3) => v3.votes(),
+            TargetVoteState::V4(v4) => v4.votes(),
         }
     }
 
     fn votes_mut(&mut self) -> &mut VecDeque<LandedVote> {
         match &mut self.target_state {
             TargetVoteState::V3(v3) => v3.votes_mut(),
+            TargetVoteState::V4(v4) => v4.votes_mut(),
         }
     }
 
     fn set_votes(&mut self, votes: VecDeque<LandedVote>) {
         match &mut self.target_state {
             TargetVoteState::V3(v3) => v3.set_votes(votes),
+            TargetVoteState::V4(v4) => v4.set_votes(votes),
         }
     }
 
-    fn contains_slot(&self, slot: Slot) -> bool {
+    fn contains_slot(&self, candidate_slot: Slot) -> bool {
         match &self.target_state {
-            TargetVoteState::V3(v3) => v3.contains_slot(slot),
+            TargetVoteState::V3(v3) => v3.contains_slot(candidate_slot),
+            TargetVoteState::V4(v4) => v4.contains_slot(candidate_slot),
+        }
+    }
+
+    fn last_lockout(&self) -> Option<&Lockout> {
+        match &self.target_state {
+            TargetVoteState::V3(v3) => v3.last_lockout(),
+            TargetVoteState::V4(v4) => v4.last_lockout(),
         }
     }
 
     fn last_voted_slot(&self) -> Option<Slot> {
         match &self.target_state {
             TargetVoteState::V3(v3) => v3.last_voted_slot(),
+            TargetVoteState::V4(v4) => v4.last_voted_slot(),
         }
     }
 
     fn root_slot(&self) -> Option<Slot> {
         match &self.target_state {
             TargetVoteState::V3(v3) => v3.root_slot(),
+            TargetVoteState::V4(v4) => v4.root_slot(),
         }
     }
 
     fn set_root_slot(&mut self, root_slot: Option<Slot>) {
         match &mut self.target_state {
             TargetVoteState::V3(v3) => v3.set_root_slot(root_slot),
+            TargetVoteState::V4(v4) => v4.set_root_slot(root_slot),
         }
     }
 
     fn current_epoch(&self) -> Epoch {
         match &self.target_state {
             TargetVoteState::V3(v3) => v3.current_epoch(),
+            TargetVoteState::V4(v4) => v4.current_epoch(),
         }
     }
 
-    fn epoch_credits_last(&self) -> Option<&(Epoch, u64, u64)> {
+    fn epoch_credits(&self) -> &Vec<(Epoch, u64, u64)> {
         match &self.target_state {
-            TargetVoteState::V3(v3) => v3.epoch_credits_last(),
+            TargetVoteState::V3(v3) => v3.epoch_credits(),
+            TargetVoteState::V4(v4) => v4.epoch_credits(),
         }
     }
 
-    fn credits_for_vote_at_index(&self, index: usize) -> u64 {
+    fn epoch_credits_mut(&mut self) -> &mut Vec<(Epoch, u64, u64)> {
+        match &mut self.target_state {
+            TargetVoteState::V3(v3) => v3.epoch_credits_mut(),
+            TargetVoteState::V4(v4) => v4.epoch_credits_mut(),
+        }
+    }
+
+    fn last_timestamp(&self) -> &BlockTimestamp {
         match &self.target_state {
-            TargetVoteState::V3(v3) => v3.credits_for_vote_at_index(index),
+            TargetVoteState::V3(v3) => v3.last_timestamp(),
+            TargetVoteState::V4(v4) => v4.last_timestamp(),
         }
     }
 
-    fn increment_credits(&mut self, epoch: Epoch, credits: u64) {
+    fn set_last_timestamp(&mut self, timestamp: BlockTimestamp) {
         match &mut self.target_state {
-            TargetVoteState::V3(v3) => v3.increment_credits(epoch, credits),
-        }
-    }
-
-    fn process_timestamp(&mut self, slot: Slot, timestamp: i64) -> Result<(), VoteError> {
-        match &mut self.target_state {
-            TargetVoteState::V3(v3) => v3.process_timestamp(slot, timestamp),
-        }
-    }
-
-    fn process_next_vote_slot(&mut self, next_vote_slot: Slot, epoch: Epoch, current_slot: Slot) {
-        match &mut self.target_state {
-            TargetVoteState::V3(v3) => {
-                v3.process_next_vote_slot(next_vote_slot, epoch, current_slot)
-            }
+            TargetVoteState::V3(v3) => v3.set_last_timestamp(timestamp),
+            TargetVoteState::V4(v4) => v4.set_last_timestamp(timestamp),
         }
     }
 
@@ -388,6 +846,7 @@ impl VoteStateHandle for VoteStateHandler {
     ) -> Result<(), InstructionError> {
         match self.target_state {
             TargetVoteState::V3(v3) => v3.set_vote_account_state(vote_account),
+            TargetVoteState::V4(v4) => v4.set_vote_account_state(vote_account),
         }
     }
 }
@@ -404,6 +863,11 @@ impl VoteStateHandler {
                 let vote_state = VoteStateV3::deserialize(vote_account.get_data())?;
                 TargetVoteState::V3(vote_state)
             }
+            VoteStateTargetVersion::V4 => {
+                let vote_state =
+                    VoteStateV4::deserialize(vote_account.get_data(), vote_account.get_key())?;
+                TargetVoteState::V4(vote_state)
+            }
         };
         Ok(Self { target_state })
     }
@@ -414,22 +878,31 @@ impl VoteStateHandler {
         clock: &Clock,
         target_version: VoteStateTargetVersion,
     ) -> Result<(), InstructionError> {
-        let state = match target_version {
+        match target_version {
             VoteStateTargetVersion::V3 => {
-                VoteStateVersions::V3(Box::new(VoteStateV3::new(vote_init, clock)))
+                VoteStateV3::new(vote_init, clock).set_vote_account_state(vote_account)
             }
-        };
-        vote_account.set_state(&state)
+            VoteStateTargetVersion::V4 => {
+                let vote_state = create_new_vote_state_v4(vote_account.get_key(), vote_init, clock);
+                vote_state.set_vote_account_state(vote_account)
+            }
+        }
     }
 
     pub fn deinitialize_vote_account_state(
         vote_account: &mut BorrowedInstructionAccount,
         target_version: VoteStateTargetVersion,
     ) -> Result<(), InstructionError> {
-        let state = match target_version {
-            VoteStateTargetVersion::V3 => VoteStateVersions::V3(Box::<VoteStateV3>::default()),
-        };
-        vote_account.set_state(&state)
+        match target_version {
+            VoteStateTargetVersion::V3 => {
+                VoteStateV3::default().set_vote_account_state(vote_account)
+            }
+            VoteStateTargetVersion::V4 => {
+                // As per SIMD-0185, clear the entire account.
+                vote_account.get_data_mut()?.fill(0);
+                Ok(())
+            }
+        }
     }
 
     pub fn check_vote_account_length(
@@ -439,6 +912,7 @@ impl VoteStateHandler {
         let length = vote_account.get_data().len();
         let expected = match target_version {
             VoteStateTargetVersion::V3 => VoteStateV3::size_of(),
+            VoteStateTargetVersion::V4 => VoteStateV4::size_of(),
         };
         if length != expected {
             Err(InstructionError::InvalidAccountData)
@@ -455,35 +929,1266 @@ impl VoteStateHandler {
     }
 
     #[cfg(test)]
+    pub fn new_v4(vote_state: VoteStateV4) -> Self {
+        Self {
+            target_state: TargetVoteState::V4(vote_state),
+        }
+    }
+
+    #[cfg(test)]
     pub fn default_v3() -> Self {
         Self::new_v3(VoteStateV3::default())
     }
 
     #[cfg(test)]
-    pub fn last_lockout(&self) -> Option<&Lockout> {
+    pub fn default_v4() -> Self {
+        Self::new_v4(VoteStateV4::default())
+    }
+
+    #[cfg(test)]
+    pub fn as_ref_v3(&self) -> &VoteStateV3 {
         match &self.target_state {
-            TargetVoteState::V3(v3) => v3.last_lockout(),
+            TargetVoteState::V3(v3) => v3,
+            _ => panic!("not a v3"),
         }
     }
 
     #[cfg(test)]
-    pub fn credits(&self) -> u64 {
+    pub fn as_ref_v4(&self) -> &VoteStateV4 {
         match &self.target_state {
-            TargetVoteState::V3(v3) => v3.credits(),
+            TargetVoteState::V4(v4) => v4,
+            _ => panic!("not a v4"),
         }
     }
 
     #[cfg(test)]
-    pub fn epoch_credits(&self) -> &Vec<(Epoch, u64, u64)> {
-        match &self.target_state {
-            TargetVoteState::V3(v3) => &v3.epoch_credits,
+    pub fn serialize(self) -> Vec<u8> {
+        match self.target_state {
+            TargetVoteState::V3(v3) => {
+                let mut data = vec![0; VoteStateV3::size_of()];
+                let versioned = VoteStateVersions::V3(Box::new(v3));
+                bincode::serialize_into(&mut data[..], &versioned).unwrap();
+                data
+            }
+            TargetVoteState::V4(v4) => {
+                let mut data = vec![0; VoteStateV4::size_of()];
+                let versioned = VoteStateVersions::V4(Box::new(v4));
+                bincode::serialize_into(&mut data[..], &versioned).unwrap();
+                data
+            }
+        }
+    }
+}
+
+// Computes the vote latency for vote on voted_for_slot where the vote itself landed in current_slot
+pub(crate) fn compute_vote_latency(voted_for_slot: Slot, current_slot: Slot) -> u8 {
+    std::cmp::min(current_slot.saturating_sub(voted_for_slot), u8::MAX as u64) as u8
+}
+
+#[allow(clippy::arithmetic_side_effects)]
+#[allow(clippy::type_complexity)]
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::id,
+        solana_account::AccountSharedData,
+        solana_clock::Clock,
+        solana_epoch_schedule::MAX_LEADER_SCHEDULE_EPOCH_OFFSET,
+        solana_pubkey::Pubkey,
+        solana_rent::Rent,
+        solana_sdk_ids::native_loader,
+        solana_transaction_context::{InstructionAccount, TransactionContext},
+        solana_vote_interface::{
+            authorized_voters::AuthorizedVoters,
+            state::{BlockTimestamp, VoteInit, MAX_EPOCH_CREDITS_HISTORY, MAX_LOCKOUT_HISTORY},
+        },
+        std::collections::VecDeque,
+        test_case::test_case,
+    };
+
+    fn mock_transaction_context(
+        vote_pubkey: Pubkey,
+        vote_account: AccountSharedData,
+        rent: Rent,
+    ) -> TransactionContext {
+        let program_account = AccountSharedData::new(0, 0, &native_loader::id());
+        let mut transaction_context = TransactionContext::new(
+            vec![(id(), program_account), (vote_pubkey, vote_account)],
+            rent,
+            0,
+            0,
+        );
+        transaction_context
+            .configure_next_instruction_for_tests(
+                0,
+                vec![InstructionAccount::new(1, false, true)],
+                &[],
+            )
+            .unwrap();
+        transaction_context
+    }
+
+    fn get_max_sized_vote_state_v3() -> VoteStateV3 {
+        let mut authorized_voters = AuthorizedVoters::default();
+        for i in 0..=MAX_LEADER_SCHEDULE_EPOCH_OFFSET {
+            authorized_voters.insert(i, Pubkey::new_unique());
+        }
+
+        VoteStateV3 {
+            votes: VecDeque::from(vec![LandedVote::default(); MAX_LOCKOUT_HISTORY]),
+            root_slot: Some(u64::MAX),
+            epoch_credits: vec![(0, 0, 0); MAX_EPOCH_CREDITS_HISTORY],
+            authorized_voters,
+            ..Default::default()
         }
     }
 
-    #[cfg(test)]
-    pub fn nth_recent_lockout(&self, position: usize) -> Option<&Lockout> {
-        match &self.target_state {
-            TargetVoteState::V3(v3) => v3.nth_recent_lockout(position),
+    fn get_max_sized_vote_state_v4() -> VoteStateV4 {
+        let mut authorized_voters = AuthorizedVoters::default();
+        for i in 0..=MAX_LEADER_SCHEDULE_EPOCH_OFFSET {
+            authorized_voters.insert(i, Pubkey::new_unique());
         }
+
+        VoteStateV4 {
+            votes: VecDeque::from(vec![LandedVote::default(); MAX_LOCKOUT_HISTORY]),
+            root_slot: Some(u64::MAX),
+            epoch_credits: vec![(0, 0, 0); MAX_EPOCH_CREDITS_HISTORY],
+            authorized_voters,
+            bls_pubkey_compressed: Some([255; BLS_PUBLIC_KEY_COMPRESSED_SIZE]),
+            ..Default::default()
+        }
+    }
+
+    fn set_new_authorized_voter_and_assert<T: VoteStateHandle>(
+        vote_state: &mut T,
+        original_voter: Pubkey,
+        epoch_offset: Epoch,
+        prior_voters_last_callback: Option<fn(&T) -> &(Pubkey, Epoch, Epoch)>,
+    ) {
+        let new_voter = Pubkey::new_unique();
+        // Set a new authorized voter
+        vote_state
+            .set_new_authorized_voter(&new_voter, 0, epoch_offset, |_| Ok(()))
+            .unwrap();
+
+        if let Some(prior_voters_last) = prior_voters_last_callback {
+            assert_eq!(
+                prior_voters_last(vote_state),
+                &(original_voter, 0, epoch_offset),
+            );
+        }
+
+        // Trying to set authorized voter for same epoch again should fail
+        assert_eq!(
+            vote_state.set_new_authorized_voter(&new_voter, 0, epoch_offset, |_| Ok(())),
+            Err(VoteError::TooSoonToReauthorize.into())
+        );
+
+        // Setting the same authorized voter again should succeed
+        vote_state
+            .set_new_authorized_voter(&new_voter, 2, 2 + epoch_offset, |_| Ok(()))
+            .unwrap();
+
+        // Set a third and fourth authorized voter
+        let new_voter2 = Pubkey::new_unique();
+        vote_state
+            .set_new_authorized_voter(&new_voter2, 3, 3 + epoch_offset, |_| Ok(()))
+            .unwrap();
+        if let Some(prior_voters_last) = prior_voters_last_callback {
+            assert_eq!(
+                prior_voters_last(vote_state),
+                &(new_voter, epoch_offset, 3 + epoch_offset),
+            );
+        }
+
+        let new_voter3 = Pubkey::new_unique();
+        vote_state
+            .set_new_authorized_voter(&new_voter3, 6, 6 + epoch_offset, |_| Ok(()))
+            .unwrap();
+        if let Some(prior_voters_last) = prior_voters_last_callback {
+            assert_eq!(
+                prior_voters_last(vote_state),
+                &(new_voter2, 3 + epoch_offset, 6 + epoch_offset),
+            );
+        }
+
+        // Check can set back to original voter
+        vote_state
+            .set_new_authorized_voter(&original_voter, 9, 9 + epoch_offset, |_| Ok(()))
+            .unwrap();
+
+        // Run with these voters for a while, check the ranges of authorized
+        // voters is correct
+        for i in 9..epoch_offset {
+            assert_eq!(
+                vote_state.get_and_update_authorized_voter(i).unwrap(),
+                original_voter
+            );
+        }
+        for i in epoch_offset..3 + epoch_offset {
+            assert_eq!(
+                vote_state.get_and_update_authorized_voter(i).unwrap(),
+                new_voter
+            );
+        }
+        for i in 3 + epoch_offset..6 + epoch_offset {
+            assert_eq!(
+                vote_state.get_and_update_authorized_voter(i).unwrap(),
+                new_voter2
+            );
+        }
+        for i in 6 + epoch_offset..9 + epoch_offset {
+            assert_eq!(
+                vote_state.get_and_update_authorized_voter(i).unwrap(),
+                new_voter3
+            );
+        }
+        for i in 9 + epoch_offset..=10 + epoch_offset {
+            assert_eq!(
+                vote_state.get_and_update_authorized_voter(i).unwrap(),
+                original_voter
+            );
+        }
+    }
+
+    #[test]
+    fn test_set_new_authorized_voter() {
+        let vote_pubkey = Pubkey::new_unique();
+        let original_voter = Pubkey::new_unique();
+        let epoch_offset = 15;
+
+        let vote_init = VoteInit {
+            node_pubkey: original_voter,
+            authorized_voter: original_voter,
+            authorized_withdrawer: original_voter,
+            commission: 0,
+        };
+        let clock = Clock::default();
+
+        // Start with v3. We'll also check `prior_voters`.
+        let mut vote_state = VoteStateV3::new(&vote_init, &clock);
+        assert!(vote_state.prior_voters.last().is_none());
+
+        set_new_authorized_voter_and_assert(
+            &mut vote_state,
+            original_voter,
+            epoch_offset,
+            Some(|vote_state: &VoteStateV3| vote_state.prior_voters.last().unwrap()),
+        );
+
+        // Now try with v4. No `prior_voters` to check.
+        let mut vote_state = create_new_vote_state_v4(&vote_pubkey, &vote_init, &clock);
+
+        set_new_authorized_voter_and_assert(&mut vote_state, original_voter, epoch_offset, None);
+    }
+
+    fn assert_authorized_voter_is_locked_within_epoch<T: VoteStateHandle>(
+        vote_state: &mut T,
+        original_voter: &Pubkey,
+    ) {
+        // Test that it's not possible to set a new authorized
+        // voter within the same epoch, even if none has been
+        // explicitly set before
+        let new_voter = Pubkey::new_unique();
+        assert_eq!(
+            vote_state.set_new_authorized_voter(&new_voter, 1, 1, |_| Ok(())),
+            Err(VoteError::TooSoonToReauthorize.into())
+        );
+        assert_eq!(
+            vote_state.authorized_voters().get_authorized_voter(1),
+            Some(*original_voter)
+        );
+        // Set a new authorized voter for a future epoch
+        assert_eq!(
+            vote_state.set_new_authorized_voter(&new_voter, 1, 2, |_| Ok(())),
+            Ok(())
+        );
+        // Test that it's not possible to set a new authorized
+        // voter within the same epoch, even if none has been
+        // explicitly set before
+        assert_eq!(
+            vote_state.set_new_authorized_voter(original_voter, 3, 3, |_| Ok(())),
+            Err(VoteError::TooSoonToReauthorize.into())
+        );
+        assert_eq!(
+            vote_state.authorized_voters().get_authorized_voter(3),
+            Some(new_voter)
+        );
+    }
+
+    #[test]
+    fn test_authorized_voter_is_locked_within_epoch() {
+        let vote_pubkey = Pubkey::new_unique();
+        let original_voter = Pubkey::new_unique();
+
+        let vote_init = VoteInit {
+            node_pubkey: original_voter,
+            authorized_voter: original_voter,
+            authorized_withdrawer: original_voter,
+            commission: 0,
+        };
+        let clock = Clock::default();
+
+        // First test v3.
+        let mut vote_state = VoteStateV3::new(&vote_init, &clock);
+        assert_authorized_voter_is_locked_within_epoch(&mut vote_state, &original_voter);
+
+        // Now v4.
+        let mut vote_state = create_new_vote_state_v4(&vote_pubkey, &vote_init, &clock);
+        assert_authorized_voter_is_locked_within_epoch(&mut vote_state, &original_voter);
+    }
+
+    #[test]
+    fn test_get_and_update_authorized_voter_v3() {
+        let original_voter = Pubkey::new_unique();
+        let mut vote_state = VoteStateV3::new(
+            &VoteInit {
+                node_pubkey: original_voter,
+                authorized_voter: original_voter,
+                authorized_withdrawer: original_voter,
+                commission: 0,
+            },
+            &Clock::default(),
+        );
+
+        assert_eq!(vote_state.authorized_voters().len(), 1);
+        assert_eq!(
+            *vote_state.authorized_voters().first().unwrap().1,
+            original_voter
+        );
+
+        // If no new authorized voter was set, the same authorized voter
+        // is locked into the next epoch
+        assert_eq!(
+            vote_state.get_and_update_authorized_voter(1).unwrap(),
+            original_voter
+        );
+
+        // Try to get the authorized voter for epoch 5, implies
+        // the authorized voter for epochs 1-4 were unchanged
+        assert_eq!(
+            vote_state.get_and_update_authorized_voter(5).unwrap(),
+            original_voter
+        );
+
+        // Authorized voter for expired epoch 0..5 should have been
+        // purged and no longer queryable
+        assert_eq!(vote_state.authorized_voters().len(), 1);
+        for i in 0..5 {
+            assert!(vote_state
+                .authorized_voters()
+                .get_authorized_voter(i)
+                .is_none());
+        }
+
+        // Set an authorized voter change at slot 7
+        let new_authorized_voter = Pubkey::new_unique();
+        vote_state
+            .set_new_authorized_voter(&new_authorized_voter, 5, 7, |_| Ok(()))
+            .unwrap();
+
+        // Try to get the authorized voter for epoch 6, unchanged
+        assert_eq!(
+            vote_state.get_and_update_authorized_voter(6).unwrap(),
+            original_voter
+        );
+
+        // Try to get the authorized voter for epoch 7 and onwards, should
+        // be the new authorized voter
+        for i in 7..10 {
+            assert_eq!(
+                vote_state.get_and_update_authorized_voter(i).unwrap(),
+                new_authorized_voter
+            );
+        }
+        assert_eq!(vote_state.authorized_voters().len(), 1);
+    }
+
+    // v4 purging retains one extra epoch compared to v3.
+    // Besides that, the functionality should be the same.
+    #[test]
+    fn test_get_and_update_authorized_voter_v4() {
+        let vote_pubkey = Pubkey::new_unique();
+        let original_voter = Pubkey::new_unique();
+        let mut vote_state = create_new_vote_state_v4(
+            &vote_pubkey,
+            &VoteInit {
+                node_pubkey: original_voter,
+                authorized_voter: original_voter,
+                authorized_withdrawer: original_voter,
+                commission: 0,
+            },
+            &Clock::default(),
+        );
+
+        // Run the same exercise as the v3 test to start.
+
+        assert_eq!(vote_state.authorized_voters().len(), 1);
+        assert_eq!(
+            *vote_state.authorized_voters().first().unwrap().1,
+            original_voter
+        );
+
+        // If no new authorized voter was set, the same authorized voter
+        // is locked into the next epoch
+        assert_eq!(
+            vote_state.get_and_update_authorized_voter(1).unwrap(),
+            original_voter
+        );
+
+        // Try to get the authorized voter for epoch 5, implies
+        // the authorized voter for epochs 1-4 were unchanged
+        assert_eq!(
+            vote_state.get_and_update_authorized_voter(5).unwrap(),
+            original_voter
+        );
+
+        // Just like with the v3 tests, authorized voters for epochs 0..5 should
+        // be purged, but only because we didn't cache an entry for current - 1.
+        assert_eq!(vote_state.authorized_voters().len(), 1);
+        for i in 0..5 {
+            assert!(vote_state
+                .authorized_voters()
+                .get_authorized_voter(i)
+                .is_none());
+        }
+
+        // Say we're in epoch 7. Cache entries for both epochs 6 and 7.
+        assert_eq!(
+            vote_state.get_and_update_authorized_voter(6).unwrap(),
+            original_voter
+        );
+        assert_eq!(
+            vote_state.get_and_update_authorized_voter(7).unwrap(),
+            original_voter
+        );
+
+        // Now we should have length 2.
+        assert_eq!(vote_state.authorized_voters().len(), 2);
+
+        // 0..=5 should still be purged.
+        for i in 0..=5 {
+            assert!(vote_state
+                .authorized_voters()
+                .get_authorized_voter(i)
+                .is_none());
+        }
+
+        // Set an authorized voter change at epoch 9.
+        let new_authorized_voter = Pubkey::new_unique();
+        vote_state
+            .set_new_authorized_voter(&new_authorized_voter, 7, 9, |_| Ok(()))
+            .unwrap();
+
+        // Try to get the authorized voter for epoch 8, unchanged
+        assert_eq!(
+            vote_state.get_and_update_authorized_voter(8).unwrap(),
+            original_voter
+        );
+
+        // Try to get the authorized voter for epoch 9 and onwards, should
+        // be the new authorized voter
+        for i in 9..12 {
+            assert_eq!(
+                vote_state.get_and_update_authorized_voter(i).unwrap(),
+                new_authorized_voter
+            );
+        }
+        assert_eq!(vote_state.authorized_voters().len(), 2);
+
+        // If we skip a few epochs ahead, only the current epoch is retained.
+        assert_eq!(
+            vote_state.get_and_update_authorized_voter(15).unwrap(),
+            new_authorized_voter
+        );
+        assert_eq!(vote_state.authorized_voters().len(), 1);
+    }
+
+    #[test_case(
+        VoteStateV3::size_of(),
+        get_max_sized_vote_state_v3(),
+        |vote_state, data| {
+            let versioned = VoteStateVersions::new_v3(vote_state);
+            VoteStateV3::serialize(&versioned, data).unwrap();
+        };
+        "VoteStateV3"
+    )]
+    #[test_case(
+        VoteStateV4::size_of(),
+        get_max_sized_vote_state_v4(),
+        |vote_state, data| {
+            let versioned = VoteStateVersions::new_v4(vote_state);
+            VoteStateV4::serialize(&versioned, data).unwrap();
+        };
+        "VoteStateV4"
+    )]
+    fn test_vote_state_max_size<T: Clone + VoteStateHandle>(
+        max_size: usize,
+        mut vote_state: T,
+        verify_serialize: fn(T, &mut [u8]),
+    ) {
+        let mut max_sized_data = vec![0; max_size];
+        let (start_leader_schedule_epoch, _) = vote_state.authorized_voters().last().unwrap();
+        let start_current_epoch =
+            start_leader_schedule_epoch - MAX_LEADER_SCHEDULE_EPOCH_OFFSET + 1;
+
+        for i in start_current_epoch..start_current_epoch + 2 * MAX_LEADER_SCHEDULE_EPOCH_OFFSET {
+            vote_state
+                .set_new_authorized_voter(
+                    &Pubkey::new_unique(),
+                    i,
+                    i + MAX_LEADER_SCHEDULE_EPOCH_OFFSET,
+                    |_| Ok(()),
+                )
+                .unwrap();
+
+            verify_serialize(vote_state.clone(), &mut max_sized_data);
+        }
+    }
+
+    #[test_case(VoteStateV3::default() ; "VoteStateV3")]
+    #[test_case(VoteStateV4::default() ; "VoteStateV4")]
+    fn test_vote_state_epoch_credits<T: VoteStateHandle>(mut vote_state: T) {
+        assert_eq!(vote_state.credits(), 0);
+        assert_eq!(vote_state.epoch_credits().clone(), vec![]);
+
+        let mut expected = vec![];
+        let mut credits = 0;
+        let epochs = (MAX_EPOCH_CREDITS_HISTORY + 2) as u64;
+        for epoch in 0..epochs {
+            for _j in 0..epoch {
+                vote_state.increment_credits(epoch, 1);
+                credits += 1;
+            }
+            expected.push((epoch, credits, credits - epoch));
+        }
+
+        while expected.len() > MAX_EPOCH_CREDITS_HISTORY {
+            expected.remove(0);
+        }
+
+        assert_eq!(vote_state.credits(), credits);
+        assert_eq!(vote_state.epoch_credits().clone(), expected);
+    }
+
+    #[test_case(VoteStateV3::default() ; "VoteStateV3")]
+    #[test_case(VoteStateV4::default() ; "VoteStateV4")]
+    fn test_vote_state_epoch0_no_credits<T: VoteStateHandle>(mut vote_state: T) {
+        assert_eq!(vote_state.epoch_credits().len(), 0);
+        vote_state.increment_credits(1, 1);
+        assert_eq!(vote_state.epoch_credits().len(), 1);
+
+        vote_state.increment_credits(2, 1);
+        assert_eq!(vote_state.epoch_credits().len(), 2);
+    }
+
+    #[test_case(VoteStateV3::default() ; "VoteStateV3")]
+    #[test_case(VoteStateV4::default() ; "VoteStateV4")]
+    fn test_vote_state_increment_credits<T: VoteStateHandle>(mut vote_state: T) {
+        let credits = (MAX_EPOCH_CREDITS_HISTORY + 2) as u64;
+        for i in 0..credits {
+            vote_state.increment_credits(i, 1);
+        }
+        assert_eq!(vote_state.credits(), credits);
+        assert!(vote_state.epoch_credits().len() <= MAX_EPOCH_CREDITS_HISTORY);
+    }
+
+    #[test_case(VoteStateV3::default() ; "VoteStateV3")]
+    #[test_case(VoteStateV4::default() ; "VoteStateV4")]
+    fn test_vote_process_timestamp<T: VoteStateHandle>(mut vote_state: T) {
+        let (slot, timestamp) = (15, 1_575_412_285);
+        vote_state.set_last_timestamp(BlockTimestamp { slot, timestamp });
+
+        assert_eq!(
+            vote_state.process_timestamp(slot - 1, timestamp + 1),
+            Err(VoteError::TimestampTooOld)
+        );
+        assert_eq!(
+            vote_state.last_timestamp(),
+            &BlockTimestamp { slot, timestamp }
+        );
+        assert_eq!(
+            vote_state.process_timestamp(slot + 1, timestamp - 1),
+            Err(VoteError::TimestampTooOld)
+        );
+        assert_eq!(
+            vote_state.process_timestamp(slot, timestamp + 1),
+            Err(VoteError::TimestampTooOld)
+        );
+        assert_eq!(vote_state.process_timestamp(slot, timestamp), Ok(()));
+        assert_eq!(
+            vote_state.last_timestamp(),
+            &BlockTimestamp { slot, timestamp }
+        );
+        assert_eq!(vote_state.process_timestamp(slot + 1, timestamp), Ok(()));
+        assert_eq!(
+            vote_state.last_timestamp(),
+            &BlockTimestamp {
+                slot: slot + 1,
+                timestamp
+            }
+        );
+        assert_eq!(
+            vote_state.process_timestamp(slot + 2, timestamp + 1),
+            Ok(())
+        );
+        assert_eq!(
+            vote_state.last_timestamp(),
+            &BlockTimestamp {
+                slot: slot + 2,
+                timestamp: timestamp + 1
+            }
+        );
+
+        // Test initial vote
+        vote_state.set_last_timestamp(BlockTimestamp::default());
+        assert_eq!(vote_state.process_timestamp(0, timestamp), Ok(()));
+    }
+
+    enum ExpectedVoteStateVersion {
+        V1_14_11,
+        V3,
+    }
+
+    fn init_vote_account_state_v3_and_assert(
+        vote_pubkey: Pubkey,
+        vote_account: AccountSharedData,
+        vote_init: &VoteInit,
+        clock: &Clock,
+        rent: Rent,
+        expected_version: ExpectedVoteStateVersion,
+    ) {
+        let transaction_context = mock_transaction_context(vote_pubkey, vote_account, rent);
+        let instruction_context = transaction_context.get_next_instruction_context().unwrap();
+        let mut vote_account = instruction_context
+            .try_borrow_instruction_account(0)
+            .unwrap();
+
+        // Initialize.
+        VoteStateHandler::init_vote_account_state(
+            &mut vote_account,
+            vote_init,
+            clock,
+            VoteStateTargetVersion::V3,
+        )
+        .unwrap();
+
+        let vote_state_versions = vote_account.get_state::<VoteStateVersions>().unwrap();
+
+        match expected_version {
+            ExpectedVoteStateVersion::V1_14_11 => {
+                assert!(matches!(
+                    vote_state_versions,
+                    VoteStateVersions::V1_14_11(_)
+                ));
+                assert!(!vote_state_versions.is_uninitialized());
+
+                // Verify fields.
+                if let VoteStateVersions::V1_14_11(v1_14_11) = vote_state_versions {
+                    assert_eq!(v1_14_11.node_pubkey, vote_init.node_pubkey);
+                    assert_eq!(
+                        v1_14_11.authorized_voters.get_authorized_voter(0),
+                        Some(vote_init.authorized_voter)
+                    );
+                    assert_eq!(
+                        v1_14_11.authorized_withdrawer,
+                        vote_init.authorized_withdrawer
+                    );
+                    assert_eq!(v1_14_11.commission, vote_init.commission);
+                } else {
+                    panic!("should be v1_14_11");
+                }
+            }
+            ExpectedVoteStateVersion::V3 => {
+                assert!(matches!(vote_state_versions, VoteStateVersions::V3(_)));
+                assert!(!vote_state_versions.is_uninitialized());
+
+                // Verify fields.
+                if let VoteStateVersions::V3(v3) = vote_state_versions {
+                    assert_eq!(v3.node_pubkey, vote_init.node_pubkey);
+                    assert_eq!(
+                        v3.authorized_voters.get_authorized_voter(0),
+                        Some(vote_init.authorized_voter)
+                    );
+                    assert_eq!(v3.authorized_withdrawer, vote_init.authorized_withdrawer);
+                    assert_eq!(v3.commission, vote_init.commission);
+                } else {
+                    panic!("should be v3");
+                }
+            }
+        }
+    }
+
+    fn init_vote_account_state_v4_and_assert(
+        vote_pubkey: Pubkey,
+        vote_account: AccountSharedData,
+        vote_init: &VoteInit,
+        clock: &Clock,
+        rent: Rent,
+        expected_result: Result<(), InstructionError>,
+    ) {
+        let transaction_context = mock_transaction_context(vote_pubkey, vote_account, rent);
+        let instruction_context = transaction_context.get_next_instruction_context().unwrap();
+        let mut vote_account = instruction_context
+            .try_borrow_instruction_account(0)
+            .unwrap();
+
+        // Initialize.
+        let result = VoteStateHandler::init_vote_account_state(
+            &mut vote_account,
+            vote_init,
+            clock,
+            VoteStateTargetVersion::V4,
+        );
+        assert_eq!(result, expected_result);
+
+        if result.is_ok() {
+            let vote_state_versions = vote_account.get_state::<VoteStateVersions>().unwrap();
+            assert!(matches!(vote_state_versions, VoteStateVersions::V4(_)));
+            assert!(!vote_state_versions.is_uninitialized());
+
+            // Verify fields.
+            if let VoteStateVersions::V4(v4) = vote_state_versions {
+                assert_eq!(v4.node_pubkey, vote_init.node_pubkey);
+                assert_eq!(
+                    v4.authorized_voters.get_authorized_voter(clock.epoch),
+                    Some(vote_init.authorized_voter)
+                );
+                assert_eq!(v4.authorized_withdrawer, vote_init.authorized_withdrawer);
+                assert_eq!(
+                    v4.inflation_rewards_commission_bps,
+                    (vote_init.commission as u16) * 100
+                );
+
+                // SIMD-0185 fields
+                assert_eq!(v4.inflation_rewards_collector, vote_pubkey);
+                assert_eq!(v4.block_revenue_collector, vote_init.node_pubkey);
+                assert_eq!(
+                    v4.block_revenue_commission_bps,
+                    DEFAULT_BLOCK_REVENUE_COMMISSION_BPS
+                );
+
+                // Fields that should be default
+                assert_eq!(v4.pending_delegator_rewards, 0);
+                assert_eq!(v4.bls_pubkey_compressed, None);
+                assert!(v4.votes.is_empty());
+                assert_eq!(v4.root_slot, None);
+                assert!(v4.epoch_credits.is_empty());
+                assert_eq!(v4.last_timestamp, BlockTimestamp::default());
+            } else {
+                panic!("should be v4");
+            }
+        }
+    }
+
+    fn deinit_vote_account_state_v3_and_assert(
+        vote_pubkey: Pubkey,
+        vote_account: AccountSharedData,
+        rent: Rent,
+        expected_version: ExpectedVoteStateVersion,
+    ) {
+        let transaction_context = mock_transaction_context(vote_pubkey, vote_account, rent.clone());
+        let instruction_context = transaction_context.get_next_instruction_context().unwrap();
+        let mut vote_account = instruction_context
+            .try_borrow_instruction_account(0)
+            .unwrap();
+
+        // Deinitialize.
+        VoteStateHandler::deinitialize_vote_account_state(
+            &mut vote_account,
+            VoteStateTargetVersion::V3,
+        )
+        .unwrap();
+
+        let vote_state_versions = vote_account.get_state::<VoteStateVersions>().unwrap();
+
+        match expected_version {
+            ExpectedVoteStateVersion::V1_14_11 => {
+                assert!(matches!(
+                    vote_state_versions,
+                    VoteStateVersions::V1_14_11(_)
+                ));
+                assert!(vote_state_versions.is_uninitialized());
+            }
+            ExpectedVoteStateVersion::V3 => {
+                assert!(matches!(vote_state_versions, VoteStateVersions::V3(_)));
+                assert!(vote_state_versions.is_uninitialized());
+            }
+        }
+    }
+
+    fn deinit_vote_account_state_v4_and_assert(
+        vote_pubkey: Pubkey,
+        vote_account: AccountSharedData,
+        rent: Rent,
+    ) {
+        let transaction_context = mock_transaction_context(vote_pubkey, vote_account, rent.clone());
+        let instruction_context = transaction_context.get_next_instruction_context().unwrap();
+        let mut vote_account = instruction_context
+            .try_borrow_instruction_account(0)
+            .unwrap();
+
+        // Deinitialize.
+        VoteStateHandler::deinitialize_vote_account_state(
+            &mut vote_account,
+            VoteStateTargetVersion::V4,
+        )
+        .unwrap();
+
+        // Per SIMD-0185, V4 should completely zero out the account data.
+        let account_data = vote_account.get_data();
+        assert!(account_data.iter().all(|&b| b == 0),);
+
+        // Vote account was completely zeroed, so this should deserialize as a
+        // v1, but it should be uninitialized.
+        let vote_state_versions = vote_account.get_state::<VoteStateVersions>().unwrap();
+        assert!(matches!(vote_state_versions, VoteStateVersions::V0_23_5(_)));
+        assert!(vote_state_versions.is_uninitialized());
+    }
+
+    #[test]
+    fn test_init_vote_account_state_v3() {
+        let vote_pubkey = Pubkey::new_unique();
+        let vote_init = VoteInit {
+            node_pubkey: Pubkey::new_unique(),
+            authorized_voter: Pubkey::new_unique(),
+            authorized_withdrawer: Pubkey::new_unique(),
+            commission: 5,
+        };
+        let clock = Clock::default();
+        let rent = Rent::default();
+
+        // First create a vote account that's too small for v3.
+        let v1_14_11_size = VoteState1_14_11::size_of();
+        let lamports = rent.minimum_balance(v1_14_11_size);
+        let vote_account = AccountSharedData::new(lamports, v1_14_11_size, &id());
+
+        // Initialize - should default to v1_14_11.
+        init_vote_account_state_v3_and_assert(
+            vote_pubkey,
+            vote_account,
+            &vote_init,
+            &clock,
+            rent.clone(),
+            ExpectedVoteStateVersion::V1_14_11,
+        );
+
+        // Create a vote account that's too small for v3, but has enough
+        // lamports for resize.
+        let v3_size = VoteStateV3::size_of();
+        let lamports = rent.minimum_balance(v3_size);
+        let vote_account = AccountSharedData::new(lamports, v1_14_11_size, &id());
+
+        // Initialize - should resize and create v3.
+        init_vote_account_state_v3_and_assert(
+            vote_pubkey,
+            vote_account,
+            &vote_init,
+            &clock,
+            rent.clone(),
+            ExpectedVoteStateVersion::V3,
+        );
+
+        // Now create a vote account that's large enough for v3.
+        let lamports = rent.minimum_balance(v3_size);
+        let vote_account = AccountSharedData::new(lamports, v3_size, &id());
+
+        // Initialize - should create v3.
+        init_vote_account_state_v3_and_assert(
+            vote_pubkey,
+            vote_account,
+            &vote_init,
+            &clock,
+            rent,
+            ExpectedVoteStateVersion::V3,
+        );
+    }
+
+    #[test]
+    fn test_init_vote_account_state_v4() {
+        let vote_pubkey = Pubkey::new_unique();
+        let vote_init = VoteInit {
+            node_pubkey: Pubkey::new_unique(),
+            authorized_voter: Pubkey::new_unique(),
+            authorized_withdrawer: Pubkey::new_unique(),
+            commission: 5,
+        };
+        let clock = Clock::default();
+        let rent = Rent::default();
+
+        // First create a vote account that's too small for v4.
+        let v1_14_11_size = VoteState1_14_11::size_of();
+        let lamports = rent.minimum_balance(v1_14_11_size);
+        let vote_account = AccountSharedData::new(lamports, v1_14_11_size, &id());
+
+        // Initialize - should fail.
+        init_vote_account_state_v4_and_assert(
+            vote_pubkey,
+            vote_account,
+            &vote_init,
+            &clock,
+            rent.clone(),
+            Err(InstructionError::AccountNotRentExempt),
+        );
+
+        // Create a vote account that's too small for v4, but has enough
+        // lamports for resize.
+        let v4_size = VoteStateV4::size_of();
+        let lamports = rent.minimum_balance(v4_size);
+        let vote_account = AccountSharedData::new(lamports, v1_14_11_size, &id());
+
+        // Initialize - should resize and create v4.
+        init_vote_account_state_v4_and_assert(
+            vote_pubkey,
+            vote_account,
+            &vote_init,
+            &clock,
+            rent.clone(),
+            Ok(()),
+        );
+
+        // Now create a vote account that's large enough for v4.
+        let lamports = rent.minimum_balance(v4_size);
+        let vote_account = AccountSharedData::new(lamports, v4_size, &id());
+
+        // Initialize - should create v4.
+        init_vote_account_state_v4_and_assert(
+            vote_pubkey,
+            vote_account,
+            &vote_init,
+            &clock,
+            rent,
+            Ok(()),
+        );
+    }
+
+    #[test]
+    fn test_deinitialize_vote_account_state_v3() {
+        let vote_pubkey = Pubkey::new_unique();
+        let rent = Rent::default();
+
+        // First create a vote account that's too small for v3.
+        let v1_14_11_size = VoteState1_14_11::size_of();
+        let lamports = rent.minimum_balance(v1_14_11_size);
+        let vote_account = AccountSharedData::new(lamports, v1_14_11_size, &id());
+
+        // Deinitialize - should default to v1_14_11.
+        deinit_vote_account_state_v3_and_assert(
+            vote_pubkey,
+            vote_account,
+            rent.clone(),
+            ExpectedVoteStateVersion::V1_14_11,
+        );
+
+        // Create a vote account that's too small for v3, but has enough
+        // lamports for resize.
+        let v3_size = VoteStateV3::size_of();
+        let lamports = rent.minimum_balance(v3_size);
+        let vote_account = AccountSharedData::new(lamports, v1_14_11_size, &id());
+
+        // Deinitialize - should resize and create v3.
+        deinit_vote_account_state_v3_and_assert(
+            vote_pubkey,
+            vote_account,
+            rent.clone(),
+            ExpectedVoteStateVersion::V3,
+        );
+
+        // Now create a vote account that's large enough for v3.
+        let lamports = rent.minimum_balance(v3_size);
+        let vote_account = AccountSharedData::new(lamports, v3_size, &id());
+
+        // Deinitialize - should create v3.
+        deinit_vote_account_state_v3_and_assert(
+            vote_pubkey,
+            vote_account,
+            rent,
+            ExpectedVoteStateVersion::V3,
+        );
+    }
+
+    #[test]
+    fn test_deinitialize_vote_account_state_v4() {
+        let vote_pubkey = Pubkey::new_unique();
+        let rent = Rent::default();
+
+        // First create a vote account that's too small for v4.
+        let v1_14_11_size = VoteState1_14_11::size_of();
+        let lamports = rent.minimum_balance(v1_14_11_size);
+        let vote_account = AccountSharedData::new(lamports, v1_14_11_size, &id());
+
+        // Deinitialize - should fail.
+        deinit_vote_account_state_v4_and_assert(vote_pubkey, vote_account, rent.clone());
+
+        // Create a vote account that's too small for v4, but has enough
+        // lamports for resize.
+        let v4_size = VoteStateV4::size_of();
+        let lamports = rent.minimum_balance(v4_size);
+        let vote_account = AccountSharedData::new(lamports, v1_14_11_size, &id());
+
+        // Deinitialize - should resize and create v4.
+        deinit_vote_account_state_v4_and_assert(vote_pubkey, vote_account, rent.clone());
+
+        // Now create a vote account that's large enough for v4.
+        let lamports = rent.minimum_balance(v4_size);
+        let vote_account = AccountSharedData::new(lamports, v4_size, &id());
+
+        // Deinitialize - should create v4.
+        deinit_vote_account_state_v4_and_assert(vote_pubkey, vote_account, rent);
+    }
+
+    #[test]
+    fn test_v4_commission_basis_points() {
+        // Test that commission is properly converted to basis points
+        // (multiplied by 100), as per SIMD-0185.
+        let mut handler = VoteStateHandler::new_v4(VoteStateV4::default());
+
+        for (input, expected) in [
+            (0, 0),
+            (1, 100),
+            (5, 500),
+            (10, 1_000),
+            (25, 2_500),
+            (50, 5_000),
+            (75, 7_500),
+            (100, 10_000),
+            (255, 25_500),
+        ] {
+            handler.set_commission(input);
+            assert_eq!(handler.commission(), input);
+
+            // Verify the internal V4 state has the correct basis points.
+            let vote_state_v4 = handler.as_ref_v4();
+            assert_eq!(vote_state_v4.inflation_rewards_commission_bps, expected);
+        }
+    }
+
+    #[test]
+    fn test_v4_conversion_from_all_versions() {
+        // Test conversion from all vote state versions to v4 per SIMD-0185.
+        let vote_pubkey = Pubkey::new_unique();
+        let node_pubkey = Pubkey::new_unique();
+        let authorized_voter = Pubkey::new_unique();
+        let authorized_withdrawer = Pubkey::new_unique();
+        let commission = 42u8;
+        let votes = vec![Lockout::new(100)];
+        let votes_deque: VecDeque<Lockout> = votes.iter().cloned().collect();
+        let epoch_credits = vec![(5, 200, 100)];
+        let root_slot = Some(50);
+
+        let rent = Rent::default();
+
+        // Helper to verify v4 defaults per SIMD-0185.
+        let verify_v4_defaults = |v4_state: &VoteStateV4, expected_commission_bps: u16| {
+            assert_eq!(
+                v4_state.inflation_rewards_commission_bps,
+                expected_commission_bps
+            );
+            assert_eq!(v4_state.inflation_rewards_collector, vote_pubkey);
+            assert_eq!(v4_state.block_revenue_collector, node_pubkey);
+            assert_eq!(
+                v4_state.block_revenue_commission_bps,
+                DEFAULT_BLOCK_REVENUE_COMMISSION_BPS
+            );
+            assert_eq!(v4_state.pending_delegator_rewards, 0);
+            assert_eq!(v4_state.bls_pubkey_compressed, None);
+        };
+
+        // Helper to deserialize and convert vote state through handler.
+        let deserialize_and_convert = |versioned: VoteStateVersions, space: usize| -> VoteStateV4 {
+            let vote_account =
+                AccountSharedData::new_data(rent.minimum_balance(space), &versioned, &id())
+                    .unwrap();
+
+            let transaction_context =
+                mock_transaction_context(vote_pubkey, vote_account, rent.clone());
+            let instruction_context = transaction_context.get_next_instruction_context().unwrap();
+            let vote_account_borrowed = instruction_context
+                .try_borrow_instruction_account(0)
+                .unwrap();
+
+            let handler = VoteStateHandler::deserialize_and_convert(
+                &vote_account_borrowed,
+                VoteStateTargetVersion::V4,
+            )
+            .unwrap();
+
+            handler.as_ref_v4().clone()
+        };
+
+        // V0_23_5
+        // NOTE: On target_os = "solana", VoteState0_23_5::deserialize should
+        // fail, but we can't replicate that in these unit tests. This should
+        // be tested in the program's processor tests.
+
+        // V1_14_11
+        {
+            let vote_state_v2 = VoteState1_14_11 {
+                node_pubkey,
+                authorized_withdrawer,
+                commission,
+                authorized_voters: AuthorizedVoters::new(0, authorized_voter),
+                votes: votes_deque.clone(),
+                epoch_credits: epoch_credits.clone(),
+                root_slot,
+                ..VoteState1_14_11::default()
+            };
+
+            let versioned = VoteStateVersions::V1_14_11(Box::new(vote_state_v2.clone()));
+            let vote_state_v4 = deserialize_and_convert(versioned, VoteState1_14_11::size_of());
+
+            // Compare fields that were already present in V1_14_11.
+            assert_eq!(vote_state_v4.node_pubkey, node_pubkey);
+            assert_eq!(vote_state_v4.authorized_withdrawer, authorized_withdrawer);
+            assert_eq!(
+                vote_state_v4.authorized_voters,
+                vote_state_v2.authorized_voters
+            );
+            assert_eq!(vote_state_v4.epoch_credits, epoch_credits);
+            assert_eq!(vote_state_v4.root_slot, root_slot);
+            assert_eq!(vote_state_v4.votes.len(), vote_state_v2.votes.len());
+            for (v4_vote, v2_vote) in vote_state_v4.votes.iter().zip(vote_state_v2.votes.iter()) {
+                assert_eq!(v4_vote.lockout, *v2_vote);
+            }
+
+            // Verify SIMD-0185 defaults.
+            verify_v4_defaults(&vote_state_v4, (commission as u16) * 100);
+        }
+
+        // V3
+        {
+            let vote_init = VoteInit {
+                node_pubkey,
+                authorized_voter,
+                authorized_withdrawer,
+                commission,
+            };
+            let mut vote_state_v3 = VoteStateV3::new(&vote_init, &Clock::default());
+            for lockout in &votes {
+                vote_state_v3.votes.push_back(LandedVote {
+                    latency: 1,
+                    lockout: *lockout,
+                });
+            }
+            vote_state_v3.epoch_credits = epoch_credits.clone();
+            vote_state_v3.root_slot = root_slot;
+
+            let versioned = VoteStateVersions::V3(Box::new(vote_state_v3.clone()));
+            let vote_state_v4 = deserialize_and_convert(versioned, VoteStateV3::size_of());
+
+            // Compare fields that were already present in V3.
+            assert_eq!(vote_state_v4.node_pubkey, node_pubkey);
+            assert_eq!(vote_state_v4.authorized_withdrawer, authorized_withdrawer);
+            assert_eq!(
+                vote_state_v4.authorized_voters,
+                vote_state_v3.authorized_voters
+            );
+            assert_eq!(vote_state_v4.epoch_credits, epoch_credits);
+            assert_eq!(vote_state_v4.root_slot, root_slot);
+            assert_eq!(vote_state_v4.last_timestamp, vote_state_v3.last_timestamp);
+            assert_eq!(vote_state_v4.votes, vote_state_v3.votes);
+
+            // Verify SIMD-0185 defaults.
+            verify_v4_defaults(&vote_state_v4, (commission as u16) * 100);
+        }
+
+        // V4
+        {
+            let mut initial_vote_state_v4 = VoteStateV4 {
+                node_pubkey,
+                authorized_withdrawer,
+                inflation_rewards_commission_bps: 1234,
+                block_revenue_commission_bps: 5678,
+                inflation_rewards_collector: Pubkey::new_unique(),
+                block_revenue_collector: Pubkey::new_unique(),
+                pending_delegator_rewards: 999,
+                bls_pubkey_compressed: Some([42; BLS_PUBLIC_KEY_COMPRESSED_SIZE]),
+                authorized_voters: AuthorizedVoters::new(0, authorized_voter),
+                epoch_credits: epoch_credits.clone(),
+                root_slot,
+                ..VoteStateV4::default()
+            };
+            for lockout in &votes {
+                initial_vote_state_v4.votes.push_back(LandedVote {
+                    latency: 1,
+                    lockout: *lockout,
+                });
+            }
+
+            let versioned = VoteStateVersions::V4(Box::new(initial_vote_state_v4.clone()));
+            let vote_state_v4 = deserialize_and_convert(versioned, VoteStateV4::size_of());
+
+            // Should be an exact copy.
+            assert_eq!(vote_state_v4, initial_vote_state_v4);
+        }
+    }
+
+    #[test]
+    fn test_v3_v4_size_equality() {
+        let v3_size = VoteStateV3::size_of();
+        let v4_size = VoteStateV4::size_of();
+        assert_eq!(v3_size, v4_size, "V3 and V4 should have the same size");
+    }
+
+    #[test_case(
+        VoteState1_14_11::size_of(),
+        false,
+        Err(InstructionError::AccountNotRentExempt);
+        "v1_14_11 size insufficient lamports - no fallback"
+    )]
+    #[test_case(
+        VoteState1_14_11::size_of(),
+        true,
+        Ok(());
+        "v1_14_11 size sufficient lamports - resize and succeed"
+    )]
+    #[test_case(
+        VoteStateV4::size_of(),
+        true,
+        Ok(());
+        "v4 properly sized with rent-exempt lamports - succeed"
+    )]
+    fn test_v4_resize_behavior(
+        account_size: usize,
+        sufficient_lamports: bool,
+        expected_result: Result<(), InstructionError>,
+    ) {
+        let vote_pubkey = Pubkey::new_unique();
+        let node_pubkey = Pubkey::new_unique();
+        let authorized_voter = Pubkey::new_unique();
+        let authorized_withdrawer = Pubkey::new_unique();
+        let rent = Rent::default();
+
+        let vote_init = VoteInit {
+            node_pubkey,
+            authorized_voter,
+            authorized_withdrawer,
+            commission: 42,
+        };
+
+        let lamports = if sufficient_lamports {
+            rent.minimum_balance(VoteStateV4::size_of())
+        } else {
+            rent.minimum_balance(account_size)
+        };
+
+        let mut vote_account = AccountSharedData::new(lamports, account_size, &id());
+        vote_account.set_data_from_slice(&vec![0; account_size]);
+
+        let transaction_context = mock_transaction_context(vote_pubkey, vote_account, rent.clone());
+        let instruction_context = transaction_context.get_next_instruction_context().unwrap();
+        let mut vote_account_borrowed = instruction_context
+            .try_borrow_instruction_account(0)
+            .unwrap();
+
+        let result = VoteStateHandler::init_vote_account_state(
+            &mut vote_account_borrowed,
+            &vote_init,
+            &Clock::default(),
+            VoteStateTargetVersion::V4,
+        );
+
+        assert_eq!(result, expected_result);
     }
 }

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -3,9 +3,12 @@
 
 mod handler;
 
-pub use solana_vote_interface::state::{vote_state_versions::*, *};
+pub use {
+    handler::VoteStateTargetVersion,
+    solana_vote_interface::state::{vote_state_versions::*, *},
+};
 use {
-    handler::{VoteStateHandle, VoteStateHandler, VoteStateTargetVersion},
+    handler::{VoteStateHandle, VoteStateHandler},
     log::*,
     solana_account::{AccountSharedData, ReadableAccount, WritableAccount},
     solana_clock::{Clock, Epoch, Slot},
@@ -16,12 +19,15 @@ use {
     solana_rent::Rent,
     solana_slot_hashes::SlotHash,
     solana_transaction_context::{BorrowedInstructionAccount, IndexOfAccount, InstructionContext},
-    solana_vote_interface::{authorized_voters::AuthorizedVoters, error::VoteError, program::id},
+    solana_vote_interface::{error::VoteError, program::id},
     std::{
         cmp::Ordering,
         collections::{HashSet, VecDeque},
     },
 };
+
+// TODO: Change me once the program has full v4 feature gate support.
+pub(crate) const TEMP_HARDCODED_TARGET_VERSION: VoteStateTargetVersion = VoteStateTargetVersion::V3;
 
 // utility function, used by Stakes, tests
 pub fn from<T: ReadableAccount>(account: &T) -> Option<VoteStateV3> {
@@ -31,10 +37,6 @@ pub fn from<T: ReadableAccount>(account: &T) -> Option<VoteStateV3> {
 // utility function, used by Stakes, tests
 pub fn to<T: WritableAccount>(versioned: &VoteStateVersions, account: &mut T) -> Option<()> {
     VoteStateV3::serialize(versioned, account.data_as_mut_slice()).ok()
-}
-
-fn compute_vote_latency(voted_for_slot: Slot, current_slot: Slot) -> u8 {
-    std::cmp::min(current_slot.saturating_sub(voted_for_slot), u8::MAX as u64) as u8
 }
 
 /// Checks the proposed vote state with the current and
@@ -576,7 +578,7 @@ pub fn process_new_vote_state(
     // have had their latency initialized to 0 by the above loop.  Those will now be updated to their actual latency.
     for new_vote in new_state.iter_mut() {
         if new_vote.latency == 0 {
-            new_vote.latency = compute_vote_latency(new_vote.slot(), current_slot);
+            new_vote.latency = handler::compute_vote_latency(new_vote.slot(), current_slot);
         }
     }
 
@@ -676,13 +678,13 @@ pub fn process_slot_vote_unchecked<T: VoteStateHandle>(vote_state: &mut T, slot:
 /// key
 pub fn authorize<S: std::hash::BuildHasher>(
     vote_account: &mut BorrowedInstructionAccount,
+    target_version: VoteStateTargetVersion,
     authorized: &Pubkey,
     vote_authorize: VoteAuthorize,
     signers: &HashSet<Pubkey, S>,
     clock: &Clock,
 ) -> Result<(), InstructionError> {
-    let mut vote_state =
-        VoteStateHandler::deserialize_and_convert(vote_account, VoteStateTargetVersion::V3)?;
+    let mut vote_state = VoteStateHandler::deserialize_and_convert(vote_account, target_version)?;
 
     match vote_authorize {
         VoteAuthorize::Voter => {
@@ -719,11 +721,11 @@ pub fn authorize<S: std::hash::BuildHasher>(
 /// Update the node_pubkey, requires signature of the authorized voter
 pub fn update_validator_identity<S: std::hash::BuildHasher>(
     vote_account: &mut BorrowedInstructionAccount,
+    target_version: VoteStateTargetVersion,
     node_pubkey: &Pubkey,
     signers: &HashSet<Pubkey, S>,
 ) -> Result<(), InstructionError> {
-    let mut vote_state =
-        VoteStateHandler::deserialize_and_convert(vote_account, VoteStateTargetVersion::V3)?;
+    let mut vote_state = VoteStateHandler::deserialize_and_convert(vote_account, target_version)?;
 
     // current authorized withdrawer must say "yay"
     verify_authorized_signer(vote_state.authorized_withdrawer(), signers)?;
@@ -739,13 +741,13 @@ pub fn update_validator_identity<S: std::hash::BuildHasher>(
 /// Update the vote account's commission
 pub fn update_commission<S: std::hash::BuildHasher>(
     vote_account: &mut BorrowedInstructionAccount,
+    target_version: VoteStateTargetVersion,
     commission: u8,
     signers: &HashSet<Pubkey, S>,
     epoch_schedule: &EpochSchedule,
     clock: &Clock,
 ) -> Result<(), InstructionError> {
-    let vote_state_result =
-        VoteStateHandler::deserialize_and_convert(vote_account, VoteStateTargetVersion::V3);
+    let vote_state_result = VoteStateHandler::deserialize_and_convert(vote_account, target_version);
     let enforce_commission_update_rule = if let Ok(decoded_vote_state) = &vote_state_result {
         commission > decoded_vote_state.commission()
     } else {
@@ -764,11 +766,6 @@ pub fn update_commission<S: std::hash::BuildHasher>(
     vote_state.set_commission(commission);
 
     vote_state.set_vote_account_state(vote_account)
-}
-
-/// Given a proposed new commission, returns true if this would be a commission increase, false otherwise
-pub fn is_commission_increase(vote_state: &VoteStateV3, commission: u8) -> bool {
-    commission > vote_state.commission
 }
 
 /// Given the current slot and epoch schedule, determine if a commission change
@@ -802,6 +799,7 @@ fn verify_authorized_signer<S: std::hash::BuildHasher>(
 pub fn withdraw<S: std::hash::BuildHasher>(
     instruction_context: &InstructionContext,
     vote_account_index: IndexOfAccount,
+    target_version: VoteStateTargetVersion,
     lamports: u64,
     to_account_index: IndexOfAccount,
     signers: &HashSet<Pubkey, S>,
@@ -810,8 +808,7 @@ pub fn withdraw<S: std::hash::BuildHasher>(
 ) -> Result<(), InstructionError> {
     let mut vote_account =
         instruction_context.try_borrow_instruction_account(vote_account_index)?;
-    let vote_state =
-        VoteStateHandler::deserialize_and_convert(&vote_account, VoteStateTargetVersion::V3)?;
+    let vote_state = VoteStateHandler::deserialize_and_convert(&vote_account, target_version)?;
 
     verify_authorized_signer(vote_state.authorized_withdrawer(), signers)?;
 
@@ -822,7 +819,8 @@ pub fn withdraw<S: std::hash::BuildHasher>(
 
     if remaining_balance == 0 {
         let reject_active_vote_account_close = vote_state
-            .epoch_credits_last()
+            .epoch_credits()
+            .last()
             .map(|(last_epoch_with_credits, _, _)| {
                 let current_epoch = clock.epoch;
                 // if current_epoch - last_epoch_with_credits < 2 then the validator has received credits
@@ -836,10 +834,7 @@ pub fn withdraw<S: std::hash::BuildHasher>(
             return Err(VoteError::ActiveVoteAccountClose.into());
         } else {
             // Deinitialize upon zero-balance
-            VoteStateHandler::deinitialize_vote_account_state(
-                &mut vote_account,
-                VoteStateTargetVersion::V3,
-            )?;
+            VoteStateHandler::deinitialize_vote_account_state(&mut vote_account, target_version)?;
         }
     } else {
         let min_rent_exempt_balance = rent_sysvar.minimum_balance(vote_account.get_data().len());
@@ -860,11 +855,12 @@ pub fn withdraw<S: std::hash::BuildHasher>(
 /// that the transaction must be signed by the staker's keys
 pub fn initialize_account<S: std::hash::BuildHasher>(
     vote_account: &mut BorrowedInstructionAccount,
+    target_version: VoteStateTargetVersion,
     vote_init: &VoteInit,
     signers: &HashSet<Pubkey, S>,
     clock: &Clock,
 ) -> Result<(), InstructionError> {
-    VoteStateHandler::check_vote_account_length(vote_account, VoteStateTargetVersion::V3)?;
+    VoteStateHandler::check_vote_account_length(vote_account, target_version)?;
     let versioned = vote_account.get_state::<VoteStateVersions>()?;
 
     if !versioned.is_uninitialized() {
@@ -874,21 +870,16 @@ pub fn initialize_account<S: std::hash::BuildHasher>(
     // node must agree to accept this vote account
     verify_authorized_signer(&vote_init.node_pubkey, signers)?;
 
-    VoteStateHandler::init_vote_account_state(
-        vote_account,
-        vote_init,
-        clock,
-        VoteStateTargetVersion::V3,
-    )
+    VoteStateHandler::init_vote_account_state(vote_account, vote_init, clock, target_version)
 }
 
 fn verify_and_get_vote_state_handler<S: std::hash::BuildHasher>(
     vote_account: &BorrowedInstructionAccount,
+    target_version: VoteStateTargetVersion,
     clock: &Clock,
     signers: &HashSet<Pubkey, S>,
 ) -> Result<VoteStateHandler, InstructionError> {
-    let mut vote_state =
-        VoteStateHandler::deserialize_and_convert(vote_account, VoteStateTargetVersion::V3)?;
+    let mut vote_state = VoteStateHandler::deserialize_and_convert(vote_account, target_version)?;
 
     if vote_state.is_uninitialized() {
         return Err(InstructionError::UninitializedAccount);
@@ -902,12 +893,14 @@ fn verify_and_get_vote_state_handler<S: std::hash::BuildHasher>(
 
 pub fn process_vote_with_account<S: std::hash::BuildHasher>(
     vote_account: &mut BorrowedInstructionAccount,
+    target_version: VoteStateTargetVersion,
     slot_hashes: &[SlotHash],
     clock: &Clock,
     vote: &Vote,
     signers: &HashSet<Pubkey, S>,
 ) -> Result<(), InstructionError> {
-    let mut vote_state = verify_and_get_vote_state_handler(vote_account, clock, signers)?;
+    let mut vote_state =
+        verify_and_get_vote_state_handler(vote_account, target_version, clock, signers)?;
 
     process_vote(&mut vote_state, vote, slot_hashes, clock.epoch, clock.slot)?;
     if let Some(timestamp) = vote.timestamp {
@@ -922,12 +915,14 @@ pub fn process_vote_with_account<S: std::hash::BuildHasher>(
 
 pub fn process_vote_state_update<S: std::hash::BuildHasher>(
     vote_account: &mut BorrowedInstructionAccount,
+    target_version: VoteStateTargetVersion,
     slot_hashes: &[SlotHash],
     clock: &Clock,
     vote_state_update: VoteStateUpdate,
     signers: &HashSet<Pubkey, S>,
 ) -> Result<(), InstructionError> {
-    let mut vote_state = verify_and_get_vote_state_handler(vote_account, clock, signers)?;
+    let mut vote_state =
+        verify_and_get_vote_state_handler(vote_account, target_version, clock, signers)?;
     do_process_vote_state_update(
         &mut vote_state,
         slot_hashes,
@@ -968,12 +963,14 @@ pub fn do_process_vote_state_update(
 
 pub fn process_tower_sync<S: std::hash::BuildHasher>(
     vote_account: &mut BorrowedInstructionAccount,
+    target_version: VoteStateTargetVersion,
     slot_hashes: &[SlotHash],
     clock: &Clock,
     tower_sync: TowerSync,
     signers: &HashSet<Pubkey, S>,
 ) -> Result<(), InstructionError> {
-    let mut vote_state = verify_and_get_vote_state_handler(vote_account, clock, signers)?;
+    let mut vote_state =
+        verify_and_get_vote_state_handler(vote_account, target_version, clock, signers)?;
     do_process_tower_sync(
         &mut vote_state,
         slot_hashes,
@@ -1044,24 +1041,6 @@ pub fn create_account_with_authorized(
     vote_account
 }
 
-// TODO(wen): when we have VoteStateV4::new(), switch all users there.
-pub fn new_v4_vote_state(
-    node_pubkey: &Pubkey,
-    authorized_voter: &Pubkey,
-    authorized_withdrawer: &Pubkey,
-    bls_pubkey_compressed: Option<[u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE]>,
-    inflation_rewards_commission_bps: u16,
-) -> VoteStateV4 {
-    VoteStateV4 {
-        node_pubkey: *node_pubkey,
-        authorized_voters: AuthorizedVoters::new(0, *authorized_voter),
-        authorized_withdrawer: *authorized_withdrawer,
-        bls_pubkey_compressed,
-        inflation_rewards_commission_bps,
-        ..VoteStateV4::default()
-    }
-}
-
 pub fn create_v4_account_with_authorized(
     node_pubkey: &Pubkey,
     authorized_voter: &Pubkey,
@@ -1072,7 +1051,7 @@ pub fn create_v4_account_with_authorized(
 ) -> AccountSharedData {
     let mut vote_account = AccountSharedData::new(lamports, VoteStateV4::size_of(), &id());
 
-    let vote_state = new_v4_vote_state(
+    let vote_state = handler::create_new_vote_state_v4_for_tests(
         node_pubkey,
         authorized_voter,
         authorized_withdrawer,
@@ -1099,64 +1078,51 @@ pub fn create_account(
     create_account_with_authorized(node_pubkey, vote_pubkey, vote_pubkey, commission, lamports)
 }
 
+#[allow(clippy::arithmetic_side_effects)]
 #[cfg(test)]
 mod tests {
     use {
         super::*,
-        crate::vote_state,
         assert_matches::assert_matches,
         solana_account::AccountSharedData,
         solana_clock::DEFAULT_SLOTS_PER_EPOCH,
         solana_sha256_hasher::hash,
         solana_transaction_context::{InstructionAccount, TransactionContext},
-        std::cell::RefCell,
+        solana_vote_interface::authorized_voters::AuthorizedVoters,
         test_case::test_case,
     };
 
     const MAX_RECENT_VOTES: usize = 16;
 
-    fn vote_state_new_for_test(auth_pubkey: &Pubkey) -> VoteStateHandler {
-        VoteStateHandler::new_v3(VoteStateV3::new(
-            &VoteInit {
-                node_pubkey: solana_pubkey::new_rand(),
-                authorized_voter: *auth_pubkey,
-                authorized_withdrawer: *auth_pubkey,
-                commission: 0,
-            },
-            &Clock::default(),
-        ))
+    fn vote_state_new_for_test(
+        vote_pubkey: &Pubkey,
+        target_version: VoteStateTargetVersion,
+    ) -> VoteStateHandler {
+        let auth_pubkey = solana_pubkey::new_rand();
+        let vote_init = VoteInit {
+            node_pubkey: solana_pubkey::new_rand(),
+            authorized_voter: auth_pubkey,
+            authorized_withdrawer: auth_pubkey,
+            commission: 0,
+        };
+        let clock = Clock::default();
+
+        match target_version {
+            VoteStateTargetVersion::V3 => {
+                VoteStateHandler::new_v3(VoteStateV3::new(&vote_init, &clock))
+            }
+            VoteStateTargetVersion::V4 => VoteStateHandler::new_v4(
+                handler::create_new_vote_state_v4(vote_pubkey, &vote_init, &clock),
+            ),
+        }
     }
 
-    fn create_test_account() -> (Pubkey, RefCell<AccountSharedData>) {
-        let rent = Rent::default();
-        let balance = rent.minimum_balance(VoteStateV3::size_of());
+    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
+    #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
+    fn test_vote_state_upgrade_from_1_14_11(target_version: VoteStateTargetVersion) {
         let vote_pubkey = solana_pubkey::new_rand();
-        (
-            vote_pubkey,
-            RefCell::new(vote_state::create_account(
-                &vote_pubkey,
-                &solana_pubkey::new_rand(),
-                0,
-                balance,
-            )),
-        )
-    }
+        let mut vote_state = vote_state_new_for_test(&vote_pubkey, target_version);
 
-    #[test]
-    fn test_vote_state_upgrade_from_1_14_11() {
-        // Create an initial vote account that is sized for the 1_14_11 version of vote state, and has only the
-        // required lamports for rent exempt minimum at that size
-        let node_pubkey = solana_pubkey::new_rand();
-        let withdrawer_pubkey = solana_pubkey::new_rand();
-        let mut vote_state = VoteStateV3::new(
-            &VoteInit {
-                node_pubkey,
-                authorized_voter: withdrawer_pubkey,
-                authorized_withdrawer: withdrawer_pubkey,
-                commission: 10,
-            },
-            &Clock::default(),
-        );
         // Simulate prior epochs completed with credits and each setting a new authorized voter
         vote_state.increment_credits(0, 100);
         assert_eq!(
@@ -1173,6 +1139,7 @@ mod tests {
             vote_state.set_new_authorized_voter(&solana_pubkey::new_rand(), 2, 3, |_pubkey| Ok(())),
             Ok(())
         );
+
         // Simulate votes having occurred
         vec![
             100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116,
@@ -1182,10 +1149,35 @@ mod tests {
         .into_iter()
         .for_each(|v| vote_state.process_next_vote_slot(v, 4, 0));
 
-        let version1_14_11_serialized = bincode::serialize(&VoteStateVersions::V1_14_11(Box::new(
-            VoteState1_14_11::from(vote_state.clone()),
-        )))
-        .unwrap();
+        // Create an initial vote account that is sized for the 1_14_11 version of vote state, and has only the
+        // required lamports for rent exempt minimum at that size
+        let vote_state_v1_14_11 = match target_version {
+            VoteStateTargetVersion::V3 => {
+                // v3 can be converted directly to V1_14_11.
+                VoteState1_14_11::from(vote_state.as_ref_v3().clone())
+            }
+            VoteStateTargetVersion::V4 => {
+                // v4 cannot be converted directly to V1_14_11.
+                VoteState1_14_11 {
+                    node_pubkey: *vote_state.node_pubkey(),
+                    authorized_withdrawer: *vote_state.authorized_withdrawer(),
+                    commission: vote_state.commission(),
+                    votes: vote_state
+                        .votes()
+                        .iter()
+                        .map(|landed_vote| (*landed_vote).into())
+                        .collect(),
+                    root_slot: vote_state.root_slot(),
+                    authorized_voters: vote_state.authorized_voters().clone(),
+                    epoch_credits: vote_state.epoch_credits().clone(),
+                    last_timestamp: vote_state.last_timestamp().clone(),
+                    prior_voters: CircBuf::default(), // v4 does not store prior_voters
+                }
+            }
+        };
+        let version1_14_11_serialized =
+            bincode::serialize(&VoteStateVersions::V1_14_11(Box::new(vote_state_v1_14_11)))
+                .unwrap();
         let version1_14_11_serialized_len = version1_14_11_serialized.len();
         let rent = Rent::default();
         let lamports = rent.minimum_balance(version1_14_11_serialized_len);
@@ -1197,7 +1189,7 @@ mod tests {
         // vote account that was just created
         let processor_account = AccountSharedData::new(0, 0, &solana_sdk_ids::native_loader::id());
         let mut transaction_context = TransactionContext::new(
-            vec![(id(), processor_account), (node_pubkey, vote_account)],
+            vec![(id(), processor_account), (vote_pubkey, vote_account)],
             rent.clone(),
             0,
             0,
@@ -1222,76 +1214,87 @@ mod tests {
         assert_matches!(vote_state_version, VoteStateVersions::V1_14_11(_));
 
         // Convert the vote state to current as would occur during vote instructions
-        let converted_vote_state = VoteStateV3::deserialize(borrowed_account.get_data()).unwrap();
+        let converted_vote_state =
+            VoteStateHandler::deserialize_and_convert(&borrowed_account, target_version).unwrap();
 
         // Check to make sure that the vote_state is unchanged
         assert!(vote_state == converted_vote_state);
 
         let vote_state = converted_vote_state;
 
-        // Now re-set the vote account state; because the feature is not enabled, the old 1_14_11 format should be
-        // written out
-        assert_eq!(
-            VoteStateHandler::new_v3(vote_state.clone())
-                .set_vote_account_state(&mut borrowed_account),
-            Ok(())
-        );
-        let vote_state_version = borrowed_account.get_state::<VoteStateVersions>().unwrap();
-        assert_matches!(vote_state_version, VoteStateVersions::V1_14_11(_));
+        // Now re-set the vote account state, knowing the account only has
+        // enough lamports for V1_14_11.
+        match target_version {
+            VoteStateTargetVersion::V3 => {
+                // V3 will write out as V1_14_11.
+                assert_eq!(
+                    vote_state
+                        .clone()
+                        .set_vote_account_state(&mut borrowed_account),
+                    Ok(())
+                );
+                let vote_state_version = borrowed_account.get_state::<VoteStateVersions>().unwrap();
+                assert_matches!(vote_state_version, VoteStateVersions::V1_14_11(_));
+            }
+            VoteStateTargetVersion::V4 => {
+                // V4 will throw an error.
+                assert_eq!(
+                    vote_state
+                        .clone()
+                        .set_vote_account_state(&mut borrowed_account),
+                    Err(InstructionError::AccountNotRentExempt)
+                );
+            }
+        }
 
         // Convert the vote state to current as would occur during vote instructions
-        let converted_vote_state = VoteStateV3::deserialize(borrowed_account.get_data()).unwrap();
+        let converted_vote_state =
+            VoteStateHandler::deserialize_and_convert(&borrowed_account, target_version).unwrap();
 
         // Check to make sure that the vote_state is unchanged
-        assert_eq!(vote_state, converted_vote_state);
+        assert!(vote_state == converted_vote_state);
 
         let vote_state = converted_vote_state;
 
-        // Test that if the vote account does not have sufficient lamports to realloc,
-        // the old vote state is written out
+        // Now top-up the vote account's lamports to be rent exempt for the target version.
+        let space = match target_version {
+            VoteStateTargetVersion::V3 => VoteStateV3::size_of(),
+            VoteStateTargetVersion::V4 => VoteStateV4::size_of(), // They're the same, but for posterity
+        };
         assert_eq!(
-            VoteStateHandler::new_v3(vote_state.clone())
+            borrowed_account.set_lamports(rent.minimum_balance(space)),
+            Ok(())
+        );
+        assert_eq!(
+            vote_state
+                .clone()
                 .set_vote_account_state(&mut borrowed_account),
             Ok(())
         );
+
+        // The vote state version should match the target version.
         let vote_state_version = borrowed_account.get_state::<VoteStateVersions>().unwrap();
-        assert_matches!(vote_state_version, VoteStateVersions::V1_14_11(_));
+        match target_version {
+            VoteStateTargetVersion::V3 => {
+                assert_matches!(vote_state_version, VoteStateVersions::V3(_));
+            }
+            VoteStateTargetVersion::V4 => {
+                assert_matches!(vote_state_version, VoteStateVersions::V4(_));
+            }
+        }
 
         // Convert the vote state to current as would occur during vote instructions
-        let converted_vote_state = VoteStateV3::deserialize(borrowed_account.get_data()).unwrap();
-
-        // Check to make sure that the vote_state is unchanged
-        assert_eq!(vote_state, converted_vote_state);
-
-        let vote_state = converted_vote_state;
-
-        // Test that when the feature is enabled, if the vote account does have sufficient lamports, the
-        // new vote state is written out
-        assert_eq!(
-            borrowed_account.set_lamports(rent.minimum_balance(VoteStateV3::size_of())),
-            Ok(())
-        );
-        assert_eq!(
-            VoteStateHandler::new_v3(vote_state.clone())
-                .set_vote_account_state(&mut borrowed_account),
-            Ok(())
-        );
-        let vote_state_version = borrowed_account.get_state::<VoteStateVersions>().unwrap();
-        assert_matches!(vote_state_version, VoteStateVersions::V3(_));
-
-        // Convert the vote state to current as would occur during vote instructions
-        let converted_vote_state = VoteStateV3::deserialize(borrowed_account.get_data()).unwrap();
+        let converted_vote_state =
+            VoteStateHandler::deserialize_and_convert(&borrowed_account, target_version).unwrap();
 
         // Check to make sure that the vote_state is unchanged
         assert_eq!(vote_state, converted_vote_state);
     }
 
-    #[test]
-    fn test_vote_lockout() {
-        let (_vote_pubkey, vote_account) = create_test_account();
-
-        let vote_state_v3 = VoteStateV3::deserialize(vote_account.borrow().data()).unwrap();
-        let mut vote_state = VoteStateHandler::new_v3(vote_state_v3);
+    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
+    #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
+    fn test_vote_lockout(target_version: VoteStateTargetVersion) {
+        let mut vote_state = vote_state_new_for_test(&solana_pubkey::new_rand(), target_version);
 
         for i in 0..(MAX_LOCKOUT_HISTORY + 1) {
             process_slot_vote_unchecked(&mut vote_state, (INITIAL_LOCKOUT * i) as u64);
@@ -1322,23 +1325,17 @@ mod tests {
         assert_eq!(vote_state.votes().len(), 2);
     }
 
-    #[test]
-    fn test_update_commission() {
-        let node_pubkey = Pubkey::new_unique();
-        let withdrawer_pubkey = Pubkey::new_unique();
-        let clock = Clock::default();
-        let vote_state = VoteStateV3::new(
-            &VoteInit {
-                node_pubkey,
-                authorized_voter: withdrawer_pubkey,
-                authorized_withdrawer: withdrawer_pubkey,
-                commission: 10,
-            },
-            &clock,
-        );
+    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
+    #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
+    fn test_update_commission(target_version: VoteStateTargetVersion) {
+        let mut vote_state = vote_state_new_for_test(&solana_pubkey::new_rand(), target_version);
+        let node_pubkey = *vote_state.node_pubkey();
+        let withdrawer_pubkey = *vote_state.authorized_withdrawer();
 
-        let serialized =
-            bincode::serialize(&VoteStateVersions::V3(Box::new(vote_state.clone()))).unwrap();
+        // Set commission to start.
+        vote_state.set_commission(10);
+
+        let serialized = vote_state.serialize();
         let serialized_len = serialized.len();
         let rent = Rent::default();
         let lamports = rent.minimum_balance(serialized_len);
@@ -1385,14 +1382,15 @@ mod tests {
 
         // Increase commission in first half of epoch -- allowed
         assert_eq!(
-            VoteStateV3::deserialize(borrowed_account.get_data())
+            VoteStateHandler::deserialize_and_convert(&borrowed_account, target_version)
                 .unwrap()
-                .commission,
+                .commission(),
             10
         );
         assert_matches!(
             update_commission(
                 &mut borrowed_account,
+                target_version,
                 11,
                 &signers,
                 &epoch_schedule,
@@ -1401,9 +1399,9 @@ mod tests {
             Ok(())
         );
         assert_eq!(
-            VoteStateV3::deserialize(borrowed_account.get_data())
+            VoteStateHandler::deserialize_and_convert(&borrowed_account, target_version)
                 .unwrap()
-                .commission,
+                .commission(),
             11
         );
 
@@ -1411,6 +1409,7 @@ mod tests {
         assert_matches!(
             update_commission(
                 &mut borrowed_account,
+                target_version,
                 12,
                 &signers,
                 &epoch_schedule,
@@ -1419,9 +1418,9 @@ mod tests {
             Err(_)
         );
         assert_eq!(
-            VoteStateV3::deserialize(borrowed_account.get_data())
+            VoteStateHandler::deserialize_and_convert(&borrowed_account, target_version)
                 .unwrap()
-                .commission,
+                .commission(),
             11
         );
 
@@ -1429,6 +1428,7 @@ mod tests {
         assert_matches!(
             update_commission(
                 &mut borrowed_account,
+                target_version,
                 10,
                 &signers,
                 &epoch_schedule,
@@ -1437,22 +1437,23 @@ mod tests {
             Ok(())
         );
         assert_eq!(
-            VoteStateV3::deserialize(borrowed_account.get_data())
+            VoteStateHandler::deserialize_and_convert(&borrowed_account, target_version)
                 .unwrap()
-                .commission,
+                .commission(),
             10
         );
 
         assert_eq!(
-            VoteStateV3::deserialize(borrowed_account.get_data())
+            VoteStateHandler::deserialize_and_convert(&borrowed_account, target_version)
                 .unwrap()
-                .commission,
+                .commission(),
             10
         );
 
         assert_matches!(
             update_commission(
                 &mut borrowed_account,
+                target_version,
                 9,
                 &signers,
                 &epoch_schedule,
@@ -1461,17 +1462,17 @@ mod tests {
             Ok(())
         );
         assert_eq!(
-            VoteStateV3::deserialize(borrowed_account.get_data())
+            VoteStateHandler::deserialize_and_convert(&borrowed_account, target_version)
                 .unwrap()
-                .commission,
+                .commission(),
             9
         );
     }
 
-    #[test]
-    fn test_vote_double_lockout_after_expiration() {
-        let voter_pubkey = solana_pubkey::new_rand();
-        let mut vote_state = vote_state_new_for_test(&voter_pubkey);
+    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
+    #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
+    fn test_vote_double_lockout_after_expiration(target_version: VoteStateTargetVersion) {
+        let mut vote_state = vote_state_new_for_test(&solana_pubkey::new_rand(), target_version);
 
         for i in 0..3 {
             process_slot_vote_unchecked(&mut vote_state, i as u64);
@@ -1496,10 +1497,10 @@ mod tests {
         check_lockouts(&vote_state);
     }
 
-    #[test]
-    fn test_expire_multiple_votes() {
-        let voter_pubkey = solana_pubkey::new_rand();
-        let mut vote_state = vote_state_new_for_test(&voter_pubkey);
+    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
+    #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
+    fn test_expire_multiple_votes(target_version: VoteStateTargetVersion) {
+        let mut vote_state = vote_state_new_for_test(&solana_pubkey::new_rand(), target_version);
 
         for i in 0..3 {
             process_slot_vote_unchecked(&mut vote_state, i as u64);
@@ -1528,10 +1529,10 @@ mod tests {
         assert_eq!(vote_state.votes()[2].confirmation_count(), 1);
     }
 
-    #[test]
-    fn test_vote_credits() {
-        let voter_pubkey = solana_pubkey::new_rand();
-        let mut vote_state = vote_state_new_for_test(&voter_pubkey);
+    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
+    #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
+    fn test_vote_credits(target_version: VoteStateTargetVersion) {
+        let mut vote_state = vote_state_new_for_test(&solana_pubkey::new_rand(), target_version);
 
         for i in 0..MAX_LOCKOUT_HISTORY {
             process_slot_vote_unchecked(&mut vote_state, i as u64);
@@ -1547,10 +1548,10 @@ mod tests {
         assert_eq!(vote_state.credits(), 3);
     }
 
-    #[test]
-    fn test_duplicate_vote() {
-        let voter_pubkey = solana_pubkey::new_rand();
-        let mut vote_state = vote_state_new_for_test(&voter_pubkey);
+    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
+    #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
+    fn test_duplicate_vote(target_version: VoteStateTargetVersion) {
+        let mut vote_state = vote_state_new_for_test(&solana_pubkey::new_rand(), target_version);
         process_slot_vote_unchecked(&mut vote_state, 0);
         process_slot_vote_unchecked(&mut vote_state, 1);
         process_slot_vote_unchecked(&mut vote_state, 0);
@@ -1559,10 +1560,10 @@ mod tests {
         assert!(vote_state.nth_recent_lockout(2).is_none());
     }
 
-    #[test]
-    fn test_nth_recent_lockout() {
-        let voter_pubkey = solana_pubkey::new_rand();
-        let mut vote_state = vote_state_new_for_test(&voter_pubkey);
+    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
+    #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
+    fn test_nth_recent_lockout(target_version: VoteStateTargetVersion) {
+        let mut vote_state = vote_state_new_for_test(&solana_pubkey::new_rand(), target_version);
         for i in 0..MAX_LOCKOUT_HISTORY {
             process_slot_vote_unchecked(&mut vote_state, i as u64);
         }
@@ -1598,12 +1599,11 @@ mod tests {
     }
 
     /// check that two accounts with different data can be brought to the same state with one vote submission
-    #[test]
-    fn test_process_missed_votes() {
-        let account_a = solana_pubkey::new_rand();
-        let mut vote_state_a = vote_state_new_for_test(&account_a);
-        let account_b = solana_pubkey::new_rand();
-        let mut vote_state_b = vote_state_new_for_test(&account_b);
+    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
+    #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
+    fn test_process_missed_votes(target_version: VoteStateTargetVersion) {
+        let mut vote_state_a = vote_state_new_for_test(&solana_pubkey::new_rand(), target_version);
+        let mut vote_state_b = vote_state_new_for_test(&solana_pubkey::new_rand(), target_version);
 
         // process some votes on account a
         (0..5).for_each(|i| process_slot_vote_unchecked(&mut vote_state_a, i as u64));
@@ -1625,10 +1625,9 @@ mod tests {
         assert_eq!(recent_votes(&vote_state_a), recent_votes(&vote_state_b));
     }
 
-    #[test]
-    fn test_process_vote_skips_old_vote() {
-        let mut vote_state = VoteStateHandler::default_v3();
-
+    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
+    #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
+    fn test_process_vote_skips_old_vote(mut vote_state: VoteStateHandler) {
         let vote = Vote::new(vec![0], Hash::default());
         let slot_hashes: Vec<_> = vec![(0, vote.hash)];
         assert_eq!(
@@ -1643,10 +1642,9 @@ mod tests {
         assert_eq!(recent, recent_votes(&vote_state));
     }
 
-    #[test]
-    fn test_check_slots_are_valid_vote_empty_slot_hashes() {
-        let vote_state = VoteStateHandler::default_v3();
-
+    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
+    #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
+    fn test_check_slots_are_valid_vote_empty_slot_hashes(vote_state: VoteStateHandler) {
         let vote = Vote::new(vec![0], Hash::default());
         assert_eq!(
             check_slots_are_valid(&vote_state, &vote.slots, &vote.hash, &[]),
@@ -1654,10 +1652,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_check_slots_are_valid_new_vote() {
-        let vote_state = VoteStateHandler::default_v3();
-
+    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
+    #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
+    fn test_check_slots_are_valid_new_vote(vote_state: VoteStateHandler) {
         let vote = Vote::new(vec![0], Hash::default());
         let slot_hashes: Vec<_> = vec![(*vote.slots.last().unwrap(), vote.hash)];
         assert_eq!(
@@ -1666,10 +1663,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_check_slots_are_valid_bad_hash() {
-        let vote_state = VoteStateHandler::default_v3();
-
+    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
+    #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
+    fn test_check_slots_are_valid_bad_hash(vote_state: VoteStateHandler) {
         let vote = Vote::new(vec![0], Hash::default());
         let slot_hashes: Vec<_> = vec![(*vote.slots.last().unwrap(), hash(vote.hash.as_ref()))];
         assert_eq!(
@@ -1678,10 +1674,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_check_slots_are_valid_bad_slot() {
-        let vote_state = VoteStateHandler::default_v3();
-
+    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
+    #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
+    fn test_check_slots_are_valid_bad_slot(vote_state: VoteStateHandler) {
         let vote = Vote::new(vec![1], Hash::default());
         let slot_hashes: Vec<_> = vec![(0, vote.hash)];
         assert_eq!(
@@ -1690,10 +1685,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_check_slots_are_valid_duplicate_vote() {
-        let mut vote_state = VoteStateHandler::default_v3();
-
+    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
+    #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
+    fn test_check_slots_are_valid_duplicate_vote(mut vote_state: VoteStateHandler) {
         let vote = Vote::new(vec![0], Hash::default());
         let slot_hashes: Vec<_> = vec![(*vote.slots.last().unwrap(), vote.hash)];
         assert_eq!(
@@ -1706,10 +1700,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_check_slots_are_valid_next_vote() {
-        let mut vote_state = VoteStateHandler::default_v3();
-
+    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
+    #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
+    fn test_check_slots_are_valid_next_vote(mut vote_state: VoteStateHandler) {
         let vote = Vote::new(vec![0], Hash::default());
         let slot_hashes: Vec<_> = vec![(*vote.slots.last().unwrap(), vote.hash)];
         assert_eq!(
@@ -1725,10 +1718,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_check_slots_are_valid_next_vote_only() {
-        let mut vote_state = VoteStateHandler::default_v3();
-
+    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
+    #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
+    fn test_check_slots_are_valid_next_vote_only(mut vote_state: VoteStateHandler) {
         let vote = Vote::new(vec![0], Hash::default());
         let slot_hashes: Vec<_> = vec![(*vote.slots.last().unwrap(), vote.hash)];
         assert_eq!(
@@ -1743,10 +1735,10 @@ mod tests {
             Ok(())
         );
     }
-    #[test]
-    fn test_process_vote_empty_slots() {
-        let mut vote_state = VoteStateHandler::default_v3();
 
+    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
+    #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
+    fn test_process_vote_empty_slots(mut vote_state: VoteStateHandler) {
         let vote = Vote::new(vec![], Hash::default());
         assert_eq!(
             process_vote(&mut vote_state, &vote, &[], 0, 0),
@@ -1772,12 +1764,9 @@ mod tests {
     }
 
     // Test vote credit updates after "one credit per slot" feature is enabled
-    #[test]
-    fn test_vote_state_update_increment_credits() {
-        // Create a new VoteStateV3 handler
-        let mut vote_state =
-            VoteStateHandler::new_v3(VoteStateV3::new(&VoteInit::default(), &Clock::default()));
-
+    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
+    #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
+    fn test_vote_state_update_increment_credits(mut vote_state: VoteStateHandler) {
         // Test data: a sequence of groups of votes to simulate having been cast, after each group a vote
         // state update is compared to "normal" vote processing to ensure that credits are earned equally
         let test_vote_groups: Vec<Vec<Slot>> = vec![
@@ -1852,8 +1841,9 @@ mod tests {
     }
 
     // Test vote credit updates after "timely vote credits" feature is enabled
-    #[test]
-    fn test_timely_credits() {
+    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
+    #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
+    fn test_timely_credits(target_version: VoteStateTargetVersion) {
         // Each of the following (Vec<Slot>, Slot, u32) tuples gives a set of slots to cast votes on, a slot in which
         // the vote was cast, and the number of credits that should have been earned by the vote account after this
         // and all prior votes were cast.
@@ -2018,15 +2008,18 @@ mod tests {
             ),
         ];
 
+        let new_vote_state = || match target_version {
+            VoteStateTargetVersion::V3 => VoteStateHandler::default_v3(),
+            VoteStateTargetVersion::V4 => VoteStateHandler::default_v4(),
+        };
+
         // For each vote group, process all vote groups leading up to it and it itself, and ensure that the number of
         // credits earned is correct for both regular votes and vote state updates
         for i in 0..test_vote_groups.len() {
             // Create a new VoteStateV3 for vote transaction
-            let mut vote_state_1 =
-                VoteStateHandler::new_v3(VoteStateV3::new(&VoteInit::default(), &Clock::default()));
+            let mut vote_state_1 = new_vote_state();
             // Create a new VoteStateV3 for vote state update transaction
-            let mut vote_state_2 =
-                VoteStateHandler::new_v3(VoteStateV3::new(&VoteInit::default(), &Clock::default()));
+            let mut vote_state_2 = new_vote_state();
             test_vote_groups.iter().take(i + 1).for_each(|vote_group| {
                 let vote = Vote {
                     slots: vote_group.0.clone(), //vote_group.0 is the set of slots to cast votes on
@@ -2066,8 +2059,9 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_retroactive_voting_timely_credits() {
+    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
+    #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
+    fn test_retroactive_voting_timely_credits(mut vote_state: VoteStateHandler) {
         // Each of the following (Vec<(Slot, int)>, Slot, Option<Slot>, u32) tuples gives the following data:
         // Vec<(Slot, int)> -- the set of slots and confirmation_counts that is the proposed vote state
         // Slot -- the slot in which the proposed vote state landed
@@ -2148,10 +2142,6 @@ mod tests {
             ),
         ];
 
-        // Initial vote state
-        let mut vote_state =
-            VoteStateHandler::new_v3(VoteStateV3::new(&VoteInit::default(), &Clock::default()));
-
         // Process the vote state updates in sequence and ensure that the credits earned after each is processed is
         // correct
         test_vote_state_updates
@@ -2182,9 +2172,9 @@ mod tests {
             });
     }
 
-    #[test]
-    fn test_process_new_vote_too_many_votes() {
-        let mut vote_state1 = VoteStateHandler::default_v3();
+    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
+    #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
+    fn test_process_new_vote_too_many_votes(mut vote_state1: VoteStateHandler) {
         let bad_votes: VecDeque<Lockout> = (0..=MAX_LOCKOUT_HISTORY)
             .map(|slot| {
                 Lockout::new_with_confirmation_count(
@@ -2207,9 +2197,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_process_new_vote_state_root_rollback() {
-        let mut vote_state1 = VoteStateHandler::default_v3();
+    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
+    #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
+    fn test_process_new_vote_state_root_rollback(mut vote_state1: VoteStateHandler) {
         for i in 0..MAX_LOCKOUT_HISTORY + 2 {
             process_slot_vote_unchecked(&mut vote_state1, i as Slot);
         }
@@ -2251,9 +2241,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_process_new_vote_state_zero_confirmations() {
-        let mut vote_state1 = VoteStateHandler::default_v3();
+    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
+    #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
+    fn test_process_new_vote_state_zero_confirmations(mut vote_state1: VoteStateHandler) {
         let current_epoch = vote_state1.current_epoch();
 
         let bad_votes: VecDeque<Lockout> = vec![
@@ -2291,9 +2281,10 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_process_new_vote_state_confirmations_too_large() {
-        let mut vote_state1 = VoteStateHandler::default_v3();
+    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
+    #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
+    fn test_process_new_vote_state_confirmations_too_large(initial_vote_state: VoteStateHandler) {
+        let mut vote_state1 = initial_vote_state.clone();
         let current_epoch = vote_state1.current_epoch();
 
         let good_votes: VecDeque<Lockout> = vec![Lockout::new_with_confirmation_count(
@@ -2312,7 +2303,7 @@ mod tests {
         )
         .unwrap();
 
-        let mut vote_state1 = VoteStateHandler::default_v3();
+        let mut vote_state1 = initial_vote_state;
         let bad_votes: VecDeque<Lockout> = vec![Lockout::new_with_confirmation_count(
             0,
             MAX_LOCKOUT_HISTORY as u32 + 1,
@@ -2331,9 +2322,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_process_new_vote_state_slot_smaller_than_root() {
-        let mut vote_state1 = VoteStateHandler::default_v3();
+    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
+    #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
+    fn test_process_new_vote_state_slot_smaller_than_root(mut vote_state1: VoteStateHandler) {
         let current_epoch = vote_state1.current_epoch();
         let root_slot = 5;
 
@@ -2372,9 +2363,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_process_new_vote_state_slots_not_ordered() {
-        let mut vote_state1 = VoteStateHandler::default_v3();
+    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
+    #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
+    fn test_process_new_vote_state_slots_not_ordered(mut vote_state1: VoteStateHandler) {
         let current_epoch = vote_state1.current_epoch();
 
         let bad_votes: VecDeque<Lockout> = vec![
@@ -2412,9 +2403,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_process_new_vote_state_confirmations_not_ordered() {
-        let mut vote_state1 = VoteStateHandler::default_v3();
+    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
+    #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
+    fn test_process_new_vote_state_confirmations_not_ordered(mut vote_state1: VoteStateHandler) {
         let current_epoch = vote_state1.current_epoch();
 
         let bad_votes: VecDeque<Lockout> = vec![
@@ -2452,9 +2443,11 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_process_new_vote_state_new_vote_state_lockout_mismatch() {
-        let mut vote_state1 = VoteStateHandler::default_v3();
+    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
+    #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
+    fn test_process_new_vote_state_new_vote_state_lockout_mismatch(
+        mut vote_state1: VoteStateHandler,
+    ) {
         let current_epoch = vote_state1.current_epoch();
 
         let bad_votes: VecDeque<Lockout> = vec![
@@ -2477,9 +2470,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_process_new_vote_state_confirmation_rollback() {
-        let mut vote_state1 = VoteStateHandler::default_v3();
+    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
+    #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
+    fn test_process_new_vote_state_confirmation_rollback(mut vote_state1: VoteStateHandler) {
         let current_epoch = vote_state1.current_epoch();
         let votes: VecDeque<Lockout> = vec![
             Lockout::new_with_confirmation_count(0, 4),
@@ -2512,9 +2505,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_process_new_vote_state_root_progress() {
-        let mut vote_state1 = VoteStateHandler::default_v3();
+    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
+    #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
+    fn test_process_new_vote_state_root_progress(mut vote_state1: VoteStateHandler) {
         for i in 0..MAX_LOCKOUT_HISTORY {
             process_slot_vote_unchecked(&mut vote_state1, i as u64);
         }
@@ -2546,8 +2539,11 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_process_new_vote_state_same_slot_but_not_common_ancestor() {
+    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
+    #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
+    fn test_process_new_vote_state_same_slot_but_not_common_ancestor(
+        initial_vote_state: VoteStateHandler,
+    ) {
         // It might be possible that during the switch from old vote instructions
         // to new vote instructions, new_state contains votes for slots LESS
         // than the current state, for instance:
@@ -2566,7 +2562,7 @@ mod tests {
         // will immediately pop off 2.
 
         // Construct on-chain vote state
-        let mut vote_state1 = VoteStateHandler::default_v3();
+        let mut vote_state1 = initial_vote_state.clone();
         process_slot_votes_unchecked(&mut vote_state1, &[1, 2, 5]);
         assert_eq!(
             vote_state1
@@ -2578,7 +2574,7 @@ mod tests {
         );
 
         // Construct local tower state
-        let mut vote_state2 = VoteStateHandler::default_v3();
+        let mut vote_state2 = initial_vote_state;
         process_slot_votes_unchecked(&mut vote_state2, &[1, 2, 3, 5, 7]);
         assert_eq!(
             vote_state2
@@ -2603,10 +2599,11 @@ mod tests {
         assert_eq!(vote_state1, vote_state2);
     }
 
-    #[test]
-    fn test_process_new_vote_state_lockout_violation() {
+    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
+    #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
+    fn test_process_new_vote_state_lockout_violation(initial_vote_state: VoteStateHandler) {
         // Construct on-chain vote state
-        let mut vote_state1 = VoteStateHandler::default_v3();
+        let mut vote_state1 = initial_vote_state.clone();
         process_slot_votes_unchecked(&mut vote_state1, &[1, 2, 4, 5]);
         assert_eq!(
             vote_state1
@@ -2619,7 +2616,7 @@ mod tests {
 
         // Construct conflicting tower state. Vote 4 is missing,
         // but 5 should not have popped off vote 4.
-        let mut vote_state2 = VoteStateHandler::default_v3();
+        let mut vote_state2 = initial_vote_state;
         process_slot_votes_unchecked(&mut vote_state2, &[1, 2, 3, 5, 7]);
         assert_eq!(
             vote_state2
@@ -2644,10 +2641,11 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_process_new_vote_state_lockout_violation2() {
+    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
+    #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
+    fn test_process_new_vote_state_lockout_violation2(initial_vote_state: VoteStateHandler) {
         // Construct on-chain vote state
-        let mut vote_state1 = VoteStateHandler::default_v3();
+        let mut vote_state1 = initial_vote_state.clone();
         process_slot_votes_unchecked(&mut vote_state1, &[1, 2, 5, 6, 7]);
         assert_eq!(
             vote_state1
@@ -2660,7 +2658,7 @@ mod tests {
 
         // Construct a new vote state. Violates on-chain state because 8
         // should not have popped off 7
-        let mut vote_state2 = VoteStateHandler::default_v3();
+        let mut vote_state2 = initial_vote_state;
         process_slot_votes_unchecked(&mut vote_state2, &[1, 2, 3, 5, 6, 8]);
         assert_eq!(
             vote_state2
@@ -2686,10 +2684,10 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_process_new_vote_state_expired_ancestor_not_removed() {
+    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
+    #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
+    fn test_process_new_vote_state_expired_ancestor_not_removed(mut vote_state1: VoteStateHandler) {
         // Construct on-chain vote state
-        let mut vote_state1 = VoteStateHandler::default_v3();
         process_slot_votes_unchecked(&mut vote_state1, &[1, 2, 3, 9]);
         assert_eq!(
             vote_state1
@@ -2731,9 +2729,11 @@ mod tests {
         assert_eq!(vote_state1, vote_state2,);
     }
 
-    #[test]
-    fn test_process_new_vote_current_state_contains_bigger_slots() {
-        let mut vote_state1 = VoteStateHandler::default_v3();
+    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
+    #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
+    fn test_process_new_vote_current_state_contains_bigger_slots(
+        mut vote_state1: VoteStateHandler,
+    ) {
         process_slot_votes_unchecked(&mut vote_state1, &[6, 7, 8]);
         assert_eq!(
             vote_state1
@@ -2786,9 +2786,9 @@ mod tests {
         assert_eq!(*vote_state1.votes(), good_votes);
     }
 
-    #[test]
-    fn test_filter_old_votes() {
-        let mut vote_state = VoteStateHandler::default_v3();
+    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
+    #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
+    fn test_filter_old_votes(mut vote_state: VoteStateHandler) {
         let old_vote_slot = 1;
         let vote = Vote::new(vec![old_vote_slot], Hash::default());
 
@@ -2829,8 +2829,15 @@ mod tests {
             .collect()
     }
 
-    fn build_vote_state(vote_slots: Vec<Slot>, slot_hashes: &[(Slot, Hash)]) -> VoteStateHandler {
-        let mut vote_state = VoteStateHandler::default_v3();
+    fn build_vote_state(
+        target_version: VoteStateTargetVersion,
+        vote_slots: Vec<Slot>,
+        slot_hashes: &[(Slot, Hash)],
+    ) -> VoteStateHandler {
+        let mut vote_state = match target_version {
+            VoteStateTargetVersion::V3 => VoteStateHandler::default_v3(),
+            VoteStateTargetVersion::V4 => VoteStateHandler::default_v4(),
+        };
 
         if !vote_slots.is_empty() {
             let vote_hash = slot_hashes
@@ -2846,10 +2853,11 @@ mod tests {
         vote_state
     }
 
-    #[test]
-    fn test_check_and_filter_proposed_vote_state_empty() {
+    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
+    #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
+    fn test_check_and_filter_proposed_vote_state_empty(target_version: VoteStateTargetVersion) {
         let empty_slot_hashes = build_slot_hashes(vec![]);
-        let empty_vote_state = build_vote_state(vec![], &empty_slot_hashes);
+        let empty_vote_state = build_vote_state(target_version, vec![], &empty_slot_hashes);
 
         // Test with empty TowerSync, should return EmptySlots error
         let mut tower_sync = TowerSync::from(vec![]);
@@ -2878,11 +2886,12 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_check_and_filter_proposed_vote_state_too_old() {
+    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
+    #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
+    fn test_check_and_filter_proposed_vote_state_too_old(target_version: VoteStateTargetVersion) {
         let slot_hashes = build_slot_hashes(vec![1, 2, 3, 4]);
         let latest_vote = 4;
-        let vote_state = build_vote_state(vec![1, 2, 3, latest_vote], &slot_hashes);
+        let vote_state = build_vote_state(target_version, vec![1, 2, 3, latest_vote], &slot_hashes);
 
         // Test with a vote for a slot less than the latest vote in the vote_state,
         // should return error `VoteTooOld`
@@ -2917,6 +2926,7 @@ mod tests {
     }
 
     fn run_test_check_and_filter_proposed_vote_state_older_than_history_root(
+        target_version: VoteStateTargetVersion,
         earliest_slot_in_history: Slot,
         current_vote_state_slots: Vec<Slot>,
         current_vote_state_root: Option<Slot>,
@@ -2944,7 +2954,8 @@ mod tests {
                 .collect::<Vec<Slot>>(),
         );
 
-        let mut vote_state = build_vote_state(current_vote_state_slots, &slot_hashes);
+        let mut vote_state =
+            build_vote_state(target_version, current_vote_state_slots, &slot_hashes);
         vote_state.set_root_slot(current_vote_state_root);
 
         slot_hashes.retain(|slot| slot.0 >= earliest_slot_in_history);
@@ -2987,8 +2998,11 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_check_and_filter_proposed_vote_state_older_than_history_root() {
+    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
+    #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
+    fn test_check_and_filter_proposed_vote_state_older_than_history_root(
+        target_version: VoteStateTargetVersion,
+    ) {
         // Test when `proposed_root` is in `current_vote_state_slots` but it's not the latest
         // slot
         let earliest_slot_in_history = 5;
@@ -2999,6 +3013,7 @@ mod tests {
         let expected_root = Some(4);
         let expected_vote_state = vec![Lockout::new_with_confirmation_count(5, 1)];
         run_test_check_and_filter_proposed_vote_state_older_than_history_root(
+            target_version,
             earliest_slot_in_history,
             current_vote_state_slots,
             current_vote_state_root,
@@ -3018,6 +3033,7 @@ mod tests {
         let expected_root = Some(4);
         let expected_vote_state = vec![Lockout::new_with_confirmation_count(5, 1)];
         run_test_check_and_filter_proposed_vote_state_older_than_history_root(
+            target_version,
             earliest_slot_in_history,
             current_vote_state_slots,
             current_vote_state_root,
@@ -3040,6 +3056,7 @@ mod tests {
             Lockout::new_with_confirmation_count(5, 1),
         ];
         run_test_check_and_filter_proposed_vote_state_older_than_history_root(
+            target_version,
             earliest_slot_in_history,
             current_vote_state_slots,
             current_vote_state_root,
@@ -3061,6 +3078,7 @@ mod tests {
             Lockout::new_with_confirmation_count(5, 1),
         ];
         run_test_check_and_filter_proposed_vote_state_older_than_history_root(
+            target_version,
             earliest_slot_in_history,
             current_vote_state_slots,
             current_vote_state_root,
@@ -3084,6 +3102,7 @@ mod tests {
             Lockout::new_with_confirmation_count(5, 1),
         ];
         run_test_check_and_filter_proposed_vote_state_older_than_history_root(
+            target_version,
             earliest_slot_in_history,
             current_vote_state_slots,
             current_vote_state_root,
@@ -3102,6 +3121,7 @@ mod tests {
         let expected_root = None;
         let expected_vote_state = vec![Lockout::new_with_confirmation_count(5, 1)];
         run_test_check_and_filter_proposed_vote_state_older_than_history_root(
+            target_version,
             earliest_slot_in_history,
             current_vote_state_slots,
             current_vote_state_root,
@@ -3112,10 +3132,13 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_check_and_filter_proposed_vote_state_slots_not_ordered() {
+    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
+    #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
+    fn test_check_and_filter_proposed_vote_state_slots_not_ordered(
+        target_version: VoteStateTargetVersion,
+    ) {
         let slot_hashes = build_slot_hashes(vec![1, 2, 3, 4]);
-        let vote_state = build_vote_state(vec![1], &slot_hashes);
+        let vote_state = build_vote_state(target_version, vec![1], &slot_hashes);
 
         // Test with a `TowerSync` where the slots are out of order
         let vote_slot = 3;
@@ -3152,10 +3175,13 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_check_and_filter_proposed_vote_state_older_than_history_slots_filtered() {
+    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
+    #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
+    fn test_check_and_filter_proposed_vote_state_older_than_history_slots_filtered(
+        target_version: VoteStateTargetVersion,
+    ) {
         let slot_hashes = build_slot_hashes(vec![1, 2, 3, 4]);
-        let mut vote_state = build_vote_state(vec![1, 2, 3, 4], &slot_hashes);
+        let mut vote_state = build_vote_state(target_version, vec![1, 2, 3, 4], &slot_hashes);
 
         // Test with a `TowerSync` where there:
         // 1) Exists a slot less than `earliest_slot_in_history`
@@ -3200,10 +3226,13 @@ mod tests {
         assert!(do_process_tower_sync(&mut vote_state, &slot_hashes, 0, 0, tower_sync,).is_ok());
     }
 
-    #[test]
-    fn test_check_and_filter_proposed_vote_state_older_than_history_slots_not_filtered() {
+    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
+    #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
+    fn test_check_and_filter_proposed_vote_state_older_than_history_slots_not_filtered(
+        target_version: VoteStateTargetVersion,
+    ) {
         let slot_hashes = build_slot_hashes(vec![4]);
-        let mut vote_state = build_vote_state(vec![4], &slot_hashes);
+        let mut vote_state = build_vote_state(target_version, vec![4], &slot_hashes);
 
         // Test with a `TowerSync` where there:
         // 1) Exists a slot less than `earliest_slot_in_history`
@@ -3245,11 +3274,13 @@ mod tests {
         assert!(do_process_tower_sync(&mut vote_state, &slot_hashes, 0, 0, tower_sync,).is_ok());
     }
 
-    #[test]
+    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
+    #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
     fn test_check_and_filter_proposed_vote_state_older_than_history_slots_filtered_and_not_filtered(
+        target_version: VoteStateTargetVersion,
     ) {
         let slot_hashes = build_slot_hashes(vec![6]);
-        let mut vote_state = build_vote_state(vec![6], &slot_hashes);
+        let mut vote_state = build_vote_state(target_version, vec![6], &slot_hashes);
 
         // Test with a `TowerSync` where there exists both a slot:
         // 1) Less than `earliest_slot_in_history`
@@ -3304,10 +3335,13 @@ mod tests {
         assert!(do_process_tower_sync(&mut vote_state, &slot_hashes, 0, 0, tower_sync,).is_ok());
     }
 
-    #[test]
-    fn test_check_and_filter_proposed_vote_state_slot_not_on_fork() {
+    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
+    #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
+    fn test_check_and_filter_proposed_vote_state_slot_not_on_fork(
+        target_version: VoteStateTargetVersion,
+    ) {
         let slot_hashes = build_slot_hashes(vec![2, 4, 6, 8]);
-        let vote_state = build_vote_state(vec![2, 4, 6], &slot_hashes);
+        let vote_state = build_vote_state(target_version, vec![2, 4, 6], &slot_hashes);
 
         // Test with a `TowerSync` where there:
         // 1) Exists a slot not in the slot hashes history
@@ -3359,10 +3393,13 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_check_and_filter_proposed_vote_state_root_on_different_fork() {
+    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
+    #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
+    fn test_check_and_filter_proposed_vote_state_root_on_different_fork(
+        target_version: VoteStateTargetVersion,
+    ) {
         let slot_hashes = build_slot_hashes(vec![2, 4, 6, 8]);
-        let vote_state = build_vote_state(vec![6], &slot_hashes);
+        let vote_state = build_vote_state(target_version, vec![6], &slot_hashes);
 
         // Test with a `TowerSync` where:
         // 1) The root is not present in slot hashes history
@@ -3395,10 +3432,13 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_check_and_filter_proposed_vote_state_slot_newer_than_slot_history() {
+    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
+    #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
+    fn test_check_and_filter_proposed_vote_state_slot_newer_than_slot_history(
+        target_version: VoteStateTargetVersion,
+    ) {
         let slot_hashes = build_slot_hashes(vec![2, 4, 6, 8, 10]);
-        let vote_state = build_vote_state(vec![2, 4, 6], &slot_hashes);
+        let vote_state = build_vote_state(target_version, vec![2, 4, 6], &slot_hashes);
 
         // Test with a `TowerSync` where there:
         // 1) The last slot in the update is a slot not in the slot hashes history
@@ -3421,10 +3461,13 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_check_and_filter_proposed_vote_state_slot_all_slot_hashes_in_update_ok() {
+    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
+    #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
+    fn test_check_and_filter_proposed_vote_state_slot_all_slot_hashes_in_update_ok(
+        target_version: VoteStateTargetVersion,
+    ) {
         let slot_hashes = build_slot_hashes(vec![2, 4, 6, 8]);
-        let mut vote_state = build_vote_state(vec![2, 4, 6], &slot_hashes);
+        let mut vote_state = build_vote_state(target_version, vec![2, 4, 6], &slot_hashes);
 
         // Test with a `TowerSync` where every slot in the history is
         // in the update
@@ -3466,10 +3509,13 @@ mod tests {
         assert!(do_process_tower_sync(&mut vote_state, &slot_hashes, 0, 0, tower_sync,).is_ok());
     }
 
-    #[test]
-    fn test_check_and_filter_proposed_vote_state_slot_some_slot_hashes_in_update_ok() {
+    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
+    #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
+    fn test_check_and_filter_proposed_vote_state_slot_some_slot_hashes_in_update_ok(
+        target_version: VoteStateTargetVersion,
+    ) {
         let slot_hashes = build_slot_hashes(vec![2, 4, 6, 8, 10]);
-        let mut vote_state = build_vote_state(vec![6], &slot_hashes);
+        let mut vote_state = build_vote_state(target_version, vec![6], &slot_hashes);
 
         // Test with a `TowerSync` where only some slots in the history are
         // in the update, and others slots in the history are missing.
@@ -3515,10 +3561,13 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_check_and_filter_proposed_vote_state_slot_hash_mismatch() {
+    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
+    #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
+    fn test_check_and_filter_proposed_vote_state_slot_hash_mismatch(
+        target_version: VoteStateTargetVersion,
+    ) {
         let slot_hashes = build_slot_hashes(vec![2, 4, 6, 8]);
-        let vote_state = build_vote_state(vec![2, 4, 6], &slot_hashes);
+        let vote_state = build_vote_state(target_version, vec![2, 4, 6], &slot_hashes);
 
         // Test with a `TowerSync` where the hash is mismatched
 


### PR DESCRIPTION
Cherry-pick> vote state handler: port over vote-program-specific methods from vote-interface (#8017)

Cherry-pick> vote-program: patch init-deinit v2 size bug from handler (#8077)

Cherry-pick> vote-program: handler: init v4 support (#8120)

Cherry-pick> vote-program: handler: add v4 variant (#8178)

Cherry-pick> vote-program: plumb `target_version` through the program (#8191)