### PR TITLE
bug: fix for metrics collection

### DIFF
--- a/votor/src/consensus_pool_service/stats.rs
+++ b/votor/src/consensus_pool_service/stats.rs
@@ -72,10 +72,7 @@ impl ConsensusPoolServiceStats {
             ),
             ("received_votes", received_votes, i64),
             ("received_certificates", received_certificates, i64),
-            // This field was earlier reported as `i64` and was then changed to `bool`.
-            // This is causing conflicts in influxdb and causing problems with metrics collection.
-            // TODO: after roughly November 2, 2025 the older data referring to this value as `i64` in influxdb will be dropped and then this field can be renamed back to `standstill`.
-            ("standstill_bool", standstill, bool),
+            ("in_standstill_bool", standstill, bool),
             ("prune_old_state_called", prune_old_state_called, i64),
         );
     }


### PR DESCRIPTION
#### Problem

https://anza-xyz.slack.com/archives/C08D0FL5Q4T/p1760033928310479?thread_ts=1760017436.833329&cid=C08D0FL5Q4T

Originally standstill was reported as an integer and in https://github.com/anza-xyz/alpenglow/pull/501 it was changed to be a boolean.  This causing conflicts in influxdb and causing problems with metrics collection.

#### Summary of Changes

Renames the standstill variable in metrics.  Also adds a comment about when we can rename it back because the original integer data should be dropped due to the retention policy.