### PR TITLE
refactor: bump the `solana-bls-signatures` crate version (#8473)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7312,9 +7312,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bls-signatures"
-version = "0.3.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a40ce56d14f58c3ebe9275c3739c4052748ec5c4922854c12dc823dbf450ebd1"
+checksum = "61c75573697bbb148afa8209aa3ce228ca0754584c9a8a91e818db0f706ae4fb"
 dependencies = [
  "base64 0.22.1",
  "blst",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -392,7 +392,7 @@ solana-big-mod-exp = "3.0.0"
 solana-bincode = "3.0.0"
 solana-blake3-hasher = "3.0.0"
 solana-bloom = { path = "bloom", version = "=3.1.0" }
-solana-bls-signatures = { version = "0.3.0", features = ["serde"] }
+solana-bls-signatures = { version = "1.0.0", features = ["serde"] }
 solana-bls12-381 = { path = "curves/bls12-381", version = "=3.1.0" }
 solana-bn254 = "3.0.0"
 solana-borsh = "3.0.0"

--- a/votor/src/consensus_pool/vote_certificate_builder.rs
+++ b/votor/src/consensus_pool/vote_certificate_builder.rs
@@ -1,7 +1,6 @@
 use {
     crate::common::{certificate_limits_and_vote_types, VoteType},
     bitvec::prelude::*,
-    itertools::Itertools,
     solana_bls_signatures::{BlsError, SignatureProjective},
     solana_signer_store::{encode_base2, encode_base3, DecodeError, EncodeError},
     solana_votor_messages::consensus_message::{Certificate, CertificateMessage, VoteMessage},
@@ -72,11 +71,9 @@ impl VoteCertificateBuilder {
             }
         }
 
-        let signature_iter = messages
-            .iter()
-            .map(|vote_message| &vote_message.signature)
-            .collect_vec();
-        Ok(self.signature.aggregate_with(&signature_iter)?)
+        Ok(self
+            .signature
+            .aggregate_with(messages.iter().map(|m| &m.signature))?)
     }
 
     pub fn build(mut self) -> Result<CertificateMessage, CertificateError> {
@@ -322,9 +319,8 @@ mod tests {
         let certificate_message = builder.build().expect("Failed to build certificate");
 
         // 3. Verification: Aggregate the public keys and verify the signature.
-        let pubkey_refs: Vec<_> = keypairs.iter().map(|kp| &kp.public).collect();
-        let aggregate_pubkey =
-            BLSPubkeyProjective::aggregate(&pubkey_refs).expect("Failed to aggregate public keys");
+        let aggregate_pubkey = BLSPubkeyProjective::aggregate(keypairs.iter().map(|kp| &kp.public))
+            .expect("Failed to aggregate public keys");
 
         let verification_result =
             aggregate_pubkey.verify_signature(&certificate_message.signature, &serialized_vote);
@@ -404,13 +400,10 @@ mod tests {
             }
         }
 
-        let pubkey_refs: Vec<_> = all_pubkeys.iter().collect();
-        let message_refs: Vec<&[u8]> = all_messages.iter().map(|m| m.as_slice()).collect();
-
         SignatureProjective::verify_distinct_aggregated(
-            &pubkey_refs,
+            all_pubkeys.iter(),
             &certificate_message.signature,
-            &message_refs,
+            all_messages.iter().map(Vec::as_slice),
         )
         .unwrap();
     }


### PR DESCRIPTION
We recently did some work on the `solana-bls-signatures` crate to introduce iterators instead of slices.

This PR bumps the `solana-bls-signatures` crate version so we can use iterators.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->

#### Problem


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
