### PR TITLE
nit: move `VoteType` to make it more convenient to use

### DIFF
--- a/votor-messages/src/vote.rs
+++ b/votor-messages/src/vote.rs
@@ -28,6 +28,23 @@ pub enum Vote {
     Genesis(GenesisVote),
 }
 
+/// Enum of different types of [`Vote`]s.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum VoteType {
+    /// Finalize vote.
+    Finalize,
+    /// Notarize vote.
+    Notarize,
+    /// Notarize fallback vote.
+    NotarizeFallback,
+    /// Skip vote
+    Skip,
+    /// Skip fallback vote.
+    SkipFallback,
+    /// Genesis vote.
+    Genesis,
+}
+
 impl Vote {
     /// Create a new notarization vote
     pub fn new_notarization_vote(slot: Slot, block_id: Hash) -> Self {
@@ -114,6 +131,18 @@ impl Vote {
     /// Whether the vote is a notarization or finalization
     pub fn is_notarization_or_finalization(&self) -> bool {
         matches!(self, Self::Notarize(_) | Self::Finalize(_))
+    }
+
+    /// Returns the [`VoteType`] for the vote.
+    pub fn get_type(&self) -> VoteType {
+        match self {
+            Vote::Notarize(_) => VoteType::Notarize,
+            Vote::NotarizeFallback(_) => VoteType::NotarizeFallback,
+            Vote::Skip(_) => VoteType::Skip,
+            Vote::SkipFallback(_) => VoteType::SkipFallback,
+            Vote::Finalize(_) => VoteType::Finalize,
+            Vote::Genesis(_) => VoteType::Genesis,
+        }
     }
 }
 

--- a/votor/src/common.rs
+++ b/votor/src/common.rs
@@ -1,35 +1,14 @@
 use {
     solana_votor_messages::{
-        consensus_message::Certificate, migration::GENESIS_VOTE_THRESHOLD, vote::Vote,
+        consensus_message::Certificate,
+        migration::GENESIS_VOTE_THRESHOLD,
+        vote::{Vote, VoteType},
     },
     std::time::Duration,
 };
 
 // Core consensus types and constants
 pub type Stake = u64;
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum VoteType {
-    Finalize,
-    Notarize,
-    NotarizeFallback,
-    Skip,
-    SkipFallback,
-    Genesis,
-}
-
-impl VoteType {
-    pub fn get_type(vote: &Vote) -> VoteType {
-        match vote {
-            Vote::Notarize(_) => VoteType::Notarize,
-            Vote::NotarizeFallback(_) => VoteType::NotarizeFallback,
-            Vote::Skip(_) => VoteType::Skip,
-            Vote::SkipFallback(_) => VoteType::SkipFallback,
-            Vote::Finalize(_) => VoteType::Finalize,
-            Vote::Genesis(_) => VoteType::Genesis,
-        }
-    }
-}
 
 pub const fn conflicting_types(vote_type: VoteType) -> &'static [VoteType] {
     match vote_type {

--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -3,8 +3,7 @@ use {
         commitment::CommitmentError,
         common::{
             certificate_limits_and_vote_types, conflicting_types, vote_to_certificate_ids, Stake,
-            VoteType, MAX_ENTRIES_PER_PUBKEY_FOR_NOTARIZE_LITE,
-            MAX_ENTRIES_PER_PUBKEY_FOR_OTHER_TYPES,
+            MAX_ENTRIES_PER_PUBKEY_FOR_NOTARIZE_LITE, MAX_ENTRIES_PER_PUBKEY_FOR_OTHER_TYPES,
         },
         consensus_pool::{
             parent_ready_tracker::ParentReadyTracker,
@@ -25,7 +24,7 @@ use {
         consensus_message::{
             Block, Certificate, CertificateMessage, CertificateType, ConsensusMessage, VoteMessage,
         },
-        vote::Vote,
+        vote::{Vote, VoteType},
     },
     std::{
         cmp::Ordering,
@@ -421,7 +420,7 @@ impl ConsensusPool {
             }
             *block_id
         });
-        let vote_type = VoteType::get_type(vote);
+        let vote_type = vote.get_type();
         if let Some(conflicting_type) =
             self.has_conflicting_vote(vote_slot, vote_type, &validator_vote_key, &block_id)
         {

--- a/votor/src/consensus_pool/stats.rs
+++ b/votor/src/consensus_pool/stats.rs
@@ -1,7 +1,6 @@
 use {
-    crate::common::VoteType,
     solana_metrics::datapoint_info,
-    solana_votor_messages::consensus_message::CertificateType,
+    solana_votor_messages::{consensus_message::CertificateType, vote::VoteType},
     std::time::{Duration, Instant},
 };
 

--- a/votor/src/consensus_pool/vote_certificate_builder.rs
+++ b/votor/src/consensus_pool/vote_certificate_builder.rs
@@ -1,5 +1,5 @@
 use {
-    crate::common::{certificate_limits_and_vote_types, VoteType},
+    crate::common::certificate_limits_and_vote_types,
     bitvec::prelude::*,
     solana_bls_signatures::{BlsError, SignatureProjective},
     solana_signer_store::{encode_base2, encode_base3, DecodeError, EncodeError},
@@ -60,7 +60,7 @@ impl VoteCertificateBuilder {
                 return Err(CertificateError::ValidatorDoesNotExist(vote_message.rank));
             }
 
-            let vote_type = VoteType::get_type(&vote_message.vote);
+            let vote_type = vote_message.vote.get_type();
             if vote_type == vote_types[0] {
                 self.bitmap_0.set(rank, true);
             } else {

--- a/votor/src/event_handler/stats.rs
+++ b/votor/src/event_handler/stats.rs
@@ -1,8 +1,8 @@
 use {
-    crate::{common::VoteType, event::VotorEvent, voting_service::BLSOp},
+    crate::{event::VotorEvent, voting_service::BLSOp},
     solana_clock::Slot,
     solana_metrics::datapoint_info,
-    solana_votor_messages::consensus_message::ConsensusMessage,
+    solana_votor_messages::{consensus_message::ConsensusMessage, vote::VoteType},
     std::{
         collections::{BTreeMap, HashMap},
         time::{Duration, Instant},
@@ -188,7 +188,7 @@ impl EventHandlerStats {
                 warn!("Unexpected BLS message type: {message:?}");
                 return;
             };
-            let vote_type = VoteType::get_type(&vote.vote);
+            let vote_type = vote.vote.get_type();
             let entry = self.sent_votes.entry(vote_type).or_insert(0);
             *entry = entry.saturating_add(1);
             if vote_type == VoteType::Notarize {


### PR DESCRIPTION
Moving `VoteType` to same place as `Vote` allows us to call a method of `Vote` to get the type instead of having to use a constructor.