### PR TITLE
refactor: more `vote_pool.rs` cleanups

### DIFF
--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -165,21 +165,21 @@ impl ConsensusPool {
 
     fn update_vote_pool(
         &mut self,
-        msg: VoteMessage,
+        vote: VoteMessage,
         validator_vote_key: Pubkey,
         validator_stake: Stake,
     ) -> Option<Stake> {
-        let vote_type = msg.vote.get_type();
+        let vote_type = vote.vote.get_type();
         let pool = self
             .vote_pools
-            .entry((msg.vote.slot(), vote_type))
+            .entry((vote.vote.slot(), vote_type))
             .or_insert_with(|| Self::new_vote_pool(vote_type));
         match pool {
             VotePool::SimpleVotePool(pool) => {
-                pool.add_vote(validator_vote_key, validator_stake, msg)
+                pool.add_vote(validator_vote_key, validator_stake, vote)
             }
             VotePool::DuplicateBlockVotePool(pool) => {
-                pool.add_vote(validator_vote_key, msg, validator_stake)
+                pool.add_vote(validator_vote_key, validator_stake, vote)
             }
         }
     }
@@ -229,11 +229,11 @@ impl ConsensusPool {
                 if let Some(pool) = self.vote_pools.get(&(slot, *vote_type)) {
                     match pool {
                         VotePool::SimpleVotePool(pool) => {
-                            cert_builder.aggregate(pool.messages()).unwrap();
+                            cert_builder.aggregate(pool.votes()).unwrap();
                         }
                         VotePool::DuplicateBlockVotePool(pool) => {
-                            if let Some(msgs) = pool.messages(block_id.as_ref().unwrap()) {
-                                cert_builder.aggregate(msgs).unwrap();
+                            if let Some(votes) = pool.votes(block_id.as_ref().unwrap()) {
+                                cert_builder.aggregate(votes).unwrap();
                             }
                         }
                     };

--- a/votor/src/consensus_pool/vote_pool.rs
+++ b/votor/src/consensus_pool/vote_pool.rs
@@ -3,7 +3,7 @@ use {
     solana_hash::Hash,
     solana_pubkey::Pubkey,
     solana_votor_messages::consensus_message::VoteMessage,
-    std::collections::{HashMap, HashSet},
+    std::collections::{BTreeMap, BTreeSet},
 };
 
 /// There are two types of vote pools:
@@ -18,9 +18,9 @@ pub(super) enum VotePool {
 
 #[derive(Default)]
 pub(super) struct SimpleVotePool {
-    msgs: Vec<VoteMessage>,
+    votes: Vec<VoteMessage>,
     total_stake: Stake,
-    prev_voted_validators: HashSet<Pubkey>,
+    prev_voted_validators: BTreeSet<Pubkey>,
 }
 
 impl SimpleVotePool {
@@ -28,18 +28,18 @@ impl SimpleVotePool {
         &mut self,
         validator_vote_key: Pubkey,
         validator_stake: Stake,
-        msg: VoteMessage,
+        vote: VoteMessage,
     ) -> Option<Stake> {
         if !self.prev_voted_validators.insert(validator_vote_key) {
             return None;
         }
-        self.msgs.push(msg);
+        self.votes.push(vote);
         self.total_stake = self.total_stake.saturating_add(validator_stake);
         Some(self.total_stake)
     }
 
-    pub(super) fn messages(&self) -> &[VoteMessage] {
-        &self.msgs
+    pub(super) fn votes(&self) -> &[VoteMessage] {
+        &self.votes
     }
 
     pub(super) fn total_stake(&self) -> Stake {
@@ -53,32 +53,32 @@ impl SimpleVotePool {
 
 #[derive(Default)]
 struct VoteEntry {
-    vote_messages: Vec<VoteMessage>,
+    votes: Vec<VoteMessage>,
     total_stake_by_key: Stake,
 }
 
 pub(super) struct DuplicateBlockVotePool {
     max_entries_per_pubkey: usize,
-    votes: HashMap<Hash, VoteEntry>,
-    prev_voted_block_ids: HashMap<Pubkey, HashSet<Hash>>,
+    vote_entries: BTreeMap<Hash, VoteEntry>,
+    prev_voted_block_ids: BTreeMap<Pubkey, BTreeSet<Hash>>,
 }
 
 impl DuplicateBlockVotePool {
     pub(super) fn new(max_entries_per_pubkey: usize) -> Self {
         Self {
             max_entries_per_pubkey,
-            votes: HashMap::new(),
-            prev_voted_block_ids: HashMap::new(),
+            vote_entries: BTreeMap::new(),
+            prev_voted_block_ids: BTreeMap::new(),
         }
     }
 
     pub(super) fn add_vote(
         &mut self,
         validator_vote_key: Pubkey,
-        msg: VoteMessage,
         validator_stake: Stake,
+        vote: VoteMessage,
     ) -> Option<Stake> {
-        let block_id = *msg.vote.block_id().unwrap();
+        let block_id = *vote.vote.block_id().unwrap();
         // Check whether the validator_vote_key already used the same voted_block_id or exceeded max_entries_per_pubkey
         // If so, return false, otherwise add the voted_block_id to the prev_votes
         let prev_voted_block_ids = self
@@ -92,8 +92,8 @@ impl DuplicateBlockVotePool {
         }
         prev_voted_block_ids.insert(block_id);
 
-        let vote_entry = self.votes.entry(block_id).or_default();
-        vote_entry.vote_messages.push(msg);
+        let vote_entry = self.vote_entries.entry(block_id).or_default();
+        vote_entry.votes.push(vote);
         vote_entry.total_stake_by_key = vote_entry
             .total_stake_by_key
             .saturating_add(validator_stake);
@@ -101,15 +101,15 @@ impl DuplicateBlockVotePool {
     }
 
     pub(super) fn total_stake_by_block_id(&self, block_id: &Hash) -> Stake {
-        self.votes
+        self.vote_entries
             .get(block_id)
             .map_or(0, |vote_entries| vote_entries.total_stake_by_key)
     }
 
-    pub(super) fn messages(&self, block_id: &Hash) -> Option<&[VoteMessage]> {
-        self.votes
+    pub(super) fn votes(&self, block_id: &Hash) -> Option<&[VoteMessage]> {
+        self.vote_entries
             .get(block_id)
-            .map(|entry| entry.vote_messages.as_slice())
+            .map(|entry| entry.votes.as_slice())
     }
 
     pub(super) fn has_prev_validator_vote_for_block(
@@ -165,23 +165,23 @@ mod test {
         let my_pubkey = Pubkey::new_unique();
         let block_id = Hash::new_unique();
         let vote = Vote::new_notarization_vote(3, block_id);
-        let vote_message = VoteMessage {
+        let vote = VoteMessage {
             vote,
             signature: BLSSignature::default(),
             rank: 1,
         };
-        assert_eq!(vote_pool.add_vote(my_pubkey, vote_message, 10), Some(10));
+        assert_eq!(vote_pool.add_vote(my_pubkey, 10, vote), Some(10));
         assert_eq!(vote_pool.total_stake_by_block_id(&block_id), 10);
 
         // Adding the same key again should fail
-        assert_eq!(vote_pool.add_vote(my_pubkey, vote_message, 10), None);
+        assert_eq!(vote_pool.add_vote(my_pubkey, 10, vote), None);
 
         // Adding a different bankhash should fail
-        assert_eq!(vote_pool.add_vote(my_pubkey, vote_message, 10), None);
+        assert_eq!(vote_pool.add_vote(my_pubkey, 10, vote), None);
 
         // Adding a different key should succeed
         let new_pubkey = Pubkey::new_unique();
-        assert_eq!(vote_pool.add_vote(new_pubkey, vote_message, 60), Some(70));
+        assert_eq!(vote_pool.add_vote(new_pubkey, 60, vote), Some(70));
         assert_eq!(vote_pool.total_stake_by_block_id(&block_id), 70);
     }
 
@@ -191,7 +191,7 @@ mod test {
         let mut vote_pool = DuplicateBlockVotePool::new(3);
         let my_pubkey = Pubkey::new_unique();
 
-        let msgs = (0..4)
+        let votes = (0..4)
             .map(|_| {
                 let vote = Vote::new_notarization_fallback_vote(7, Hash::new_unique());
                 VoteMessage {
@@ -203,38 +203,38 @@ mod test {
             .collect::<Vec<_>>();
 
         // Adding the first 3 votes should succeed, but total_stake should remain at 10
-        for msg in msgs.iter().take(3).cloned() {
-            assert_eq!(vote_pool.add_vote(my_pubkey, msg, 10), Some(10));
+        for vote in votes.iter().take(3).cloned() {
+            assert_eq!(vote_pool.add_vote(my_pubkey, 10, vote), Some(10));
             assert_eq!(
-                vote_pool.total_stake_by_block_id(msg.vote.block_id().unwrap()),
+                vote_pool.total_stake_by_block_id(vote.vote.block_id().unwrap()),
                 10
             );
         }
         // Adding the 4th vote should fail
-        assert_eq!(vote_pool.add_vote(my_pubkey, msgs[3], 10), None);
+        assert_eq!(vote_pool.add_vote(my_pubkey, 10, votes[3]), None);
         assert_eq!(
-            vote_pool.total_stake_by_block_id(msgs[3].vote.block_id().unwrap()),
+            vote_pool.total_stake_by_block_id(votes[3].vote.block_id().unwrap()),
             0
         );
 
         // Adding a different key should succeed
         let new_pubkey = Pubkey::new_unique();
-        for msg in msgs.iter().skip(1).take(2).cloned() {
-            assert_eq!(vote_pool.add_vote(new_pubkey, msg, 60), Some(70));
+        for vote in votes.iter().skip(1).take(2).cloned() {
+            assert_eq!(vote_pool.add_vote(new_pubkey, 60, vote), Some(70));
             assert_eq!(
-                vote_pool.total_stake_by_block_id(msg.vote.block_id().unwrap()),
+                vote_pool.total_stake_by_block_id(vote.vote.block_id().unwrap()),
                 70
             );
         }
 
         // The new key only added 2 votes, so adding block_ids[3] should succeed
-        assert_eq!(vote_pool.add_vote(new_pubkey, msgs[3], 60), Some(60));
+        assert_eq!(vote_pool.add_vote(new_pubkey, 60, votes[3]), Some(60));
         assert_eq!(
-            vote_pool.total_stake_by_block_id(msgs[3].vote.block_id().unwrap()),
+            vote_pool.total_stake_by_block_id(votes[3].vote.block_id().unwrap()),
             60
         );
 
         // Now if adding the same key again, it should fail
-        assert_eq!(vote_pool.add_vote(new_pubkey, msgs[0], 60), None);
+        assert_eq!(vote_pool.add_vote(new_pubkey, 60, votes[0]), None);
     }
 }


### PR DESCRIPTION
#### Problem

See #550 

#### Summary of Changes

builds on top of #550.

- vote pools do not need to know about the certificate builder
- renames some variables in simple pool and uses API to reduce amount of code
- `prev_voted_block_ids` in duplicate pool uses a hash set instead of vec to make lookups cheaper
- duplicate pool's tracking of total stake is not needed by production code
- various APIs were taking a vote message and fields derived from it, passing just vote message

