### PR TITLE
Cherry-pick> local-cluster: Add ability to start cluster WFSM and use in tests (#8500)

### DIFF
--- a/local-cluster/src/integration_tests.rs
+++ b/local-cluster/src/integration_tests.rs
@@ -416,6 +416,7 @@ pub fn run_cluster_partition<C>(
     let turbine_disabled = Arc::new(AtomicBool::new(false));
     let mut validator_config = ValidatorConfig {
         turbine_disabled: turbine_disabled.clone(),
+        wait_for_supermajority: Some(0),
         ..ValidatorConfig::default_for_test()
     };
 
@@ -610,6 +611,7 @@ pub fn test_faulty_node(
     validator_configs[0].broadcast_stage_type = faulty_node_type;
     for config in &mut validator_configs {
         config.fixed_leader_schedule = Some(fixed_leader_schedule.clone());
+        config.wait_for_supermajority = Some(0);
     }
 
     let mut cluster_config = ClusterConfig {

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -357,52 +357,6 @@ impl LocalCluster {
         let leader_keypair = Arc::new(leader_keypair.insecure_clone());
         let leader_vote_keypair = Arc::new(leader_vote_keypair.insecure_clone());
 
-        let leader_server = Validator::new(
-            leader_node,
-            leader_keypair.clone(),
-            &leader_ledger_path,
-            &leader_vote_keypair.pubkey(),
-            Arc::new(RwLock::new(vec![leader_vote_keypair.clone()])),
-            vec![],
-            &leader_config,
-            true, // should_check_duplicate_instance
-            None, // rpc_to_plugin_manager_receiver
-            Arc::new(RwLock::new(ValidatorStartProgress::default())),
-            socket_addr_space,
-            // We are turning tpu_enable_udp to true in order to prevent concurrent local cluster tests
-            // to use the same QUIC ports due to SO_REUSEPORT.
-            ValidatorTpuConfig::new_for_tests(true),
-            Arc::new(RwLock::new(None)),
-        )
-        .expect("assume successful validator start");
-
-        let leader_contact_info = leader_server.cluster_info.my_contact_info();
-        let mut validators = HashMap::new();
-        let leader_info = ValidatorInfo {
-            keypair: leader_keypair,
-            voting_keypair: leader_vote_keypair,
-            ledger_path: leader_ledger_path,
-            contact_info: leader_contact_info.clone(),
-        };
-        let cluster_leader = ClusterValidatorInfo::new(
-            leader_info,
-            safe_clone_config(&config.validator_configs[0]),
-            leader_server,
-        );
-
-        validators.insert(leader_pubkey, cluster_leader);
-
-        let mut cluster = Self {
-            funding_keypair: mint_keypair,
-            entry_point_info: leader_contact_info.clone(),
-            validators,
-            genesis_config,
-            connection_cache,
-            quic_connection_cache_config,
-            tpu_connection_pool_size: config.tpu_connection_pool_size,
-            shred_version: leader_contact_info.shred_version(),
-        };
-
         let node_pubkey_to_vote_key: HashMap<Pubkey, Arc<Keypair>> = keys_in_genesis
             .into_iter()
             .map(|keypairs| {
@@ -412,19 +366,130 @@ impl LocalCluster {
                 )
             })
             .collect();
-        for (stake, validator_config, (key, _)) in izip!(
-            config.node_stakes[1..].iter(),
-            config.validator_configs[1..].iter(),
-            validator_keys[1..].iter(),
-        ) {
-            cluster.add_validator(
-                validator_config,
-                *stake,
-                key.clone(),
-                node_pubkey_to_vote_key.get(&key.pubkey()).cloned(),
-                socket_addr_space,
+
+        // Check if we should start validators in parallel in order to enable WFSM
+        let wait_for_supermajority = config
+            .validator_configs
+            .iter()
+            .all(|cfg| cfg.wait_for_supermajority.is_some());
+
+        let (mut cluster, leader_contact_info) = if wait_for_supermajority {
+            info!(
+                "Detected wait_for_supermajority in validator configs, starting all validators \
+                 (including leader) in parallel"
             );
-        }
+
+            let mut cluster = Self {
+                funding_keypair: mint_keypair,
+                entry_point_info: leader_node.info.clone(),
+                validators: HashMap::new(),
+                genesis_config,
+                connection_cache,
+                quic_connection_cache_config,
+                tpu_connection_pool_size: config.tpu_connection_pool_size,
+                shred_version: leader_node.info.shred_version(),
+            };
+
+            // Start all validators in parallel
+            cluster.start_all_validators_parallel(
+                &config.validator_configs,
+                &validator_keys,
+                &node_pubkey_to_vote_key,
+                socket_addr_space,
+                (
+                    leader_pubkey,
+                    leader_node,
+                    leader_config,
+                    leader_keypair.clone(),
+                    leader_vote_keypair.clone(),
+                    leader_ledger_path,
+                ),
+            );
+
+            // Get the leader contact info from the started validators
+            let leader_contact_info = cluster
+                .validators
+                .get(&leader_pubkey)
+                .unwrap()
+                .info
+                .contact_info
+                .clone();
+
+            // Update cluster with correct entry point and shred version
+            cluster.entry_point_info = leader_contact_info.clone();
+            cluster.shred_version = leader_contact_info.shred_version();
+
+            (cluster, leader_contact_info)
+        } else {
+            assert!(
+                config
+                    .validator_configs
+                    .iter()
+                    .all(|cfg| cfg.wait_for_supermajority.is_none()),
+                "Cannot partially specify WFSM in local cluster"
+            );
+            let leader_server = Validator::new(
+                leader_node,
+                leader_keypair.clone(),
+                &leader_ledger_path,
+                &leader_vote_keypair.pubkey(),
+                Arc::new(RwLock::new(vec![leader_vote_keypair.clone()])),
+                vec![],
+                &leader_config,
+                true, // should_check_duplicate_instance
+                None, // rpc_to_plugin_manager_receiver
+                Arc::new(RwLock::new(ValidatorStartProgress::default())),
+                socket_addr_space,
+                // We are turning tpu_enable_udp to true in order to prevent concurrent local cluster tests
+                // to use the same QUIC ports due to SO_REUSEPORT.
+                ValidatorTpuConfig::new_for_tests(true),
+                Arc::new(RwLock::new(None)),
+            )
+            .expect("assume successful validator start");
+
+            let leader_contact_info = leader_server.cluster_info.my_contact_info();
+            let mut validators = HashMap::new();
+            let leader_info = ValidatorInfo {
+                keypair: leader_keypair,
+                voting_keypair: leader_vote_keypair,
+                ledger_path: leader_ledger_path,
+                contact_info: leader_contact_info.clone(),
+            };
+            let cluster_leader = ClusterValidatorInfo::new(
+                leader_info,
+                safe_clone_config(&config.validator_configs[0]),
+                leader_server,
+            );
+
+            validators.insert(leader_pubkey, cluster_leader);
+
+            let mut cluster = Self {
+                funding_keypair: mint_keypair,
+                entry_point_info: leader_contact_info.clone(),
+                validators,
+                genesis_config,
+                connection_cache,
+                quic_connection_cache_config,
+                tpu_connection_pool_size: config.tpu_connection_pool_size,
+                shred_version: leader_contact_info.shred_version(),
+            };
+
+            for (stake, validator_config, (key, _)) in izip!(
+                config.node_stakes[1..].iter(),
+                config.validator_configs[1..].iter(),
+                validator_keys[1..].iter(),
+            ) {
+                cluster.add_validator(
+                    validator_config,
+                    *stake,
+                    key.clone(),
+                    node_pubkey_to_vote_key.get(&key.pubkey()).cloned(),
+                    socket_addr_space,
+                );
+            }
+
+            (cluster, leader_contact_info)
+        };
 
         let mut listener_config = safe_clone_config(&config.validator_configs[0]);
         listener_config.voting_disabled = true;
@@ -607,6 +672,149 @@ impl LocalCluster {
 
         self.validators.insert(validator_pubkey, validator_info);
         validator_pubkey
+    }
+
+    /// Starts all the validators in parallel for use with WFSM.
+    /// This assumes that all vote accounts are setup in genesis, and does not create any
+    /// vote or stake accounts.
+    fn start_all_validators_parallel(
+        &mut self,
+        validator_configs: &[ValidatorConfig],
+        validator_keys: &[(Arc<Keypair>, bool)],
+        node_pubkey_to_vote_key: &HashMap<Pubkey, Arc<Keypair>>,
+        socket_addr_space: SocketAddrSpace,
+        leader_data: (
+            Pubkey,
+            Node,
+            ValidatorConfig,
+            Arc<Keypair>,
+            Arc<Keypair>,
+            PathBuf,
+        ),
+    ) {
+        let (
+            leader_pubkey,
+            leader_node,
+            leader_config,
+            leader_keypair,
+            leader_vote_keypair,
+            leader_ledger_path,
+        ) = leader_data;
+
+        let mut handles = vec![];
+
+        // Start bootstrap (cluster leader)
+        let handle = std::thread::spawn(move || {
+            info!("Starting boostrap {leader_pubkey}");
+
+            let leader_server = Validator::new(
+                leader_node,
+                leader_keypair.clone(),
+                &leader_ledger_path,
+                &leader_vote_keypair.pubkey(),
+                Arc::new(RwLock::new(vec![leader_vote_keypair.clone()])),
+                vec![],
+                &leader_config,
+                true, // should_check_duplicate_instance
+                None, // rpc_to_plugin_manager_receiver
+                Arc::new(RwLock::new(ValidatorStartProgress::default())),
+                socket_addr_space,
+                ValidatorTpuConfig::new_for_tests(true),
+                Arc::new(RwLock::new(None)),
+            )
+            .unwrap_or_else(|e| panic!("Cluster leader failed to start: {e:?}"));
+
+            let leader_contact_info = leader_server.cluster_info.my_contact_info();
+            let leader_info = ValidatorInfo {
+                keypair: leader_keypair,
+                voting_keypair: leader_vote_keypair,
+                ledger_path: leader_ledger_path,
+                contact_info: leader_contact_info.clone(),
+            };
+            let cluster_leader =
+                ClusterValidatorInfo::new(leader_info, leader_config, leader_server);
+
+            info!("Bootstrap {leader_pubkey} started successfully");
+            (leader_pubkey, cluster_leader)
+        });
+
+        handles.push(handle);
+
+        // Start remaining validators
+        for (i, ((key, _), validator_config)) in validator_keys[1..]
+            .iter()
+            .zip(validator_configs[1..].iter())
+            .enumerate()
+        {
+            let validator_keypair = key.clone();
+            let voting_keypair = node_pubkey_to_vote_key
+                .get(&validator_keypair.pubkey())
+                .expect("All vote accounts must be setup in genesis for WFSM")
+                .clone();
+            let validator_config = safe_clone_config(validator_config);
+            let genesis_config = self.genesis_config.clone();
+            let entry_points = vec![self.entry_point_info.clone()];
+
+            let handle = std::thread::spawn(move || {
+                let validator_pubkey = validator_keypair.pubkey();
+                info!("Starting validator {validator_pubkey}");
+
+                let validator_node = Node::new_localhost_with_pubkey(&validator_keypair.pubkey());
+                let contact_info = validator_node.info.clone();
+                let (ledger_path, _blockhash) = create_new_tmp_ledger_with_size!(
+                    &genesis_config,
+                    validator_config.max_genesis_archive_unpacked_size,
+                );
+
+                let mut config = validator_config;
+                config.rpc_addrs = Some((
+                    validator_node.info.rpc().unwrap(),
+                    validator_node.info.rpc_pubsub().unwrap(),
+                ));
+                Self::sync_ledger_path_across_nested_config_fields(&mut config, &ledger_path);
+
+                let validator_server = Validator::new(
+                    validator_node,
+                    validator_keypair.clone(),
+                    &ledger_path,
+                    &voting_keypair.pubkey(),
+                    Arc::new(RwLock::new(vec![voting_keypair.clone()])),
+                    entry_points,
+                    &config,
+                    true, // should_check_duplicate_instance
+                    None, // rpc_to_plugin_manager_receiver
+                    Arc::new(RwLock::new(ValidatorStartProgress::default())),
+                    socket_addr_space,
+                    ValidatorTpuConfig::new_for_tests(DEFAULT_TPU_ENABLE_UDP),
+                    Arc::new(RwLock::new(None)),
+                )
+                .unwrap_or_else(|e| panic!("Validator {i} failed to start: {e:?}"));
+
+                let validator_pubkey = validator_keypair.pubkey();
+                let validator_info = ClusterValidatorInfo::new(
+                    ValidatorInfo {
+                        keypair: validator_keypair,
+                        voting_keypair: voting_keypair.clone(),
+                        ledger_path,
+                        contact_info,
+                    },
+                    config,
+                    validator_server,
+                );
+
+                info!("Validator {validator_pubkey} started successfully");
+                (validator_pubkey, validator_info)
+            });
+
+            handles.push(handle);
+        }
+
+        // Wait for all validators to start
+        for handle in handles.into_iter() {
+            let (validator_pubkey, validator_info) =
+                handle.join().expect("Validator thread panicked");
+            self.validators.insert(validator_pubkey, validator_info);
+        }
     }
 
     pub fn ledger_path(&self, validator_pubkey: &Pubkey) -> PathBuf {

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1768,13 +1768,14 @@ fn test_optimistic_confirmation_violation_detection() {
     // to form a cluster. The heavier validator is the second node.
     let node_to_restart = validator_keys[1].0.pubkey();
 
+    // WFSM as we require a OC slot > 50 within 100 seconds
+    let mut validator_config = ValidatorConfig::default_for_test();
+    validator_config.wait_for_supermajority = Some(0);
+
     let mut config = ClusterConfig {
         mint_lamports: DEFAULT_MINT_LAMPORTS + node_stakes.iter().sum::<u64>(),
         node_stakes: node_stakes.clone(),
-        validator_configs: make_identical_validator_configs(
-            &ValidatorConfig::default_for_test(),
-            node_stakes.len(),
-        ),
+        validator_configs: make_identical_validator_configs(&validator_config, node_stakes.len()),
         validator_keys: Some(validator_keys),
         slots_per_epoch,
         stakers_slot_offset: slots_per_epoch,
@@ -2162,13 +2163,12 @@ fn do_test_future_tower(cluster_mode: ClusterMode) {
         ClusterMode::MasterSlave => validators[1],
     };
 
+    let mut validator_config = ValidatorConfig::default_for_test();
+    validator_config.wait_for_supermajority = Some(0);
     let mut config = ClusterConfig {
         mint_lamports: DEFAULT_MINT_LAMPORTS + DEFAULT_NODE_STAKE * 100,
         node_stakes: node_stakes.clone(),
-        validator_configs: make_identical_validator_configs(
-            &ValidatorConfig::default_for_test(),
-            node_stakes.len(),
-        ),
+        validator_configs: make_identical_validator_configs(&validator_config, node_stakes.len()),
         validator_keys: Some(validator_keys),
         slots_per_epoch,
         stakers_slot_offset: slots_per_epoch,
@@ -2664,13 +2664,12 @@ fn test_restart_tower_rollback() {
 
     let b_pubkey = validator_keys[1].0.pubkey();
 
+    let mut validator_config = ValidatorConfig::default_for_test();
+    validator_config.wait_for_supermajority = Some(0);
     let mut config = ClusterConfig {
         mint_lamports: DEFAULT_MINT_LAMPORTS + DEFAULT_NODE_STAKE * 100,
         node_stakes: node_stakes.clone(),
-        validator_configs: make_identical_validator_configs(
-            &ValidatorConfig::default_for_test(),
-            node_stakes.len(),
-        ),
+        validator_configs: make_identical_validator_configs(&validator_config, node_stakes.len()),
         validator_keys: Some(validator_keys),
         slots_per_epoch,
         stakers_slot_offset: slots_per_epoch,
@@ -2813,6 +2812,7 @@ fn test_rpc_block_subscribe() {
     let node_stakes = vec![leader_stake, rpc_stake];
     let mut validator_config = ValidatorConfig::default_for_test();
     validator_config.enable_default_rpc_block_subscribe();
+    validator_config.wait_for_supermajority = Some(0);
 
     let validator_keys = [
         "28bN3xyvrP4E8LwEgtLjhnkb7cY4amQb6DrYAbAYjgRV4GAGgkVM2K7wnxnAS7WDneuavza7x21MiafLu1HkwQt4",
@@ -2893,6 +2893,7 @@ fn test_oc_bad_signatures() {
     let node_stakes = vec![leader_stake, our_node_stake];
     let mut validator_config = ValidatorConfig {
         require_tower: true,
+        wait_for_supermajority: Some(0),
         ..ValidatorConfig::default_for_test()
     };
     validator_config.enable_default_rpc_block_subscribe();
@@ -3273,13 +3274,12 @@ fn run_test_load_program_accounts(scan_commitment: CommitmentConfig) {
         scan_client_receiver,
     );
 
+    let mut validator_config = ValidatorConfig::default_for_test();
+    validator_config.wait_for_supermajority = Some(0);
     let mut config = ClusterConfig {
         mint_lamports: DEFAULT_MINT_LAMPORTS + node_stakes.iter().sum::<u64>(),
         node_stakes: node_stakes.clone(),
-        validator_configs: make_identical_validator_configs(
-            &ValidatorConfig::default_for_test(),
-            node_stakes.len(),
-        ),
+        validator_configs: make_identical_validator_configs(&validator_config, node_stakes.len()),
         validator_keys: Some(validator_keys),
         slots_per_epoch,
         stakers_slot_offset: slots_per_epoch,
@@ -3422,6 +3422,7 @@ fn do_test_lockout_violation_with_or_without_tower(with_tower: bool) {
     default_config.fixed_leader_schedule = Some(FixedSchedule {
         leader_schedule: leader_schedule.clone(),
     });
+    default_config.wait_for_supermajority = Some(0);
     let mut validator_configs =
         make_identical_validator_configs(&default_config, node_stakes.len());
 
@@ -4559,7 +4560,8 @@ fn test_leader_failure_4() {
     // Cluster needs a supermajority to remain even after taking 1 node offline,
     // so the minimum number of nodes for this test is 4.
     let num_nodes = 4;
-    let validator_config = ValidatorConfig::default_for_test();
+    let mut validator_config = ValidatorConfig::default_for_test();
+    validator_config.wait_for_supermajority = Some(0);
     // Embed vote and stake account in genesis to avoid waiting for stake
     // activation and race conditions around accepting gossip votes, repairing
     // blocks, etc. before we advance through too many epochs.
@@ -4655,8 +4657,10 @@ fn test_slot_hash_expiry() {
 
     // We want B to not vote (we are trying to simulate its votes not landing until it gets to the
     // minority fork)
+    let mut validator_config = ValidatorConfig::default_for_test();
+    validator_config.wait_for_supermajority = Some(0);
     let mut validator_configs =
-        make_identical_validator_configs(&ValidatorConfig::default_for_test(), node_stakes.len());
+        make_identical_validator_configs(&validator_config, node_stakes.len());
     validator_configs[1].voting_disabled = true;
 
     let mut config = ClusterConfig {


### PR DESCRIPTION
Cherrypick https://github.com/anza-xyz/agave/pull/8500

Want to merge a local-cluster test for the migration that doesn't take forever to run https://github.com/anza-xyz/alpenglow/pull/502/commits/b08e35212ef1305c5fb14bd978a17751e7b76fd1#diff-5e9f940ea065adfd3066ef0d8ef0cfb5029b5ba478d96fb484b36954e464505cR6212. 

This means we need really short epochs so the feature activation hits quickly. Really short epochs requires roots out the gate which we cannot achieve reliably without WFSM.