### PR TITLE
migration: turn off popular & ancestor hashes repair requests

### DIFF
--- a/core/src/repair/repair_handler.rs
+++ b/core/src/repair/repair_handler.rs
@@ -21,6 +21,7 @@ use {
     solana_perf::packet::{Packet, PacketBatch, PacketBatchRecycler, PinnedPacketBatch},
     solana_pubkey::Pubkey,
     solana_runtime::bank_forks::SharableBanks,
+    solana_votor_messages::migration::MigrationStatus,
     std::{
         collections::HashSet,
         net::SocketAddr,
@@ -167,12 +168,14 @@ impl RepairHandlerType {
         cluster_info: Arc<ClusterInfo>,
         sharable_banks: SharableBanks,
         serve_repair_whitelist: Arc<RwLock<HashSet<Pubkey>>>,
+        migration_status: Arc<MigrationStatus>,
     ) -> ServeRepair {
         ServeRepair::new(
             cluster_info,
             sharable_banks,
             serve_repair_whitelist,
             self.to_handler(blockstore),
+            migration_status,
         )
     }
 }

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -55,6 +55,7 @@ use {
         streamer::PacketBatchSender,
     },
     solana_time_utils::timestamp,
+    solana_votor_messages::migration::MigrationStatus,
     std::{
         cmp::Reverse,
         collections::{HashMap, HashSet},
@@ -412,6 +413,7 @@ pub struct ServeRepair {
     sharable_banks: SharableBanks,
     repair_whitelist: Arc<RwLock<HashSet<Pubkey>>>,
     repair_handler: Box<dyn RepairHandler + Send + Sync>,
+    migration_status: Arc<MigrationStatus>,
 }
 
 // Cache entry for repair peers for a slot.
@@ -475,12 +477,14 @@ impl ServeRepair {
         sharable_banks: SharableBanks,
         repair_whitelist: Arc<RwLock<HashSet<Pubkey>>>,
         repair_handler: Box<dyn RepairHandler + Send + Sync>,
+        migration_status: Arc<MigrationStatus>,
     ) -> Self {
         Self {
             cluster_info,
             sharable_banks,
             repair_whitelist,
             repair_handler,
+            migration_status,
         }
     }
 
@@ -498,6 +502,7 @@ impl ServeRepair {
             bank_forks.read().unwrap().sharable_banks(),
             repair_whitelist,
             repair_handler,
+            Arc::new(MigrationStatus::default()),
         )
     }
 
@@ -575,11 +580,15 @@ impl ServeRepair {
                     slot,
                 } => {
                     stats.ancestor_hashes += 1;
-                    (
-                        self.repair_handler
-                            .run_ancestor_hashes(recycler, from_addr, *slot, *nonce),
-                        "AncestorHashes",
-                    )
+                    if *slot > self.migration_status.genesis_slot().unwrap_or(Slot::MAX) {
+                        (None, "AncestorHashes")
+                    } else {
+                        (
+                            self.repair_handler
+                                .run_ancestor_hashes(recycler, from_addr, *slot, *nonce),
+                            "AncestorHashes",
+                        )
+                    }
                 }
                 RepairProtocol::Pong(pong) => {
                     stats.pong += 1;

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -360,6 +360,7 @@ impl Tvu {
                 window_service_channels,
                 leader_schedule_cache.clone(),
                 outstanding_repair_requests,
+                migration_status.clone(),
             )
         };
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1379,11 +1379,13 @@ impl Validator {
             Some(stats_reporter_sender.clone()),
             exit.clone(),
         );
+        let migration_status = Arc::new(MigrationStatus::new(cluster_info.id()));
         let serve_repair = config.repair_handler_type.create_serve_repair(
             blockstore.clone(),
             cluster_info.clone(),
             bank_forks.read().unwrap().sharable_banks(),
             config.repair_whitelist.clone(),
+            migration_status.clone(),
         );
         let (repair_request_quic_sender, repair_request_quic_receiver) = unbounded();
         let (repair_response_quic_sender, repair_response_quic_receiver) = unbounded();
@@ -1405,7 +1407,6 @@ impl Validator {
         let wait_for_vote_to_start_leader =
             !waited_for_supermajority && !config.no_wait_for_vote_to_start_leader;
 
-        let migration_status = Arc::new(MigrationStatus::new(cluster_info.id()));
         let replay_highest_frozen = Arc::new(ReplayHighestFrozen::default());
         let leader_window_notifier = Arc::new(LeaderWindowNotifier::default());
         let block_creation_loop_config = BlockCreationLoopConfig {


### PR DESCRIPTION
Split from #502 

#### Problem
Although we do not engage in TowerBFT duplicate block consensus post AG genesis, we still respond to TowerBFT duplicate block consensus repair requests.

#### Summary of Changes
Do not respond to any TowerBFT duplicate block repair requests on slots post AG genesis.
Do not take action on popular pruned forks post AG genesis.
Just kill the ancestor hashes thread since we're not going to be sending any requests when alpenglow is active.
Store duplicate shred proofs in blockstore for slashing, but do not gossip or send them to the duplicate block state machine

4.1 we can delete all tower bft duplicate block consensus