### PR TITLE
migration: turn off epoch slots post alpenglow genesis

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3455,7 +3455,9 @@ impl ReplayStage {
                     r_replay_stats.batch_execute.totals
                 );
                 new_frozen_slots.push(bank.slot());
-                let _ = cluster_slots_update_sender.send(vec![bank_slot]);
+                if bank_slot <= migration_status.genesis_slot().unwrap_or(Slot::MAX) {
+                    let _ = cluster_slots_update_sender.send(vec![bank_slot]);
+                }
 
                 bank.freeze();
                 datapoint_info!(

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -320,6 +320,7 @@ impl Tvu {
             cluster_info.clone(),
             cluster_slots_update_receiver,
             exit.clone(),
+            migration_status.clone(),
         );
 
         let (cost_update_sender, cost_update_receiver) = unbounded();

--- a/gossip/src/epoch_specs.rs
+++ b/gossip/src/epoch_specs.rs
@@ -37,6 +37,11 @@ impl EpochSpecs {
         self.epoch_duration
     }
 
+    #[inline]
+    pub fn current_epoch(&self) -> Epoch {
+        self.epoch
+    }
+
     // Updates fields if root bank has moved to a new epoch.
     fn maybe_refresh(&mut self) {
         if self.epoch_schedule.get_epoch(self.root.get()) == self.epoch {


### PR DESCRIPTION
Split from #502 

#### Problem
It's finally time 


#### Summary of Changes
Note this DOES NOT break repair, epoch-slots is only one component of repair peer selection:
https://github.com/anza-xyz/alpenglow/blob/426b9d075290838e94b6eaaeb24aeac1aeb3e428/core/src/cluster_slots_service/cluster_slots.rs#L489

necromancy of https://github.com/anza-xyz/agave/pull/3246 will clean up peer selection