### PR TITLE
migration: drop genesis votes & certs in sigverify post migration

### DIFF
--- a/core/benches/bls_sigverify.rs
+++ b/core/benches/bls_sigverify.rs
@@ -19,6 +19,7 @@ use {
     solana_votor::consensus_pool::certificate_builder::CertificateBuilder,
     solana_votor_messages::{
         consensus_message::{CertificateType, ConsensusMessage, VoteMessage},
+        migration::MigrationStatus,
         vote::Vote,
     },
     std::{
@@ -106,6 +107,7 @@ fn setup_environment() -> BenchEnvironment {
         consensus_msg_s,
         consensus_metrics_sender,
         Arc::new(AlpenglowLastVoted::default()),
+        Arc::new(MigrationStatus::post_migration_status()),
     );
 
     BenchEnvironment {

--- a/core/src/bls_sigverify/stats.rs
+++ b/core/src/bls_sigverify/stats.rs
@@ -145,6 +145,9 @@ pub(crate) struct BLSSigVerifierStats {
     pub(crate) received_old: AtomicU64,
     pub(crate) received_verified: AtomicU64,
     pub(crate) received_votes: AtomicU64,
+    pub(crate) received_invalid_genesis_vote: AtomicU64,
+    pub(crate) received_invalid_genesis_cert: AtomicU64,
+    pub(crate) received_pre_migration_message: AtomicU64,
     pub(crate) last_stats_logged: Instant,
 }
 
@@ -177,6 +180,9 @@ impl BLSSigVerifierStats {
             received_old: AtomicU64::new(0),
             received_verified: AtomicU64::new(0),
             received_votes: AtomicU64::new(0),
+            received_invalid_genesis_vote: AtomicU64::new(0),
+            received_invalid_genesis_cert: AtomicU64::new(0),
+            received_pre_migration_message: AtomicU64::new(0),
             last_stats_logged: Instant::now(),
         }
     }
@@ -303,6 +309,21 @@ impl BLSSigVerifierStats {
             (
                 "received_malformed",
                 self.received_malformed.load(Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "received_invalid_genesis_vote",
+                self.received_invalid_genesis_vote.load(Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "received_invalid_genesis_cert",
+                self.received_invalid_genesis_cert.load(Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "received_pre_migration_message",
+                self.received_pre_migration_message.load(Ordering::Relaxed) as i64,
                 i64
             ),
         );

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -274,6 +274,7 @@ impl Tvu {
                 consensus_message_sender.clone(),
                 consensus_metrics_sender.clone(),
                 alpenglow_last_voted.clone(),
+                migration_status.clone(),
             );
             BLSSigverifyService::new(bls_packet_receiver, verifier)
         };

--- a/votor-messages/src/consensus_message.rs
+++ b/votor-messages/src/consensus_message.rs
@@ -74,6 +74,11 @@ impl CertificateType {
         matches!(self, Self::Skip(_))
     }
 
+    /// Is this a genesis certificate?
+    pub fn is_genesis(&self) -> bool {
+        matches!(self, Self::Genesis(_, _))
+    }
+
     /// Gets the block associated with this certificate, if present
     pub fn to_block(self) -> Option<Block> {
         match self {


### PR DESCRIPTION
Split from #502 

#### Problem
The new vote/cert type `Genesis` is only used pre migration to determine the genesis slot.
AG votes should not be sent during TowerBFT slots

#### Summary of Changes
Once the migration succeeds, ignore any `Genesis` votes or certs in sigverify
Pre migration, ignore all AG votes in sigverify.