### PR TITLE
refactor: some more `Vote` related cleanups

### DIFF
--- a/votor-messages/src/consensus_message.rs
+++ b/votor-messages/src/consensus_message.rs
@@ -13,7 +13,7 @@ pub const BLS_KEYPAIR_DERIVE_SEED: &[u8; 9] = b"alpenglow";
 /// Block, a (slot, hash) tuple
 pub type Block = (Slot, Hash);
 
-#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 /// BLS vote message, we need rank to look up pubkey
 pub struct VoteMessage {
     /// The vote

--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -225,7 +225,7 @@ impl ConsensusPool {
                 continue;
             }
             let mut cert_builder = CertificateBuilder::new(cert_type);
-            vote_types.iter().for_each(|vote_type| {
+            for vote_type in vote_types {
                 if let Some(pool) = self.vote_pools.get(&(slot, *vote_type)) {
                     match pool {
                         VotePool::SimpleVotePool(pool) => {
@@ -238,7 +238,7 @@ impl ConsensusPool {
                         }
                     };
                 }
-            });
+            }
             let new_cert = Arc::new(cert_builder.build()?);
             self.insert_certificate(cert_type, new_cert.clone(), events);
             self.stats.incr_cert_type(&new_cert.cert_type, true);
@@ -399,7 +399,7 @@ impl ConsensusPool {
         vote_message: VoteMessage,
         events: &mut Vec<VotorEvent>,
     ) -> Result<Vec<Arc<Certificate>>, AddVoteError> {
-        let vote = &vote_message.vote;
+        let vote = vote_message.vote;
         let rank = vote_message.rank;
         let vote_slot = vote.slot();
         let (validator_vote_key, validator_stake, total_stake) =
@@ -457,9 +457,8 @@ impl ConsensusPool {
                 );
             }
         }
-        self.stats.incr_ingested_vote_type(vote_type);
-
-        self.update_certificates(vote, block_id, events, total_stake)
+        self.stats.incr_ingested_vote(&vote);
+        self.update_certificates(&vote, block_id, events, total_stake)
     }
 
     fn add_certificate(

--- a/votor/src/consensus_pool/slot_stake_counters.rs
+++ b/votor/src/consensus_pool/slot_stake_counters.rs
@@ -35,13 +35,13 @@ impl SlotStakeCounters {
 
     pub fn add_vote(
         &mut self,
-        vote: &Vote,
+        vote: Vote,
         entry_stake: Stake,
         is_my_own_vote: bool,
         events: &mut Vec<VotorEvent>,
         stats: &mut ConsensusPoolStats,
     ) {
-        match vote {
+        match &vote {
             Vote::Skip(_) => self.skip_total = entry_stake,
             Vote::Notarize(vote) => {
                 let old_entry_stake = self
@@ -57,7 +57,7 @@ impl SlotStakeCounters {
             _ => return, // Not interested in other vote types
         }
         if self.my_first_vote.is_none() && is_my_own_vote {
-            self.my_first_vote = Some(*vote);
+            self.my_first_vote = Some(vote);
         }
         if self.my_first_vote.is_none() {
             // We have not voted yet, no need to check safe to notarize or skip
@@ -136,19 +136,13 @@ mod tests {
         let mut stats = ConsensusPoolStats::default();
         let slot = 2;
         // I voted for skip
-        counters.add_vote(
-            &Vote::new_skip_vote(slot),
-            10,
-            true,
-            &mut events,
-            &mut stats,
-        );
+        counters.add_vote(Vote::new_skip_vote(slot), 10, true, &mut events, &mut stats);
         assert!(events.is_empty());
         assert_eq!(stats.event_safe_to_notarize, 0);
 
         // 40% of stake holders voted notarize
         counters.add_vote(
-            &Vote::new_notarization_vote(slot, Hash::default()),
+            Vote::new_notarization_vote(slot, Hash::default()),
             40,
             false,
             &mut events,
@@ -163,7 +157,7 @@ mod tests {
 
         // Adding more notarizations does not trigger more events
         counters.add_vote(
-            &Vote::new_notarization_vote(slot, Hash::default()),
+            Vote::new_notarization_vote(slot, Hash::default()),
             20,
             false,
             &mut events,
@@ -180,7 +174,7 @@ mod tests {
         // I voted for notarize b
         let hash_1 = Hash::new_unique();
         counters.add_vote(
-            &Vote::new_notarization_vote(slot, hash_1),
+            Vote::new_notarization_vote(slot, hash_1),
             1,
             true,
             &mut events,
@@ -192,7 +186,7 @@ mod tests {
         // 25% of stake holders voted notarize b'
         let hash_2 = Hash::new_unique();
         counters.add_vote(
-            &Vote::new_notarization_vote(slot, hash_2),
+            Vote::new_notarization_vote(slot, hash_2),
             25,
             false,
             &mut events,
@@ -203,7 +197,7 @@ mod tests {
 
         // 35% more of stake holders voted skip
         counters.add_vote(
-            &Vote::new_skip_vote(slot),
+            Vote::new_skip_vote(slot),
             35,
             false,
             &mut events,
@@ -225,7 +219,7 @@ mod tests {
         let slot = 2;
         // I voted for notarize b
         counters.add_vote(
-            &Vote::new_notarization_vote(slot, Hash::default()),
+            Vote::new_notarization_vote(slot, Hash::default()),
             10,
             true,
             &mut events,
@@ -236,7 +230,7 @@ mod tests {
 
         // 40% of stake holders voted skip
         counters.add_vote(
-            &Vote::new_skip_vote(slot),
+            Vote::new_skip_vote(slot),
             40,
             false,
             &mut events,
@@ -249,7 +243,7 @@ mod tests {
 
         // Adding more skips does not trigger more events
         counters.add_vote(
-            &Vote::new_skip_vote(slot),
+            Vote::new_skip_vote(slot),
             20,
             false,
             &mut events,
@@ -266,7 +260,7 @@ mod tests {
         // I voted for notarize b, 10% of stake holders voted with me
         let hash_1 = Hash::new_unique();
         counters.add_vote(
-            &Vote::new_notarization_vote(slot, hash_1),
+            Vote::new_notarization_vote(slot, hash_1),
             10,
             true,
             &mut events,
@@ -275,7 +269,7 @@ mod tests {
         // 20% of stake holders voted a different notarization b'
         let hash_2 = Hash::new_unique();
         counters.add_vote(
-            &Vote::new_notarization_vote(slot, hash_2),
+            Vote::new_notarization_vote(slot, hash_2),
             20,
             false,
             &mut events,
@@ -283,7 +277,7 @@ mod tests {
         );
         // 30% of stake holders voted skip
         counters.add_vote(
-            &Vote::new_skip_vote(slot),
+            Vote::new_skip_vote(slot),
             30,
             false,
             &mut events,
@@ -296,7 +290,7 @@ mod tests {
 
         // Adding more notarization on b does not trigger more events
         counters.add_vote(
-            &Vote::new_notarization_vote(slot, hash_1),
+            Vote::new_notarization_vote(slot, hash_1),
             10,
             false,
             &mut events,

--- a/votor/src/consensus_pool/vote_pool.rs
+++ b/votor/src/consensus_pool/vote_pool.rs
@@ -139,23 +139,23 @@ mod test {
     fn test_skip_vote_pool() {
         let mut vote_pool = SimpleVotePool::default();
         let vote = Vote::new_skip_vote(5);
-        let vote_message = VoteMessage {
+        let vote = VoteMessage {
             vote,
             signature: BLSSignature::default(),
             rank: 1,
         };
         let my_pubkey = Pubkey::new_unique();
 
-        assert_eq!(vote_pool.add_vote(my_pubkey, 10, vote_message), Some(10));
+        assert_eq!(vote_pool.add_vote(my_pubkey, 10, vote.clone()), Some(10));
         assert_eq!(vote_pool.total_stake(), 10);
 
         // Adding the same key again should fail
-        assert_eq!(vote_pool.add_vote(my_pubkey, 10, vote_message), None);
+        assert_eq!(vote_pool.add_vote(my_pubkey, 10, vote.clone()), None);
         assert_eq!(vote_pool.total_stake(), 10);
 
         // Adding a different key should succeed
         let new_pubkey = Pubkey::new_unique();
-        assert_eq!(vote_pool.add_vote(new_pubkey, 60, vote_message), Some(70));
+        assert_eq!(vote_pool.add_vote(new_pubkey, 60, vote.clone()), Some(70));
         assert_eq!(vote_pool.total_stake(), 70);
     }
 
@@ -170,18 +170,18 @@ mod test {
             signature: BLSSignature::default(),
             rank: 1,
         };
-        assert_eq!(vote_pool.add_vote(my_pubkey, 10, vote), Some(10));
+        assert_eq!(vote_pool.add_vote(my_pubkey, 10, vote.clone()), Some(10));
         assert_eq!(vote_pool.total_stake_by_block_id(&block_id), 10);
 
         // Adding the same key again should fail
-        assert_eq!(vote_pool.add_vote(my_pubkey, 10, vote), None);
+        assert_eq!(vote_pool.add_vote(my_pubkey, 10, vote.clone()), None);
 
         // Adding a different bankhash should fail
-        assert_eq!(vote_pool.add_vote(my_pubkey, 10, vote), None);
+        assert_eq!(vote_pool.add_vote(my_pubkey, 10, vote.clone()), None);
 
         // Adding a different key should succeed
         let new_pubkey = Pubkey::new_unique();
-        assert_eq!(vote_pool.add_vote(new_pubkey, 60, vote), Some(70));
+        assert_eq!(vote_pool.add_vote(new_pubkey, 60, vote.clone()), Some(70));
         assert_eq!(vote_pool.total_stake_by_block_id(&block_id), 70);
     }
 
@@ -204,14 +204,14 @@ mod test {
 
         // Adding the first 3 votes should succeed, but total_stake should remain at 10
         for vote in votes.iter().take(3).cloned() {
-            assert_eq!(vote_pool.add_vote(my_pubkey, 10, vote), Some(10));
+            assert_eq!(vote_pool.add_vote(my_pubkey, 10, vote.clone()), Some(10));
             assert_eq!(
                 vote_pool.total_stake_by_block_id(vote.vote.block_id().unwrap()),
                 10
             );
         }
         // Adding the 4th vote should fail
-        assert_eq!(vote_pool.add_vote(my_pubkey, 10, votes[3]), None);
+        assert_eq!(vote_pool.add_vote(my_pubkey, 10, votes[3].clone()), None);
         assert_eq!(
             vote_pool.total_stake_by_block_id(votes[3].vote.block_id().unwrap()),
             0
@@ -220,7 +220,7 @@ mod test {
         // Adding a different key should succeed
         let new_pubkey = Pubkey::new_unique();
         for vote in votes.iter().skip(1).take(2).cloned() {
-            assert_eq!(vote_pool.add_vote(new_pubkey, 60, vote), Some(70));
+            assert_eq!(vote_pool.add_vote(new_pubkey, 60, vote.clone()), Some(70));
             assert_eq!(
                 vote_pool.total_stake_by_block_id(vote.vote.block_id().unwrap()),
                 70
@@ -228,13 +228,16 @@ mod test {
         }
 
         // The new key only added 2 votes, so adding block_ids[3] should succeed
-        assert_eq!(vote_pool.add_vote(new_pubkey, 60, votes[3]), Some(60));
+        assert_eq!(
+            vote_pool.add_vote(new_pubkey, 60, votes[3].clone()),
+            Some(60)
+        );
         assert_eq!(
             vote_pool.total_stake_by_block_id(votes[3].vote.block_id().unwrap()),
             60
         );
 
         // Now if adding the same key again, it should fail
-        assert_eq!(vote_pool.add_vote(new_pubkey, 60, votes[0]), None);
+        assert_eq!(vote_pool.add_vote(new_pubkey, 60, votes[0].clone()), None);
     }
 }

--- a/votor/src/event_handler/stats.rs
+++ b/votor/src/event_handler/stats.rs
@@ -184,7 +184,7 @@ impl EventHandlerStats {
 
     pub fn incr_vote(&mut self, bls_op: &BLSOp) {
         if let BLSOp::PushVote { message, .. } = bls_op {
-            let ConsensusMessage::Vote(vote) = **message else {
+            let ConsensusMessage::Vote(vote) = message.as_ref() else {
                 warn!("Unexpected BLS message type: {message:?}");
                 return;
             };


### PR DESCRIPTION
#### Problem

- `VoteMessage` derives `Copy` and it is a fairly big struct to copy, it should only derive `Clone` so we can consciously consider when it makes sense to copy the struct.
- vote related metrics recording seems fragile and has too many unwraps


#### Summary of Changes

- Removes `Copy` derive on `VoteMessage`
- cleans up vote related metrics similar to certificate related metrics
