### PR TITLE
nit: rename a confusing variable

### DIFF
--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -226,8 +226,8 @@ impl ConsensusPool {
             }
             let mut cert_builder = CertificateBuilder::new(cert_type);
             vote_types.iter().for_each(|vote_type| {
-                if let Some(pool) = self.vote_pools.get(&(slot, *vote_type)) {
-                    match pool {
+                if let Some(vote_pool) = self.vote_pools.get(&(slot, *vote_type)) {
+                    match vote_pool {
                         VotePool::SimpleVotePool(pool) => {
                             cert_builder.aggregate(pool.votes()).unwrap();
                         }


### PR DESCRIPTION
#### Problem
The variable is a vote pool and not a pool

#### Summary of Changes

Renames the variable as proposed in https://github.com/anza-xyz/alpenglow/pull/551/files#r2453661319
