### PR TITLE
cli: add --do-not-require-vote-history for startup / set-identity

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -297,6 +297,7 @@ pub struct ValidatorConfig {
     /// processing.
     pub run_verification: bool,
     pub require_tower: bool,
+    pub require_vote_history: bool,
     pub tower_storage: Arc<dyn TowerStorage>,
     pub vote_history_storage: Arc<dyn VoteHistoryStorage>,
     pub debug_keys: Option<Arc<HashSet<Pubkey>>>,
@@ -378,6 +379,7 @@ impl ValidatorConfig {
             max_genesis_archive_unpacked_size: MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
             run_verification: true,
             require_tower: false,
+            require_vote_history: false,
             tower_storage: Arc::new(NullTowerStorage::default()),
             vote_history_storage: Arc::new(NullVoteHistoryStorage::default()),
             debug_keys: None,
@@ -1537,11 +1539,10 @@ impl Validator {
                     vote_history
                 }
                 Err(e) => {
-                    // TODO(ashwin): we need to be viligant about this and add a CLI option to panic here.
-                    warn!(
-                        "Unable to retrieve vote history: {e:?} creating default vote history...."
+                    panic!(
+                        "Unable to retrieve vote history. If this is a new validator startup use \
+                         --do-not-require-vote-history: {e:?}"
                     );
-                    VoteHistory::new(identity_keypair.pubkey(), 0)
                 }
             };
             (Tower::default(), vote_history)
@@ -2136,7 +2137,7 @@ fn post_process_restored_vote_history(
     config: &ValidatorConfig,
     bank_forks: &BankForks,
 ) -> Result<VoteHistory, String> {
-    let mut should_require_vote_history = config.require_tower;
+    let mut should_require_vote_history = config.require_vote_history;
 
     let restored_vote_history = restored_vote_history.and_then(|mut vote_history| {
         let root_bank = bank_forks.root_bank();

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -33,6 +33,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         max_genesis_archive_unpacked_size: config.max_genesis_archive_unpacked_size,
         run_verification: config.run_verification,
         require_tower: config.require_tower,
+        require_vote_history: config.require_vote_history,
         tower_storage: config.tower_storage.clone(),
         vote_history_storage: config.vote_history_storage.clone(),
         debug_keys: config.debug_keys.clone(),

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -24,7 +24,9 @@ use {
     solana_rpc_client_api::{config::RpcAccountIndex, custom_error::RpcCustomError},
     solana_signer::Signer,
     solana_validator_exit::Exit,
-    solana_votor::event::VotorEvent,
+    solana_votor::{
+        event::VotorEvent, vote_history::VoteHistory, vote_history_storage::VoteHistoryStorage,
+    },
     std::{
         collections::{HashMap, HashSet},
         env, error,
@@ -51,6 +53,7 @@ pub struct AdminRpcRequestMetadata {
     pub validator_exit_backpressure: HashMap<String, Arc<AtomicBool>>,
     pub authorized_voter_keypairs: Arc<RwLock<Vec<Arc<Keypair>>>>,
     pub tower_storage: Arc<dyn TowerStorage>,
+    pub vote_history_storage: Arc<dyn VoteHistoryStorage>,
     pub staked_nodes_overrides: Arc<RwLock<HashMap<Pubkey, u64>>>,
     pub post_init: Arc<RwLock<Option<AdminRpcRequestMetadataPostInit>>>,
     pub rpc_to_plugin_manager_sender: Option<Sender<GeyserPluginManagerRequest>>,
@@ -208,6 +211,7 @@ pub trait AdminRpc {
         meta: Self::Metadata,
         keypair_file: String,
         require_tower: bool,
+        require_vote_history: bool,
     ) -> Result<()>;
 
     #[rpc(meta, name = "setIdentityFromBytes")]
@@ -216,6 +220,7 @@ pub trait AdminRpc {
         meta: Self::Metadata,
         identity_keypair: Vec<u8>,
         require_tower: bool,
+        require_vote_history: bool,
     ) -> Result<()>;
 
     #[rpc(meta, name = "setStakedNodesOverrides")]
@@ -508,6 +513,7 @@ impl AdminRpc for AdminRpcImpl {
         meta: Self::Metadata,
         keypair_file: String,
         require_tower: bool,
+        require_vote_history: bool,
     ) -> Result<()> {
         debug!("set_identity request received");
 
@@ -517,7 +523,12 @@ impl AdminRpc for AdminRpcImpl {
             ))
         })?;
 
-        AdminRpcImpl::set_identity_keypair(meta, identity_keypair, require_tower)
+        AdminRpcImpl::set_identity_keypair(
+            meta,
+            identity_keypair,
+            require_tower,
+            require_vote_history,
+        )
     }
 
     fn set_identity_from_bytes(
@@ -525,6 +536,7 @@ impl AdminRpc for AdminRpcImpl {
         meta: Self::Metadata,
         identity_keypair: Vec<u8>,
         require_tower: bool,
+        require_vote_history: bool,
     ) -> Result<()> {
         debug!("set_identity_from_bytes request received");
 
@@ -534,7 +546,12 @@ impl AdminRpc for AdminRpcImpl {
             ))
         })?;
 
-        AdminRpcImpl::set_identity_keypair(meta, identity_keypair, require_tower)
+        AdminRpcImpl::set_identity_keypair(
+            meta,
+            identity_keypair,
+            require_tower,
+            require_vote_history,
+        )
     }
 
     fn set_staked_nodes_overrides(&self, meta: Self::Metadata, path: String) -> Result<()> {
@@ -812,6 +829,7 @@ impl AdminRpcImpl {
         meta: AdminRpcRequestMetadata,
         identity_keypair: Keypair,
         require_tower: bool,
+        require_vote_history: bool,
     ) -> Result<()> {
         meta.with_post_init(|post_init| {
             if require_tower {
@@ -823,6 +841,22 @@ impl AdminRpcImpl {
                             err
                         ))
                     })?;
+            }
+
+            if require_vote_history {
+                let _ = VoteHistory::restore(
+                    meta.vote_history_storage.as_ref(),
+                    &identity_keypair.pubkey(),
+                )
+                .map_err(|err| {
+                    jsonrpc_core::error::Error::invalid_params(format!(
+                        "Unable to load vote history file for identity {}: {}. Ensure the vote \
+                         history file is present or (dangerous) use --do-not-require-vote-history \
+                         if you know what you're doing",
+                        identity_keypair.pubkey(),
+                        err
+                    ))
+                })?;
             }
 
             for (key, notifier) in &*post_init.notifies.read().unwrap() {
@@ -1070,6 +1104,7 @@ mod tests {
                 validator_exit_backpressure: HashMap::default(),
                 authorized_voter_keypairs: Arc::new(RwLock::new(vec![vote_keypair])),
                 tower_storage: Arc::new(NullTowerStorage {}),
+                vote_history_storage: Arc::new(solana_votor::vote_history_storage::NullVoteHistoryStorage::default()),
                 post_init: Arc::new(RwLock::new(Some(AdminRpcRequestMetadataPostInit {
                     cluster_info,
                     bank_forks: bank_forks.clone(),
@@ -1443,7 +1478,7 @@ mod tests {
         let validator_id_bytes = format!("{:?}", expected_validator_id.to_bytes());
 
         let set_id_request = format!(
-            r#"{{"jsonrpc":"2.0","id":1,"method":"setIdentityFromBytes","params":[{validator_id_bytes}, false]}}"#,
+            r#"{{"jsonrpc":"2.0","id":1,"method":"setIdentityFromBytes","params":[{validator_id_bytes}, false, false]}}"#,
         );
         let response = io.handle_request_sync(&set_id_request, meta.clone());
         let actual_parsed_response: Value =
@@ -1521,6 +1556,9 @@ mod tests {
                 validator_exit_backpressure: HashMap::default(),
                 authorized_voter_keypairs: authorized_voter_keypairs.clone(),
                 tower_storage: Arc::new(NullTowerStorage {}),
+                vote_history_storage: Arc::new(
+                    solana_votor::vote_history_storage::NullVoteHistoryStorage::default(),
+                ),
                 post_init: post_init.clone(),
                 staked_nodes_overrides: Arc::new(RwLock::new(HashMap::new())),
                 rpc_to_plugin_manager_sender: None,
@@ -1592,7 +1630,7 @@ mod tests {
         let validator_id_bytes = format!("{:?}", expected_validator_id.to_bytes());
 
         let set_id_request = format!(
-            r#"{{"jsonrpc":"2.0","id":1,"method":"setIdentityFromBytes","params":[{validator_id_bytes}, false]}}"#,
+            r#"{{"jsonrpc":"2.0","id":1,"method":"setIdentityFromBytes","params":[{validator_id_bytes}, false, false]}}"#,
         );
         let response = test_validator.handle_request(&set_id_request);
         let actual_parsed_response: Value =

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -32,6 +32,7 @@ use {
     solana_streamer::socket::SocketAddrSpace,
     solana_system_interface::program as system_program,
     solana_test_validator::*,
+    solana_votor::vote_history_storage::FileVoteHistoryStorage,
     std::{
         collections::{HashMap, HashSet},
         fs, io,
@@ -408,6 +409,7 @@ fn main() {
         value_t!(matches, "transaction_account_lock_limit", usize).ok();
 
     let tower_storage = Arc::new(FileTowerStorage::new(ledger_path.clone()));
+    let vote_history_storage = Arc::new(FileVoteHistoryStorage::new(ledger_path.clone()));
 
     let admin_service_post_init = Arc::new(RwLock::new(None));
     // If geyser_plugin_config value is invalid, the validator will exit when the values are extracted below
@@ -430,6 +432,7 @@ fn main() {
             staked_nodes_overrides: genesis.staked_nodes_overrides.clone(),
             post_init: admin_service_post_init,
             tower_storage: tower_storage.clone(),
+            vote_history_storage: vote_history_storage.clone(),
             rpc_to_plugin_manager_sender,
         },
     );

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -719,6 +719,12 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .help("Refuse to start if saved tower state is not found"),
     )
     .arg(
+        clap::Arg::with_name("do_not_require_vote_history")
+            .long("do-not-require-vote-history")
+            .takes_value(false)
+            .help("Do not require saved vote history state for startup"),
+    )
+    .arg(
         Arg::with_name("expected_genesis_hash")
             .long("expected-genesis-hash")
             .value_name("HASH")

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -534,6 +534,7 @@ pub fn execute(
 
     let mut validator_config = ValidatorConfig {
         require_tower: matches.is_present("require_tower"),
+        require_vote_history: !matches.is_present("do_not_require_vote_history"),
         tower_storage,
         vote_history_storage,
         halt_at_slot: value_t!(matches, "dev_halt_at_slot", Slot).ok(),
@@ -732,6 +733,7 @@ pub fn execute(
             authorized_voter_keypairs: authorized_voter_keypairs.clone(),
             post_init: admin_service_post_init.clone(),
             tower_storage: validator_config.tower_storage.clone(),
+            vote_history_storage: validator_config.vote_history_storage.clone(),
             staked_nodes_overrides,
             rpc_to_plugin_manager_sender,
         },

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -554,8 +554,9 @@ impl EventHandler {
         if *my_pubkey != new_pubkey || vctx.vote_history.node_pubkey != new_pubkey {
             let my_old_pubkey = vctx.vote_history.node_pubkey;
             *my_pubkey = new_pubkey;
-            // The vote history file for the new identity must exist for set-identity to succeed
-            vctx.vote_history = VoteHistory::restore(ctx.vote_history_storage.as_ref(), my_pubkey)?;
+            // It is safe to create an empty vote history here, as implies the user set --do-not-require-vote-history
+            vctx.vote_history = VoteHistory::restore(ctx.vote_history_storage.as_ref(), my_pubkey)
+                .unwrap_or(VoteHistory::new(new_identity.pubkey(), 0));
             vctx.identity_keypair = new_identity.clone();
             warn!("set-identity: from {my_old_pubkey} to {my_pubkey}");
         }


### PR DESCRIPTION
Agave exposes a `--require-tower` argument for both startup and `set-identity` that enforces the tower file is present before allowing startup. If this argument is not present we populate a default `Tower`. We then have logic to pull the latest `Tower` from the `VoteAccount`. While not perfect this gives us some resilience against operator error resulting in slashable votes.

In Alpenglow we no longer have the backup option of pulling the `VoteHistory` from a `VoteAccount`. This method is imperfect anyway. Instead always require that a `VoteHistory` file is present on startup or when calling `set-identity`.

To accomodate for first time startups or `set-identity` to an unstaked identity (where voting won't happen anyway), plug in a `--do-not-require-vote-history` cli flag which creates a default `VoteHistory`. This essentially matches the `--require-tower` workflow with the opposite default. 

Sister PR to update invalidator https://github.com/anza-xyz/infra-invalidator/pull/192