### PR TITLE
migration: Send the GenesisVote when we discover the genesis block

### DIFF
--- a/votor-messages/src/migration.rs
+++ b/votor-messages/src/migration.rs
@@ -214,6 +214,11 @@ impl MigrationPhase {
     fn is_ready_to_enable(&self) -> bool {
         matches!(self, MigrationPhase::ReadyToEnable { .. })
     }
+
+    /// Check if we are in the migrationary period
+    fn is_in_migration(&self) -> bool {
+        matches!(self, MigrationPhase::Migration { .. })
+    }
 }
 
 /// Keeps track of the current migration status
@@ -333,6 +338,7 @@ impl MigrationStatus {
     dispatch!(pub fn should_respond_to_ancestor_hashes_requests(&self, slot: Slot) -> bool);
     dispatch!(pub fn is_full_alpenglow_epoch(&self) -> bool);
     dispatch!(pub fn is_pre_feature_activation(&self) -> bool);
+    dispatch!(pub fn is_in_migration(&self) -> bool);
 
     /// The alpenglow feature flag has been activated in slot `slot`.
     /// This should only be called using the feature account of a *rooted* slot,


### PR DESCRIPTION
Split from #502 

#### Problem
Once cluster info vote listener discovers the genesis block (future PR) we need to send out the `GenesisVote` for it.

#### Summary of Changes
In replay if alpenglow is yet to be enabled and we have discovered a genesis block, send the vote.
Refactored `voting_utils` to be accessible from replay by passing in arguments rather than the `VotingContext`

