### PR TITLE
migration: do not clone record receiver, get it from PoHService

### DIFF
--- a/core/src/banking_simulation.rs
+++ b/core/src/banking_simulation.rs
@@ -755,7 +755,7 @@ impl BankingSimulator {
         let transaction_recorder = TransactionRecorder::new(record_sender);
         let (poh_controller, poh_service_message_receiver) = PohController::new();
         let migration_status = Arc::new(MigrationStatus::default());
-        let (record_receiver_sender, _record_receiver_channel) = bounded(1);
+        let (record_receiver_sender, _record_receiver_receiver) = bounded(1);
         let poh_service = PohService::new(
             poh_recorder.clone(),
             &genesis_config.poh_config,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1416,7 +1416,7 @@ impl Validator {
 
         // Pass RecordReceiver from PohService to BlockCreationLoop when shutting down. Gives us a strong guarentee
         // that both block producers are not running at the same time
-        let (record_receiver_sender, record_receiver_channel) = bounded(1);
+        let (record_receiver_sender, record_receiver_receiver) = bounded(1);
 
         let poh_service = PohService::new(
             poh_recorder.clone(),
@@ -1433,7 +1433,6 @@ impl Validator {
 
         let block_creation_loop_config = BlockCreationLoopConfig {
             exit: exit.clone(),
-            migration_status: migration_status.clone(),
             bank_forks: bank_forks.clone(),
             blockstore: blockstore.clone(),
             cluster_info: cluster_info.clone(),
@@ -1444,7 +1443,7 @@ impl Validator {
             slot_status_notifier: slot_status_notifier.clone(),
             leader_window_notifier: leader_window_notifier.clone(),
             replay_highest_frozen: replay_highest_frozen.clone(),
-            record_receiver_channel,
+            record_receiver_receiver,
         };
         let block_creation_loop = BlockCreationLoop::new(block_creation_loop_config);
 

--- a/poh/benches/transaction_recorder.rs
+++ b/poh/benches/transaction_recorder.rs
@@ -79,7 +79,7 @@ fn bench_record_transactions(c: &mut Criterion) {
     let (mut poh_controller, poh_service_receiver) = PohController::new();
     let poh_recorder = Arc::new(RwLock::new(poh_recorder));
     let migration_status = Arc::new(MigrationStatus::default());
-    let (record_receiver_sender, _record_receiver_channel) = bounded(1);
+    let (record_receiver_sender, _record_receiver_receiver) = bounded(1);
     let poh_service = PohService::new(
         poh_recorder.clone(),
         &genesis_config_info.genesis_config.poh_config,

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -1023,7 +1023,7 @@ fn do_create_test_recorder(
     let transaction_recorder = TransactionRecorder::new(record_sender);
     let poh_recorder = Arc::new(RwLock::new(poh_recorder));
     let (mut poh_controller, poh_service_message_receiver) = PohController::new();
-    let (record_receiver_sender, _record_receiver_channel) = bounded(1);
+    let (record_receiver_sender, _record_receiver_receiver) = bounded(1);
     let poh_service = PohService::new(
         poh_recorder.clone(),
         &poh_config,

--- a/poh/src/poh_service.rs
+++ b/poh/src/poh_service.rs
@@ -178,7 +178,7 @@ impl PohService {
 
                 // Pass the RecordReceiver to BlockCreationLoop,
                 if let Err(e) = record_receiver_sender.send(record_receiver) {
-                    info!("Unable to send record receiver, shutting down {e:}");
+                    error!("Unable to send record receiver, shutting down {e:}");
                     return;
                 }
 
@@ -809,7 +809,7 @@ mod tests {
             .unwrap_or(DEFAULT_HASHES_PER_BATCH);
         let (_record_sender, record_receiver) = record_channels(false);
         let (_poh_controller, poh_service_message_receiver) = PohController::new();
-        let (record_receiver_sender, _record_receiver_channel) = bounded(1);
+        let (record_receiver_sender, _record_receiver_receiver) = bounded(1);
         let poh_service = PohService::new(
             poh_recorder.clone(),
             &poh_config,


### PR DESCRIPTION
One more before we upstream BCL (I swear).

Andrew gave feedback that `RecordReceiver` is not really safe to clone, and instead sending it over a channel when `PohService` shuts down is preferred. Also gives us a strong guarantee that we're not building blocks with both. 