### PR TITLE
migration: cleanup unreachables in migration_status, set pubkey

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -731,6 +731,7 @@ impl ReplayStage {
                     };
                     warn!("Identity changed during startup from {my_old_pubkey} to {my_pubkey}");
                 }
+                migration_status.set_pubkey(my_pubkey);
             }
             let (mut progress, heaviest_subtree_fork_choice) =
                 Self::initialize_progress_and_fork_choice_with_locked_bank_forks(
@@ -1231,6 +1232,7 @@ impl ReplayStage {
                                 identity_keypair = cluster_info.keypair().clone();
                                 let my_old_pubkey = my_pubkey;
                                 my_pubkey = identity_keypair.pubkey();
+                                migration_status.set_pubkey(my_pubkey);
 
                                 // Load the new identity's tower
                                 tower = match Self::load_tower(
@@ -1415,7 +1417,7 @@ impl ReplayStage {
     /// - Shutdown poh
     /// - Start block creation loop and Votor
     ///
-    /// Should only be called if we have received a genesis certificate on our view of the genesis block.
+    /// Should only be called if we're in `ReadyToEnable`
     #[allow(clippy::too_many_arguments)]
     fn enable_alpenglow(
         exit: &AtomicBool,
@@ -1432,7 +1434,9 @@ impl ReplayStage {
     ) {
         let root_bank = bank_forks.read().unwrap().root_bank();
 
-        let genesis_block @ (genesis_slot, block_id) = migration_status.genesis_block();
+        let genesis_block @ (genesis_slot, block_id) = migration_status
+            .genesis_block()
+            .expect("Must be ready to enable");
         warn!(
             "{my_pubkey}: Alpenglow genesis vote has succeeded enabling alpenglow. Genesis block \
              {genesis_block:?}"
@@ -4027,7 +4031,8 @@ impl ReplayStage {
                     if parent_is_super_oc
                         && migration_status.qualifies_for_genesis_discovery(bank_slot)
                     {
-                        let migration_slot = migration_status.migration_slot();
+                        let migration_slot =
+                            migration_status.migration_slot().expect("In migration");
                         // We have a block whose ancestor qualifies to be the genesis block.
                         let genesis_slot = ancestors
                             .get(&bank_slot)

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -895,6 +895,7 @@ impl Validator {
         cluster_info.set_bind_ip_addrs(node.bind_ip_addrs.clone());
         let cluster_info = Arc::new(cluster_info);
         let node_multihoming = Arc::new(NodeMultihoming::from(&node));
+        migration_status.set_pubkey(cluster_info.id());
 
         assert!(is_snapshot_config_valid(&config.snapshot_config));
 

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -15,7 +15,6 @@ use {
     solana_hash::Hash,
     solana_measure::measure::Measure,
     solana_program_runtime::loaded_programs::{BlockRelation, ForkGraph},
-    solana_pubkey::Pubkey,
     solana_unified_scheduler_logic::SchedulingMode,
     solana_votor_messages::migration::MigrationStatus,
     std::{
@@ -185,13 +184,7 @@ impl BankForks {
             .activated_slot(&agave_feature_set::alpenglow::id());
         let genesis_cert = root_bank.get_alpenglow_genesis_certificate();
 
-        MigrationStatus::initialize(
-            Pubkey::default(),
-            root_epoch,
-            ff_activation_slot,
-            genesis_cert,
-            epoch_schedule,
-        )
+        MigrationStatus::initialize(root_epoch, ff_activation_slot, genesis_cert, epoch_schedule)
     }
 
     pub fn banks(&self) -> &HashMap<Slot, BankWithScheduler> {

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -221,7 +221,10 @@ impl ConsensusPoolService {
             // - When we first migrate to alpenglow from TowerBFT - kick off with genesis block
             // - If we startup post alpenglow migration - kick off with root block
             if !kick_off_parent_ready && ctx.migration_status.is_alpenglow_enabled() {
-                let genesis_block = ctx.migration_status.genesis_block();
+                let genesis_block = ctx
+                    .migration_status
+                    .genesis_block()
+                    .expect("Alpenglow is enabled");
                 let root_bank = ctx.sharable_banks.root();
                 // can expect once we have block id in snapshots (SIMD-0333)
                 let root_block = (root_bank.slot(), root_bank.block_id().unwrap_or_default());


### PR DESCRIPTION
Follow up from carl's suggestions here https://github.com/anza-xyz/alpenglow/pull/589#discussion_r2504498349

Also i'm too lazy to plumb pubkey into the startup call chain (lots of code churn for something that will be removed) - add a `set_pubkey` and use it after startup / during set-identity