### PR TITLE
fast leader handover: only notify frozen slots with valid banks

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -33,6 +33,7 @@ use {
         window_service::DuplicateSlotReceiver,
     },
     crossbeam_channel::{Receiver, RecvTimeoutError, Sender},
+    itertools::Itertools,
     rayon::{
         iter::{IntoParallelIterator, ParallelIterator},
         ThreadPool,
@@ -873,6 +874,7 @@ impl ReplayStage {
                         new_frozen_slots
                             .iter()
                             .filter_map(|slot| bank_forks_r.get(*slot))
+                            .collect_vec()
                     };
                     for bank in fast_leader_handover_notifies {
                         Self::maybe_notify_of_optimistic_parent(


### PR DESCRIPTION
#### Problem and Summary of Changes
In replay, we currently hard unwrap to access banks for fast leader handover optimistic parent notification. These banks may not exist if the latest rooted slot is past the slot we're analyzing.

Accordingly, we should only process banks that exist in bank forks.