### PR TITLE
block_component: Add GenesisCertificate block marker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8379,6 +8379,7 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "serde",
+ "solana-bls-signatures",
  "solana-clock",
  "solana-entry",
  "solana-hash",
@@ -8398,6 +8399,7 @@ dependencies = [
  "solana-system-transaction",
  "solana-transaction",
  "solana-transaction-error",
+ "solana-votor-messages",
  "thiserror 2.0.16",
 ]
 

--- a/entry/Cargo.toml
+++ b/entry/Cargo.toml
@@ -28,6 +28,7 @@ num_cpus = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true }
+solana-bls-signatures = { workspace = true }
 solana-clock = { workspace = true }
 solana-hash = { workspace = true }
 solana-measure = { workspace = true }
@@ -39,6 +40,7 @@ solana-runtime-transaction = { workspace = true }
 solana-sha256-hasher = { workspace = true }
 solana-transaction = { workspace = true }
 solana-transaction-error = { workspace = true }
+solana-votor-messages = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/runtime/src/block_component_processor.rs
+++ b/runtime/src/block_component_processor.rs
@@ -87,6 +87,8 @@ impl BlockComponentProcessor {
             BlockMarkerV1::BlockHeader(header) => self.on_header(header),
             // We process UpdateParent messages on shred ingest, so no callback needed here
             BlockMarkerV1::UpdateParent(_) => Ok(()),
+            // TODO(ashwin): update genesis certificate account / ticks
+            BlockMarkerV1::GenesisCertificate(_) => Ok(()),
         }?;
 
         if is_final {


### PR DESCRIPTION
#### Problem
We need some method to indicate the first Alpenglow block post migration

#### Summary of Changes
Add a block marker that will only be disseminated on the first alpenglow block (direct child of genesis).
This block marker holds the `GenesisCertificate`.

Future PR will populate this in BCL and process it in replay to update the genesis account.

Full details of migration in SIMD https://github.com/solana-foundation/solana-improvement-documents/pull/384/files#diff-9a9498ea503301d23f7af15f620fcb53b060f666419c9214a3fe72ff465affd9R118
