### PR TITLE
fast leader handover: populate `ParentMeta` children

### DIFF
--- a/ledger/src/blockstore/column.rs
+++ b/ledger/src/blockstore/column.rs
@@ -288,6 +288,15 @@ pub mod columns {
     /// * index type: `(Slot, BlockLocation)`
     /// * value type: [`blockstore_meta::ParentMeta`]
     pub struct ParentMeta;
+
+    #[derive(Debug)]
+    /// The pending next slots metadata column
+    ///
+    /// This column stores the children (next slots) for each slot and block location.
+    ///
+    /// * index type: `(Slot, BlockLocation)`
+    /// * value type: [`blockstore_meta::PendingNextSlotsMeta`]
+    pub struct PendingNextSlotsMeta;
 }
 
 macro_rules! convert_column_index_to_key_bytes {
@@ -1117,4 +1126,53 @@ impl ColumnName for columns::ParentMeta {
 
 impl TypedColumn for columns::ParentMeta {
     type Type = blockstore_meta::ParentMeta;
+}
+
+impl Column for columns::PendingNextSlotsMeta {
+    type Index = (Slot, BlockLocation);
+    // Key size: Slot (8 bytes) + Hash (32 bytes)
+    // When BlockLocation::Original, the hash is Hash::default().
+    type Key = [u8; std::mem::size_of::<Slot>() + HASH_BYTES];
+
+    #[inline]
+    fn key((slot, location): &Self::Index) -> Self::Key {
+        let mut key = [0u8; std::mem::size_of::<Slot>() + HASH_BYTES];
+        key[..8].copy_from_slice(&slot.to_le_bytes());
+
+        let hash_bytes = match location {
+            BlockLocation::Original => &Hash::default().to_bytes(),
+            BlockLocation::Alternate { block_id } => &block_id.to_bytes(),
+        };
+
+        key[8..40].copy_from_slice(hash_bytes);
+
+        key
+    }
+
+    fn index(key: &[u8]) -> Self::Index {
+        let slot = Slot::from_le_bytes(key[0..8].try_into().unwrap());
+        let hash = Hash::new_from_array(key[8..40].try_into().unwrap());
+        let location = match hash == Hash::default() {
+            true => BlockLocation::Original,
+            false => BlockLocation::Alternate { block_id: hash },
+        };
+
+        (slot, location)
+    }
+
+    fn as_index(slot: Slot) -> Self::Index {
+        (slot, BlockLocation::Original)
+    }
+
+    fn slot((slot, _location): Self::Index) -> Slot {
+        slot
+    }
+}
+
+impl ColumnName for columns::PendingNextSlotsMeta {
+    const NAME: &'static str = "pending_next_slots_meta";
+}
+
+impl TypedColumn for columns::PendingNextSlotsMeta {
+    type Type = blockstore_meta::PendingNextSlotsMeta;
 }

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -201,6 +201,7 @@ impl Rocks {
             new_cf_descriptor::<columns::AlternateShredData>(options, oldest_slot),
             new_cf_descriptor::<columns::AlternateMerkleRootMeta>(options, oldest_slot),
             new_cf_descriptor::<columns::ParentMeta>(options, oldest_slot),
+            new_cf_descriptor::<columns::PendingNextSlotsMeta>(options, oldest_slot),
         ];
 
         // If the access type is Secondary, we don't need to open all of the
@@ -249,7 +250,7 @@ impl Rocks {
         cf_descriptors
     }
 
-    const fn columns() -> [&'static str; 27] {
+    const fn columns() -> [&'static str; 28] {
         [
             columns::ErasureMeta::NAME,
             columns::DeadSlots::NAME,
@@ -278,6 +279,7 @@ impl Rocks {
             columns::AlternateShredData::NAME,
             columns::AlternateMerkleRootMeta::NAME,
             columns::ParentMeta::NAME,
+            columns::PendingNextSlotsMeta::NAME,
         ]
     }
 

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -435,7 +435,7 @@ pub struct BlockVersions {
 }
 
 /// Which column an associated block currently resides
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum BlockLocation {
     Original,
     Alternate { block_id: Hash },
@@ -979,11 +979,12 @@ impl OptimisticSlotMetaVersioned {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 pub struct ParentMeta {
     pub parent_slot: Slot,
     pub parent_block_id: Hash,
     pub replay_fec_set_index: u32,
+    pub children: Vec<(Slot, BlockLocation)>,
 }
 
 impl ParentMeta {
@@ -998,6 +999,11 @@ impl ParentMeta {
     pub fn block(&self) -> (Slot, Hash) {
         (self.parent_slot, self.parent_block_id)
     }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct PendingNextSlotsMeta {
+    pub children: Vec<(Slot, BlockLocation)>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
#### Problem and Summary of Changes
During Alpenglow, validators will receive `BlockComponent`s which will result in a changing parent:

- `BlockHeader`: sets the initial block parent
- `UpdateParent`: switches the parent according to Alpenglow fast leader handover protocol

These components currently fit within one shred each. On each shred's arrival, we need to maintain the full tree of parent and children relationships. While `ParentMeta` maintains parent relationships, this PR introduces children relationships, essential for `generate_new_bank_forks`.

In addition to extending `ParentMeta` with a `children` field, we introduce a `PendingNextSlotsMeta` column to track children for blocks awaiting parent metadata, i.e., blocks that aren't yet in the `ParentMeta` column.