### PR TITLE
migration: hold shred lock while purging blockstore

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -47,7 +47,7 @@ use {
     solana_keypair::Keypair,
     solana_ledger::{
         block_error::BlockError,
-        blockstore::{Blockstore, PurgeType},
+        blockstore::Blockstore,
         blockstore_processor::{
             self, BlockstoreProcessorError, ConfirmationProgress, ExecuteBatchesInternalMetrics,
             ReplaySlotStats, TransactionStatusSender,
@@ -1503,8 +1503,7 @@ impl ReplayStage {
             .expect("Highest slot must be present as blockstore is non-empty");
         if end_slot >= start_slot {
             warn!("{my_pubkey}: Purging shreds {start_slot} to {end_slot} from blockstore");
-            blockstore.purge_from_next_slots(start_slot, end_slot);
-            blockstore.purge_slots(start_slot, end_slot, PurgeType::Exact);
+            blockstore.clear_unconfirmed_slots(start_slot, end_slot);
         }
 
         migration_status.enable_alpenglow(exit);


### PR DESCRIPTION
#### Problem
Noticed some very rare flakiness in migration local-cluster tests where one node was running behind:
- The slow node attempts to enable alpenglow and purges its blockstore columns
- During the process of purging a new shred from an Alpenglow block is ingested
- Since the purge is not being done atomically, the `SlotMeta` can end up in a state that is inconsistent
- Specifically seeing situations where `parent_slot` is set for the child block, but `next_slots` for the parent does not point to the child block.

#### Summary of Changes
The original purge logic was copied from the startup process that cleans up shreds with incorrect shred versions. This is sound because window service has not yet started so there's no race.

Instead replace it with logic similar to dump & repair, which takes care to acquire the shred insertion lock to ensure that window service is not inserting shreds at the same time.