### PR TITLE
migration: turn off OC verifier during migration

### DIFF
--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -371,8 +371,14 @@ impl ClusterInfoVoteListener {
             );
             match confirmed_slots {
                 Ok(confirmed_slots) => {
+                    let confirmed_slots = confirmed_slots
+                        .into_iter()
+                        .filter(|(slot, _)| {
+                            migration_status.should_report_commitment_or_root(*slot)
+                        })
+                        .collect();
                     confirmation_verifier
-                        .add_new_optimistic_confirmed_slots(confirmed_slots.clone(), &blockstore);
+                        .add_new_optimistic_confirmed_slots(confirmed_slots, &blockstore);
                 }
                 Err(e) => match e {
                     Error::RecvTimeout(RecvTimeoutError::Disconnected) => {


### PR DESCRIPTION
#### Problem
Although we turned off reporting OC to RPC, we still verify that all OC slots are eventually rooted even during the migration.
This causes `ERROR` logs to be printed which might confuse users.

#### Summary of Changes
Also gate the OC verification logic by migration status
