### PR TITLE
fast leader handover: validator configs for local cluster tests

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -299,6 +299,7 @@ pub struct ReplayStageConfig {
     pub consensus_metrics_sender: ConsensusMetricsEventSender,
     pub consensus_metrics_receiver: ConsensusMetricsEventReceiver,
     pub migration_status: Arc<MigrationStatus>,
+    pub skip_final_block_of_leader_window: Arc<AtomicBool>,
 }
 
 pub struct ReplaySenders {
@@ -620,6 +621,7 @@ impl ReplayStage {
             consensus_metrics_sender,
             consensus_metrics_receiver,
             migration_status,
+            skip_final_block_of_leader_window,
         } = config;
 
         let ReplaySenders {
@@ -694,6 +696,7 @@ impl ReplayStage {
             consensus_metrics_sender,
             consensus_metrics_receiver,
             migration_status: migration_status.clone(),
+            skip_final_block_of_leader_window,
         };
         let votor = Votor::new(votor_config);
 

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -210,6 +210,7 @@ impl Tvu {
         voting_service_test_override: Option<VotingServiceOverride>,
         votor_event_sender: VotorEventSender,
         votor_event_receiver: VotorEventReceiver,
+        skip_final_block_of_leader_window: Arc<AtomicBool>,
         optimistic_parent_sender: Sender<LeaderWindowInfo>,
         alpenglow_quic_server_config: QuicServerParams,
         staked_nodes: Arc<RwLock<StakedNodes>>,
@@ -449,6 +450,7 @@ impl Tvu {
             consensus_metrics_sender: consensus_metrics_sender.clone(),
             consensus_metrics_receiver,
             migration_status,
+            skip_final_block_of_leader_window,
         };
 
         let voting_service = VotingService::new(
@@ -753,6 +755,7 @@ pub mod tests {
             None,
             votor_event_sender,
             votor_event_receiver,
+            Arc::new(AtomicBool::new(false)),
             optimistic_parent_sender,
             QuicServerParams::default_for_tests(),
             Arc::new(RwLock::new(StakedNodes::default())),

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -343,6 +343,7 @@ pub struct ValidatorConfig {
     pub retransmit_xdp: Option<XdpConfig>,
     pub voting_service_test_override: Option<VotingServiceOverride>,
     pub repair_handler_type: RepairHandlerType,
+    pub skip_final_block_of_leader_window: Arc<AtomicBool>,
 }
 
 impl ValidatorConfig {
@@ -428,6 +429,7 @@ impl ValidatorConfig {
             retransmit_xdp: None,
             repair_handler_type: RepairHandlerType::default(),
             voting_service_test_override: None,
+            skip_final_block_of_leader_window: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -1703,6 +1705,7 @@ impl Validator {
             config.voting_service_test_override.clone(),
             votor_event_sender.clone(),
             votor_event_receiver,
+            config.skip_final_block_of_leader_window.clone(),
             optimistic_parent_sender,
             alpenglow_quic_server_config,
             staked_nodes.clone(),

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -84,6 +84,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         retransmit_xdp: config.retransmit_xdp.clone(),
         voting_service_test_override: config.voting_service_test_override.clone(),
         repair_handler_type: config.repair_handler_type.clone(),
+        skip_final_block_of_leader_window: config.skip_final_block_of_leader_window.clone(),
     }
 }
 

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -644,6 +644,7 @@ pub fn execute(
             Arc::new(AtomicBool::new(false)),
         )]
         .into(),
+        skip_final_block_of_leader_window: Arc::new(AtomicBool::new(false)),
     };
 
     let reserved = validator_config

--- a/votor/src/voting_utils.rs
+++ b/votor/src/voting_utils.rs
@@ -21,7 +21,10 @@ use {
         consensus_message::{ConsensusMessage, VoteMessage, BLS_KEYPAIR_DERIVE_SEED},
         vote::Vote,
     },
-    std::{collections::HashMap, sync::Arc},
+    std::{
+        collections::HashMap,
+        sync::{atomic::AtomicBool, Arc},
+    },
     thiserror::Error,
 };
 
@@ -124,6 +127,9 @@ pub struct VotingContext {
     pub wait_to_vote_slot: Option<u64>,
     pub sharable_banks: SharableBanks,
     pub consensus_metrics_sender: ConsensusMetricsEventSender,
+
+    // Testing
+    pub skip_final_block_of_leader_window: Arc<AtomicBool>,
 }
 
 fn get_bls_keypair(
@@ -389,6 +395,7 @@ mod tests {
             wait_to_vote_slot: None,
             sharable_banks,
             consensus_metrics_sender: unbounded().0,
+            skip_final_block_of_leader_window: Arc::new(AtomicBool::new(false)),
         }
     }
 

--- a/votor/src/votor.rs
+++ b/votor/src/votor.rs
@@ -116,6 +116,9 @@ pub struct VotorConfig {
     pub event_receiver: VotorEventReceiver,
     pub consensus_message_receiver: Receiver<ConsensusMessage>,
     pub consensus_metrics_receiver: ConsensusMetricsEventReceiver,
+
+    // Testing
+    pub skip_final_block_of_leader_window: Arc<AtomicBool>,
 }
 
 /// Context shared with block creation, replay, gossip, banking stage etc
@@ -164,6 +167,7 @@ impl Votor {
             consensus_message_receiver: bls_receiver,
             consensus_metrics_sender,
             consensus_metrics_receiver,
+            skip_final_block_of_leader_window,
         } = config;
 
         let identity_keypair = cluster_info.keypair().clone();
@@ -195,6 +199,7 @@ impl Votor {
             wait_to_vote_slot,
             sharable_banks: sharable_banks.clone(),
             consensus_metrics_sender: consensus_metrics_sender.clone(),
+            skip_final_block_of_leader_window,
         };
 
         let root_context = RootContext {


### PR DESCRIPTION
#### Problem and Summary of Changes
We need to test fast leader handover behavior in local cluster tests.

We expose a flag that, when active for a validator, votes skip for a slot when `slot % 4 == 3` after replay. This will allow us to write local cluster tests for the case in fast leader handover wherea parent switch occurs via `UpdateParent`.