### PR TITLE
fast leader handover: use `ParentMeta` to update `SlotMeta` `next_slots`

### DIFF
--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -748,6 +748,15 @@ impl SlotMeta {
         self.is_connected()
     }
 
+    /// Clear the meta's parent_connected and connected flags.
+    /// Returns true if the meta was connected, indicating children need clearing.
+    pub fn clear_parent_connected(&mut self) -> bool {
+        let originally_connected = self.is_connected();
+        self.connected_flags
+            .remove(ConnectedFlags::PARENT_CONNECTED | ConnectedFlags::CONNECTED);
+        originally_connected
+    }
+
     /// Dangerous.
     #[cfg(feature = "dev-context-only-utils")]
     pub fn unset_parent(&mut self) {


### PR DESCRIPTION
#### Problem and Summary of Changes
As `UpdateParent` and `BlockHeader` components filter in, we need to update:

- parent information in `SlotMeta`
- the `next_slots` field for `SlotMeta` to enable `generate_new_bank_forks` to work in replay

This is important to allow non-leaders to process `UpdateParent`s during a parent switch in fast leader handover.