### PR TITLE
fast leader handover: migration interactions

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -870,7 +870,6 @@ impl ReplayStage {
                     &votor_event_sender,
                 );
                 let did_complete_bank = !new_frozen_slots.is_empty();
-
                 if migration_status.is_alpenglow_enabled() {
                     let fast_leader_handover_notifies = {
                         let bank_forks_r = bank_forks.read().unwrap();

--- a/votor-messages/src/migration.rs
+++ b/votor-messages/src/migration.rs
@@ -45,7 +45,7 @@
 use {
     crate::consensus_message::{Block, Certificate, CertificateType},
     log::*,
-    solana_clock::{Epoch, Slot, NUM_CONSECUTIVE_LEADER_SLOTS},
+    solana_clock::{Epoch, Slot},
     solana_epoch_schedule::EpochSchedule,
     spl_pod::solana_pubkey::Pubkey,
     std::{
@@ -255,8 +255,7 @@ impl MigrationPhase {
 
     /// Should this block allow the UpdateParent marker, i.e., support fast leader handover?
     fn should_allow_fast_leader_handover(&self, slot: Slot) -> bool {
-        // Only allow for alpenglow blocks, 2 leader windows after after migration
-        self.is_alpenglow_block(slot.saturating_sub(2 * NUM_CONSECUTIVE_LEADER_SLOTS))
+        self.is_alpenglow_block(slot)
     }
 
     /// Should this block use the double merkle root as the block id (instead of chained merkle root)?


### PR DESCRIPTION
#### Problem and Summary of Changes
We need to enable fast leader handover some short period after Alpenglow migration.

This PR prevents optimistic parents from being sent via replay until said short period has transpired. This prevention forces leaders to have to wait for parent ready events in consensus.