### PR TITLE
fast leader handover: factor out shutdown and drain record receiver

### DIFF
--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -416,6 +416,27 @@ fn produce_block_footer(bank: Arc<Bank>) -> BlockFooterV1 {
     }
 }
 
+/// Shutdowns the record receiver and drains any remaining records.
+fn shutdown_and_drain_record_receiver(
+    poh_recorder: &RwLock<PohRecorder>,
+    record_receiver: &mut RecordReceiver,
+) -> Result<(), PohRecorderError> {
+    record_receiver.shutdown();
+
+    while !record_receiver.is_safe_to_restart() {
+        let Ok(record) = record_receiver.recv_timeout(Duration::ZERO) else {
+            continue;
+        };
+        poh_recorder.write().unwrap().record(
+            record.slot,
+            record.mixins,
+            record.transaction_batches,
+        )?;
+    }
+
+    Ok(())
+}
+
 /// Records incoming transactions until we reach the block timeout.
 /// Afterwards:
 /// - Shutdown the record receiver
@@ -447,17 +468,7 @@ fn record_and_complete_block(
 
     // Shutdown and clear any inflight records
     // TODO: do we need to lower the block timeout from 400ms to account for this / insertion of the block footer
-    record_receiver.shutdown();
-    while !record_receiver.is_safe_to_restart() {
-        let Ok(record) = record_receiver.recv_timeout(Duration::ZERO) else {
-            continue;
-        };
-        poh_recorder.write().unwrap().record(
-            record.slot,
-            record.mixins,
-            record.transaction_batches,
-        )?;
-    }
+    shutdown_and_drain_record_receiver(poh_recorder, record_receiver)?;
 
     // Alpentick and clear bank
     let mut w_poh_recorder = poh_recorder.write().unwrap();


### PR DESCRIPTION
#### Problem and Summary of Changes
We're going to be using the "shutdown and drain record receiver" logic in a few places within fast leader handover - factor this code out.