### PR TITLE
fast leader handover: `UpdateParent` events in `BlockComponentProcessor`

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1548,10 +1548,10 @@ pub fn confirm_slot(
                 let slot_full = slot_full && ix == last_entry_batch_index.unwrap();
 
                 // Skip block component validation for genesis block. Slot 0 is handled specially,
-                // since it won't have the required block markers (e.g., the header and the footer).
+                // since it won't have the required block markers.
                 if bank.slot() != 0 {
                     processor
-                        .on_entry_batch(migration_status, is_final)
+                        .on_entry_batch(migration_status)
                         .inspect_err(|err| {
                             warn!("Block component processing failed for slot {slot}: {err:?}",);
                         })?;
@@ -1581,7 +1581,6 @@ pub fn confirm_slot(
                             parent_bank,
                             marker,
                             migration_status,
-                            is_final,
                         )
                         .inspect_err(|err| {
                             warn!("Block component processing failed for slot {slot}: {err:?}",);
@@ -1589,6 +1588,12 @@ pub fn confirm_slot(
                 }
                 progress.num_shreds += num_shreds as u64;
             }
+        }
+
+        // Skip block component validation for genesis block. Slot 0 is handled specially,
+        // since it won't have the required block markers.
+        if is_final && bank.slot() != 0 {
+            processor.on_final(migration_status, bank.slot())?;
         }
     }
 


### PR DESCRIPTION
#### Problem and Summary of Changes
We need to slightly rework how we process `BlockComponent`s in `BlockComponentProcessor` to work with fast leader handover:

**Case (1): the first component we process is a `BlockHeader`**
- Process one component at a time
- If we run into an `UpdateParent`, then return an `AbandonedBank` error
- In a separate PR, replay will clear the bank, resetting `BlockComponentProcessor`'s state
- `generate_new_bank_forks` picks up the new bank on the next iteration of the replay loop
- We intentionally don't update the progress bar, resuming from the `UpdateParent`. We then end up in case (2) below.

**Case (2): the first component we process is an `UpdateParent`**
- Because the *first* component we process is an `UpdateParent`, we don't return an `AbandonedBank` error. Instead, we keep processing events.
- We eventually get to the block footer.
- We run `is_final` checks at the end, and we're all set.

This PR implements the bullet points for the above logic.