### PR TITLE
votor: avoid floats in favor of ints

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -41,8 +41,7 @@ use {
             MAX_LOCKOUT_HISTORY,
         },
     },
-    solana_votor::fraction::Fraction,
-    solana_votor_messages::migration::GENESIS_VOTE_THRESHOLD,
+    solana_votor_messages::{fraction::Fraction, migration::GENESIS_VOTE_THRESHOLD},
     std::{
         cmp::Ordering,
         collections::{HashMap, HashSet},
@@ -510,7 +509,7 @@ impl Tower {
 
         let parent_is_super_oc = bank_slot == parent_slot + 1
             && Fraction::new(super_oc_stake, NonZeroU64::new(total_stake).unwrap())
-                > Fraction::from_percentage(GENESIS_VOTE_THRESHOLD);
+                > GENESIS_VOTE_THRESHOLD;
 
         // TODO: populate_ancestor_voted_stakes only adds zeros. Comment why
         // that is necessary (if so).

--- a/votor-messages/src/fraction.rs
+++ b/votor-messages/src/fraction.rs
@@ -1,5 +1,8 @@
+//! Fraction type for precise stake threshold comparisons.
+
 use std::num::NonZeroU64;
 
+/// Numerator / denominator, for precise comparisons without floating point.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Fraction {
     numerator: u64,
@@ -7,6 +10,7 @@ pub struct Fraction {
 }
 
 impl Fraction {
+    /// Creates a new fraction.
     #[inline]
     pub const fn new(numerator: u64, denominator: NonZeroU64) -> Self {
         Self {
@@ -15,10 +19,16 @@ impl Fraction {
         }
     }
 
+    /// Creates a fraction from a percentage (e.g. 60 -> 60/100).
     #[inline]
     pub const fn from_percentage(pct: u64) -> Self {
         // SAFETY: 100 != 0
         Self::new(pct, unsafe { NonZeroU64::new_unchecked(100) })
+    }
+
+    /// Approximates this fraction as an f64.
+    pub fn approx_f64(&self) -> f64 {
+        self.numerator as f64 / self.denominator.get() as f64
     }
 }
 

--- a/votor-messages/src/lib.rs
+++ b/votor-messages/src/lib.rs
@@ -3,6 +3,7 @@
 #![deny(missing_docs)]
 
 pub mod consensus_message;
+pub mod fraction;
 pub mod migration;
 pub mod vote;
 

--- a/votor-messages/src/migration.rs
+++ b/votor-messages/src/migration.rs
@@ -69,14 +69,16 @@ pub const MIGRATION_SLOT_OFFSET: Slot = 5000;
 #[cfg(feature = "dev-context-only-utils")]
 pub const MIGRATION_SLOT_OFFSET: Slot = 32;
 
+use crate::fraction::Fraction;
+
 /// We match Alpenglow's 20 + 20 model, by allowing a maximum of 20% malicious stake during the migration.
-pub const MIGRATION_MALICIOUS_THRESHOLD: u64 = 20;
+pub const MIGRATION_MALICIOUS_THRESHOLD: Fraction = Fraction::from_percentage(20);
 
 /// In order to rollback a block eligible for genesis vote, we need:
 /// `SWITCH_FORK_THRESHOLD` - (1 - `GENESIS_VOTE_THRESHOLD`) = `MIGRATION_MALICIOUS_THRESHOLD` malicious stake.
 ///
 /// Using 38% as the `SWITCH_FORK_THRESHOLD` gives us 82% for `GENESIS_VOTE_THRESHOLD`.
-pub const GENESIS_VOTE_THRESHOLD: u64 = 82;
+pub const GENESIS_VOTE_THRESHOLD: Fraction = Fraction::from_percentage(82);
 
 /// The interval at which we refresh our genesis vote
 pub const GENESIS_VOTE_REFRESH: Duration = Duration::from_millis(400);
@@ -516,7 +518,7 @@ impl MigrationStatus {
             .map(|b| *b != (slot, block_id))
             .unwrap_or(true)
         {
-            let genesis_vote_thresh_f64 = GENESIS_VOTE_THRESHOLD as f64 / 100.0;
+            let genesis_vote_thresh_f64 = GENESIS_VOTE_THRESHOLD.approx_f64();
             panic!(
                 "{}: We wish to cast a genesis vote on {discovered_genesis_block:?}, however we \
                  have received a genesis certificate for ({slot}, {block_id}). This means there \
@@ -567,7 +569,7 @@ impl MigrationStatus {
             return;
         };
         if *genesis_block != (slot, block_id) {
-            let genesis_vote_thresh_f64 = GENESIS_VOTE_THRESHOLD as f64 / 100.0;
+            let genesis_vote_thresh_f64 = GENESIS_VOTE_THRESHOLD.approx_f64();
             panic!(
                 "{}: We cast a genesis vote on {genesis_block:?}, however we have received a \
                  genesis certificate for ({slot}, {block_id}). This means there is significant \

--- a/votor/src/common.rs
+++ b/votor/src/common.rs
@@ -1,7 +1,7 @@
 use {
-    crate::fraction::Fraction,
     solana_votor_messages::{
         consensus_message::CertificateType,
+        fraction::Fraction,
         migration::GENESIS_VOTE_THRESHOLD,
         vote::{Vote, VoteType},
     },
@@ -53,10 +53,7 @@ pub const fn certificate_limits_and_vote_types(
             Fraction::from_percentage(60),
             &[VoteType::Skip, VoteType::SkipFallback],
         ),
-        CertificateType::Genesis(_, _) => (
-            Fraction::from_percentage(GENESIS_VOTE_THRESHOLD),
-            &[VoteType::Genesis],
-        ),
+        CertificateType::Genesis(_, _) => (GENESIS_VOTE_THRESHOLD, &[VoteType::Genesis]),
     }
 }
 

--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -12,7 +12,6 @@ use {
             vote_pool::{DuplicateBlockVotePool, SimpleVotePool, VotePool},
         },
         event::VotorEvent,
-        fraction::Fraction,
     },
     certificate_builder::{BuildError as CertificateBuildError, CertificateBuilder},
     log::{error, trace},
@@ -23,6 +22,7 @@ use {
     solana_runtime::{bank::Bank, epoch_stakes::VersionedEpochStakes},
     solana_votor_messages::{
         consensus_message::{Block, Certificate, CertificateType, ConsensusMessage, VoteMessage},
+        fraction::Fraction,
         migration::MigrationStatus,
         vote::{Vote, VoteType},
     },

--- a/votor/src/consensus_pool/slot_stake_counters.rs
+++ b/votor/src/consensus_pool/slot_stake_counters.rs
@@ -7,10 +7,9 @@ use {
         },
         consensus_pool::stats::ConsensusPoolStats,
         event::VotorEvent,
-        fraction::Fraction,
     },
     solana_hash::Hash,
-    solana_votor_messages::vote::Vote,
+    solana_votor_messages::{fraction::Fraction, vote::Vote},
     std::{collections::BTreeMap, num::NonZeroU64},
 };
 

--- a/votor/src/lib.rs
+++ b/votor/src/lib.rs
@@ -7,7 +7,6 @@ pub mod consensus_pool;
 mod consensus_pool_service;
 pub mod event;
 mod event_handler;
-pub mod fraction;
 pub mod root_utils;
 mod staked_validators_cache;
 mod timer_manager;


### PR DESCRIPTION
#### Problem and Summary of Changes
In `votor`, we have logic that resembles:

```rust
let x: f64 = ...; // some fraction that's a ratio of two u64's
let y: f64 = ...; // some alpenglow threshold that's also expressible as a ratio of two u64's

if x > y {
    ...
}
```

This PR replaces the above logic with purely int-based calculations to avoid loss-of-precision / inopportune rounding issues.