### PR TITLE
ConsensusPool: backports using ClusterInfo instead of Pubkey

### DIFF
--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -17,6 +17,7 @@ use {
     log::{error, trace},
     solana_clock::{Epoch, Slot},
     solana_epoch_schedule::EpochSchedule,
+    solana_gossip::cluster_info::ClusterInfo,
     solana_hash::Hash,
     solana_pubkey::Pubkey,
     solana_runtime::{bank::Bank, epoch_stakes::VersionedEpochStakes},
@@ -99,7 +100,7 @@ fn get_key_and_stakes(
 }
 
 pub struct ConsensusPool {
-    my_pubkey: Pubkey,
+    cluster_info: Arc<ClusterInfo>,
     // Vote pools to do bean counting for votes.
     vote_pools: BTreeMap<PoolId, VotePool>,
     /// Completed certificates
@@ -123,23 +124,23 @@ pub struct ConsensusPool {
 
 impl ConsensusPool {
     pub fn new_from_root_bank_pre_migration(
-        my_pubkey: Pubkey,
+        cluster_info: Arc<ClusterInfo>,
         bank: &Bank,
         migration_status: Arc<MigrationStatus>,
     ) -> Self {
-        let mut pool = Self::new_from_root_bank(my_pubkey, bank);
+        let mut pool = Self::new_from_root_bank(cluster_info, bank);
         pool.migration_status = Some(migration_status);
         pool
     }
 
-    pub fn new_from_root_bank(my_pubkey: Pubkey, bank: &Bank) -> Self {
+    pub fn new_from_root_bank(cluster_info: Arc<ClusterInfo>, bank: &Bank) -> Self {
         // To account for genesis and snapshots we allow default block id until
         // block id can be serialized  as part of the snapshot
         let root_block = (bank.slot(), bank.block_id().unwrap_or_default());
-        let parent_ready_tracker = ParentReadyTracker::new(my_pubkey, root_block);
+        let parent_ready_tracker = ParentReadyTracker::new(cluster_info.clone(), root_block);
 
         Self {
-            my_pubkey,
+            cluster_info,
             vote_pools: BTreeMap::new(),
             completed_certificates: BTreeMap::new(),
             highest_finalized_slot: None,
@@ -289,7 +290,11 @@ impl ConsensusPool {
         cert: Arc<Certificate>,
         events: &mut Vec<VotorEvent>,
     ) {
-        trace!("{}: Inserting certificate {:?}", self.my_pubkey, cert_type);
+        trace!(
+            "{}: Inserting certificate {:?}",
+            self.cluster_info.id(),
+            cert_type
+        );
         self.completed_certificates.insert(cert_type, cert.clone());
         match cert_type {
             CertificateType::NotarizeFallback(slot, block_id) => {
@@ -560,11 +565,6 @@ impl ConsensusPool {
     }
 
     #[cfg(test)]
-    pub(crate) fn my_pubkey(&self) -> Pubkey {
-        self.my_pubkey
-    }
-
-    #[cfg(test)]
     fn make_start_leader_decision(
         &self,
         my_leader_slot: Slot,
@@ -621,14 +621,6 @@ impl ConsensusPool {
         self.parent_ready_tracker.set_root(root_slot);
     }
 
-    /// Updates the pubkey used for logging purposes only.
-    /// This avoids the need to recreate the entire certificate pool since it's
-    /// not distinguished by the pubkey.
-    pub fn update_pubkey(&mut self, new_pubkey: Pubkey) {
-        self.my_pubkey = new_pubkey;
-        self.parent_ready_tracker.update_pubkey(new_pubkey);
-    }
-
     pub fn maybe_report(&mut self) {
         self.stats.maybe_report();
     }
@@ -659,7 +651,11 @@ impl ConsensusPool {
                     _ => None,
                 };
                 if cert_to_send.is_some() {
-                    trace!("{}: Refreshing certificate {:?}", self.my_pubkey, cert_type);
+                    trace!(
+                        "{}: Refreshing certificate {:?}",
+                        self.cluster_info.id(),
+                        cert_type
+                    );
                 }
                 cert_to_send
             })
@@ -676,7 +672,9 @@ mod tests {
             VerifiableSignature,
         },
         solana_clock::Slot,
+        solana_gossip::contact_info::ContactInfo,
         solana_hash::Hash,
+        solana_keypair::Keypair,
         solana_runtime::{
             bank::{Bank, NewBankOptions},
             bank_forks::BankForks,
@@ -685,10 +683,21 @@ mod tests {
             },
         },
         solana_signer::Signer,
+        solana_streamer::socket::SocketAddrSpace,
         solana_votor_messages::consensus_message::{VoteMessage, BLS_KEYPAIR_DERIVE_SEED},
         std::sync::{Arc, RwLock},
         test_case::test_case,
     };
+
+    fn new_cluster_info() -> Arc<ClusterInfo> {
+        let keypair = Keypair::new();
+        let contact_info = ContactInfo::new_localhost(&keypair.pubkey(), 0);
+        Arc::new(ClusterInfo::new(
+            contact_info,
+            Arc::new(keypair),
+            SocketAddrSpace::Unspecified,
+        ))
+    }
 
     fn dummy_vote_message(
         keypairs: &[ValidatorVoteKeypairs],
@@ -731,7 +740,7 @@ mod tests {
         let root_bank = bank_forks.read().unwrap().root_bank();
         (
             validator_keypairs,
-            ConsensusPool::new_from_root_bank(Pubkey::new_unique(), &root_bank),
+            ConsensusPool::new_from_root_bank(new_cluster_info(), &root_bank),
             bank_forks,
         )
     }
@@ -1856,7 +1865,7 @@ mod tests {
             .collect::<Vec<_>>();
         let bank_forks = create_bank_forks(&validator_keypairs);
         let mut pool = ConsensusPool::new_from_root_bank(
-            Pubkey::new_unique(),
+            new_cluster_info(),
             &bank_forks.read().unwrap().root_bank(),
         );
 
@@ -2308,17 +2317,5 @@ mod tests {
                 .is_ok(),
             "BLS signature verification failed for VoteMessage"
         );
-    }
-
-    #[test]
-    fn test_update_pubkey() {
-        let new_pubkey = Pubkey::new_unique();
-        let (_, mut pool, _) = create_initial_state();
-        let old_pubkey = pool.my_pubkey();
-        assert_eq!(pool.parent_ready_tracker.my_pubkey(), old_pubkey);
-        assert_ne!(old_pubkey, new_pubkey);
-        pool.update_pubkey(new_pubkey);
-        assert_eq!(pool.my_pubkey(), new_pubkey);
-        assert_eq!(pool.parent_ready_tracker.my_pubkey(), new_pubkey);
     }
 }

--- a/votor/src/consensus_pool/parent_ready_tracker.rs
+++ b/votor/src/consensus_pool/parent_ready_tracker.rs
@@ -15,9 +15,9 @@
 use {
     crate::{common::MAX_ENTRIES_PER_PUBKEY_FOR_NOTARIZE_LITE, event::VotorEvent},
     solana_clock::{Slot, NUM_CONSECUTIVE_LEADER_SLOTS},
-    solana_pubkey::Pubkey,
+    solana_gossip::cluster_info::ClusterInfo,
     solana_votor_messages::consensus_message::Block,
-    std::collections::HashMap,
+    std::{collections::HashMap, sync::Arc},
 };
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -27,10 +27,8 @@ pub enum BlockProductionParent {
     Parent(Block),
 }
 
-#[derive(Clone, Debug, Default)]
 pub struct ParentReadyTracker {
-    /// Our pubkey for logging
-    my_pubkey: Pubkey,
+    cluster_info: Arc<ClusterInfo>,
 
     /// Parent ready status for each slot
     slot_statuses: HashMap<Slot, ParentReadyStatus>,
@@ -58,7 +56,7 @@ struct ParentReadyStatus {
 
 impl ParentReadyTracker {
     /// Creates a new tracker with the root bank as implicitely notarized fallback
-    pub fn new(my_pubkey: Pubkey, root_block @ (root_slot, _): Block) -> Self {
+    pub fn new(cluster_info: Arc<ClusterInfo>, root_block @ (root_slot, _): Block) -> Self {
         let mut slot_statuses = HashMap::new();
         slot_statuses.insert(
             root_slot,
@@ -77,7 +75,7 @@ impl ParentReadyTracker {
             },
         );
         Self {
-            my_pubkey,
+            cluster_info,
             slot_statuses,
             root: root_slot,
             highest_with_parent_ready: root_slot.saturating_add(1),
@@ -100,7 +98,7 @@ impl ParentReadyTracker {
         }
         trace!(
             "{}: Adding new notar fallback for {block:?}",
-            self.my_pubkey
+            self.cluster_info.id()
         );
         status.notar_fallbacks.push(block);
         assert!(status.notar_fallbacks.len() <= MAX_ENTRIES_PER_PUBKEY_FOR_NOTARIZE_LITE);
@@ -109,7 +107,7 @@ impl ParentReadyTracker {
         for s in slot.saturating_add(1).. {
             trace!(
                 "{}: Adding new parent ready for {s} parent {block:?}",
-                self.my_pubkey
+                self.cluster_info.id()
             );
             let status = self.slot_statuses.entry(s).or_default();
             if !status.parents_ready.contains(&block) {
@@ -138,7 +136,7 @@ impl ParentReadyTracker {
             return;
         }
 
-        trace!("{}: Adding new skip for {slot:?}", self.my_pubkey);
+        trace!("{}: Adding new skip for {slot:?}", self.cluster_info.id());
         let status = self.slot_statuses.entry(slot).or_default();
         status.skip = true;
 
@@ -177,7 +175,7 @@ impl ParentReadyTracker {
         for s in future_slots {
             trace!(
                 "{}: Adding new parent ready for {s} parents {potential_parents:?}",
-                self.my_pubkey,
+                self.cluster_info.id(),
             );
             let status = self.slot_statuses.entry(s).or_default();
             for &block in &potential_parents {
@@ -232,29 +230,30 @@ impl ParentReadyTracker {
         self.root = root;
         self.slot_statuses.retain(|&s, _| s >= root);
     }
-
-    /// Updates the pubkey. Note that the pubkey is used for logging purposes only.
-    pub fn update_pubkey(&mut self, new_pubkey: Pubkey) {
-        self.my_pubkey = new_pubkey;
-    }
-
-    #[cfg(test)]
-    pub fn my_pubkey(&self) -> Pubkey {
-        self.my_pubkey
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use {
         super::*, itertools::Itertools, solana_clock::NUM_CONSECUTIVE_LEADER_SLOTS,
-        solana_hash::Hash, solana_pubkey::Pubkey,
+        solana_gossip::contact_info::ContactInfo, solana_hash::Hash, solana_keypair::Keypair,
+        solana_signer::Signer, solana_streamer::socket::SocketAddrSpace,
     };
+
+    fn new_cluster_info() -> Arc<ClusterInfo> {
+        let keypair = Keypair::new();
+        let contact_info = ContactInfo::new_localhost(&keypair.pubkey(), 0);
+        Arc::new(ClusterInfo::new(
+            contact_info,
+            Arc::new(keypair),
+            SocketAddrSpace::Unspecified,
+        ))
+    }
 
     #[test]
     fn basic() {
         let genesis = Block::default();
-        let mut tracker = ParentReadyTracker::new(Pubkey::default(), genesis);
+        let mut tracker = ParentReadyTracker::new(new_cluster_info(), genesis);
         let mut events = vec![];
 
         for i in 1..2 * NUM_CONSECUTIVE_LEADER_SLOTS {
@@ -268,7 +267,7 @@ mod tests {
     #[test]
     fn skips() {
         let genesis = Block::default();
-        let mut tracker = ParentReadyTracker::new(Pubkey::default(), genesis);
+        let mut tracker = ParentReadyTracker::new(new_cluster_info(), genesis);
         let mut events = vec![];
         let block = (1, Hash::new_unique());
 
@@ -285,7 +284,7 @@ mod tests {
     #[test]
     fn out_of_order() {
         let genesis = Block::default();
-        let mut tracker = ParentReadyTracker::new(Pubkey::default(), genesis);
+        let mut tracker = ParentReadyTracker::new(new_cluster_info(), genesis);
         let mut events = vec![];
         let block = (1, Hash::new_unique());
 
@@ -305,7 +304,7 @@ mod tests {
     fn snapshot_wfsm() {
         let root_slot = 2147;
         let root_block = (root_slot, Hash::new_unique());
-        let mut tracker = ParentReadyTracker::new(Pubkey::default(), root_block);
+        let mut tracker = ParentReadyTracker::new(new_cluster_info(), root_block);
         let mut events = vec![];
 
         assert!(tracker.parent_ready(root_slot + 1, root_block));
@@ -332,7 +331,7 @@ mod tests {
     #[test]
     fn highest_parent_ready_out_of_order() {
         let genesis = Block::default();
-        let mut tracker = ParentReadyTracker::new(Pubkey::default(), genesis);
+        let mut tracker = ParentReadyTracker::new(new_cluster_info(), genesis);
         let mut events = vec![];
         assert_eq!(tracker.highest_parent_ready(), 1);
 
@@ -354,7 +353,7 @@ mod tests {
     #[test]
     fn missed_window() {
         let genesis = Block::default();
-        let mut tracker = ParentReadyTracker::new(Pubkey::default(), genesis);
+        let mut tracker = ParentReadyTracker::new(new_cluster_info(), genesis);
         let mut events = vec![];
         assert_eq!(tracker.highest_parent_ready(), 1);
         assert_eq!(
@@ -384,7 +383,7 @@ mod tests {
     #[test]
     fn pick_more_skips() {
         let genesis = Block::default();
-        let mut tracker = ParentReadyTracker::new(Pubkey::default(), genesis);
+        let mut tracker = ParentReadyTracker::new(new_cluster_info(), genesis);
         let mut events = vec![];
 
         for i in 1..=10 {


### PR DESCRIPTION
#### Problem
ConsensusPool on agave has diverged quite a bit from alpenglow.

#### Summary of Changes

Backports using cluster info.

## The original problem and summary of changes

https://github.com/anza-xyz/agave/pull/8760

#### Problem

`ConsensusPool` and `ParentReadyTracker` are storing the node's pubkey for logging purposes.  This also requires code to update the pubkey when they change.  We already have a handy struct `ClusterInfo` that can be used to get the current pubkey.

#### Summary of Changes

Updates `ConsensusPool` and `ParentReadyTracker` to use `ClusterInfo` instead.  This allows us to simplify some related code as well.
