### PR TITLE
blockstore: remove BlockVersions column

### DIFF
--- a/core/src/repair/malicious_repair_handler.rs
+++ b/core/src/repair/malicious_repair_handler.rs
@@ -44,10 +44,7 @@ impl RepairHandler for MaliciousRepairHandler {
         let mut shred = match block_id {
             None => self.blockstore.get_data_shred(slot, shred_index),
             Some(block_id) => {
-                let location = self
-                    .blockstore()
-                    .get_block_location(slot, block_id)
-                    .expect("Unable to fetch block location from blockstore")?;
+                let location = self.blockstore().get_block_location(slot, block_id)?;
                 self.blockstore()
                     .get_data_shred_from_location(slot, shred_index, location)
             }

--- a/core/src/repair/standard_repair_handler.rs
+++ b/core/src/repair/standard_repair_handler.rs
@@ -39,10 +39,7 @@ impl RepairHandler for StandardRepairHandler {
                 nonce,
             ),
             Some(block_id) => {
-                let location = self
-                    .blockstore()
-                    .get_block_location(slot, block_id)
-                    .expect("Unable to fetch block location from blockstore")?;
+                let location = self.blockstore().get_block_location(slot, block_id)?;
                 let shred = self
                     .blockstore()
                     .get_data_shred_from_location(slot, shred_index, location)

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -259,7 +259,6 @@ pub struct Blockstore {
     blocktime_cf: LedgerColumn<cf::Blocktime>,
     code_shred_cf: LedgerColumn<cf::ShredCode>,
     data_shred_cf: LedgerColumn<cf::ShredData>,
-    block_versions_cf: LedgerColumn<cf::BlockVersions>,
     dead_slots_cf: LedgerColumn<cf::DeadSlots>,
     duplicate_slots_cf: LedgerColumn<cf::DuplicateSlots>,
     erasure_meta_cf: LedgerColumn<cf::ErasureMeta>,
@@ -443,7 +442,6 @@ impl Blockstore {
         let blocktime_cf = db.column();
         let code_shred_cf = db.column();
         let data_shred_cf = db.column();
-        let block_versions_cf = db.column();
         let dead_slots_cf = db.column();
         let duplicate_slots_cf = db.column();
         let erasure_meta_cf = db.column();
@@ -485,7 +483,6 @@ impl Blockstore {
             blocktime_cf,
             code_shred_cf,
             data_shred_cf,
-            block_versions_cf,
             dead_slots_cf,
             duplicate_slots_cf,
             erasure_meta_cf,
@@ -636,7 +633,7 @@ impl Blockstore {
     /// Checks all available block versions, if we have a *complete* block for
     /// `block_id`, returns the associated slot meta
     pub fn meta_for_block_id(&self, slot: Slot, block_id: Hash) -> Result<Option<SlotMeta>> {
-        let Some(location) = self.get_block_location(slot, block_id)? else {
+        let Some(location) = self.get_block_location(slot, block_id) else {
             return Ok(None);
         };
         self.meta_from_location(slot, location)
@@ -662,15 +659,6 @@ impl Blockstore {
     ) -> Result<Option<ParentMeta>> {
         self.parent_meta_cf
             .get((slot, location.unwrap_or(BlockLocation::Original)))
-    }
-
-    /// Returns the BlockVersions of the specified slot.
-    pub fn block_versions(&self, slot: Slot) -> Result<Option<BlockVersions>> {
-        self.block_versions_cf.get(slot)
-    }
-
-    pub fn set_block_versions(&self, slot: Slot, block_versions: &BlockVersions) -> Result<()> {
-        self.block_versions_cf.put(slot, block_versions)
     }
 
     /// Returns true if the specified slot is full.
@@ -872,6 +860,15 @@ impl Blockstore {
                 merkle_root_meta,
             ),
         }
+    }
+
+    /// Gets the double merkle meta for the given block
+    pub fn get_double_merkle_meta(
+        &self,
+        slot: Slot,
+        block_location: BlockLocation,
+    ) -> Result<Option<DoubleMerkleMeta>> {
+        self.double_merkle_meta_cf.get((slot, block_location))
     }
 
     /// Gets the double merkle root for the given block, computing it if necessary.
@@ -1217,7 +1214,6 @@ impl Blockstore {
         self.index_cf.submit_rocksdb_cf_metrics();
         self.data_shred_cf.submit_rocksdb_cf_metrics();
         self.code_shred_cf.submit_rocksdb_cf_metrics();
-        self.block_versions_cf.submit_rocksdb_cf_metrics();
         self.transaction_status_cf.submit_rocksdb_cf_metrics();
         self.address_signatures_cf.submit_rocksdb_cf_metrics();
         self.transaction_memos_cf.submit_rocksdb_cf_metrics();
@@ -3138,11 +3134,16 @@ impl Blockstore {
 
     /// Checks all available block versions, if we have a *complete* block for
     /// `block_id`, returns the location where it is stored
-    pub fn get_block_location(&self, slot: Slot, block_id: Hash) -> Result<Option<BlockLocation>> {
-        let Some(block_versions) = self.block_versions(slot)? else {
-            return Ok(None);
-        };
-        Ok(block_versions.get_location(block_id))
+    pub fn get_block_location(&self, slot: Slot, block_id: Hash) -> Option<BlockLocation> {
+        [
+            BlockLocation::Original,
+            BlockLocation::Alternate { block_id },
+        ]
+        .into_iter()
+        .find(|location| {
+            self.get_double_merkle_root(slot, *location)
+                .is_some_and(|dmr| dmr == block_id)
+        })
     }
 
     // Only used by tests
@@ -6194,13 +6195,6 @@ pub fn test_all_empty_or_min(blockstore: &Blockstore, min_slot: Slot) {
             .unwrap()
             .next()
             .map(|((slot, _), _)| slot >= min_slot)
-            .unwrap_or(true)
-        & blockstore
-            .block_versions_cf
-            .iter(IteratorMode::Start)
-            .unwrap()
-            .next()
-            .map(|(slot, _)| slot >= min_slot)
             .unwrap_or(true)
         & blockstore
             .dead_slots_cf

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -262,10 +262,6 @@ impl Blockstore {
                 .delete_range_in_batch(write_batch, from_slot, to_slot)
                 .is_ok()
             & self
-                .block_versions_cf
-                .delete_range_in_batch(write_batch, from_slot, to_slot)
-                .is_ok()
-            & self
                 .dead_slots_cf
                 .delete_range_in_batch(write_batch, from_slot, to_slot)
                 .is_ok()
@@ -371,10 +367,6 @@ impl Blockstore {
                 .is_ok()
             & self
                 .code_shred_cf
-                .delete_file_in_range(from_slot, to_slot)
-                .is_ok()
-            & self
-                .block_versions_cf
                 .delete_file_in_range(from_slot, to_slot)
                 .is_ok()
             & self

--- a/ledger/src/blockstore/column.rs
+++ b/ledger/src/blockstore/column.rs
@@ -174,16 +174,6 @@ pub mod columns {
     pub struct AlternateShredData;
 
     #[derive(Debug)]
-    /// The block versions
-    ///
-    /// This column stores information about what versions of blocks in `slot` we
-    /// have available, for use in serving repair or switching replayed banks
-    ///
-    /// * index type: `u64` (see [`SlotColumn`])
-    /// * value type: [`blockstore_meta::BlockVersions`]
-    pub struct BlockVersions;
-
-    #[derive(Debug)]
     /// The transaction status column
     ///
     /// * index type: `(`[`Signature`]`, `[`Slot`])`
@@ -780,14 +770,6 @@ impl Column for columns::AlternateShredData {
 }
 impl ColumnName for columns::AlternateShredData {
     const NAME: &'static str = "alt_data_shred";
-}
-
-impl SlotColumn for columns::BlockVersions {}
-impl ColumnName for columns::BlockVersions {
-    const NAME: &'static str = "block_versions";
-}
-impl TypedColumn for columns::BlockVersions {
-    type Type = blockstore_meta::BlockVersions;
 }
 
 impl SlotColumn for columns::Index {}

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -184,7 +184,6 @@ impl Rocks {
             new_cf_descriptor::<columns::Index>(options, oldest_slot),
             new_cf_descriptor::<columns::ShredData>(options, oldest_slot),
             new_cf_descriptor::<columns::ShredCode>(options, oldest_slot),
-            new_cf_descriptor::<columns::BlockVersions>(options, oldest_slot),
             new_cf_descriptor::<columns::TransactionStatus>(options, oldest_slot),
             new_cf_descriptor::<columns::AddressSignatures>(options, oldest_slot),
             new_cf_descriptor::<columns::TransactionMemos>(options, oldest_slot),
@@ -250,7 +249,7 @@ impl Rocks {
         cf_descriptors
     }
 
-    const fn columns() -> [&'static str; 28] {
+    const fn columns() -> [&'static str; 27] {
         [
             columns::ErasureMeta::NAME,
             columns::DeadSlots::NAME,
@@ -262,7 +261,6 @@ impl Rocks {
             columns::SlotMeta::NAME,
             columns::ShredData::NAME,
             columns::ShredCode::NAME,
-            columns::BlockVersions::NAME,
             columns::TransactionStatus::NAME,
             columns::AddressSignatures::NAME,
             columns::TransactionMemos::NAME,


### PR DESCRIPTION
#### Problem
carl had good insight that SlotMeta + DoubleMerkleMeta can tell us everything necessary about blockstore block versioning for our needs. It's not necessary to store this version info / status separately.

#### Summary of Changes
Remove this column, `get_block_location()` will instead verify by checking the `DoubleMerkleMeta` column
