### PR TITLE
feat: serialize block_id to snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,6 +273,7 @@ dependencies = [
  "solana-runtime-transaction",
  "solana-sbpf",
  "solana-sdk-ids",
+ "solana-sha256-hasher",
  "solana-shred-version",
  "solana-signature",
  "solana-stake-interface",

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -71,6 +71,7 @@ solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-runtime-transaction = { workspace = true }
 solana-sbpf = { workspace = true, features = ["debugger", "jit"] }
 solana-sdk-ids = { workspace = true }
+solana-sha256-hasher = { workspace = true }
 solana-shred-version = { workspace = true }
 solana-signature = { workspace = true }
 solana-stake-interface = { workspace = true }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -447,6 +447,7 @@ pub struct BankFieldsToDeserialize {
     pub(crate) accounts_data_len: u64,
     pub(crate) accounts_lt_hash: AccountsLtHash,
     pub(crate) bank_hash_stats: BankHashStats,
+    pub(crate) block_id: Option<Hash>,
 }
 
 /// Bank's common fields shared by all supported snapshot versions for serialization.
@@ -1835,7 +1836,7 @@ impl Bank {
             accounts_lt_hash: Mutex::new(fields.accounts_lt_hash),
             cache_for_accounts_lt_hash: DashMap::default(),
             stats_for_accounts_lt_hash: AccountsLtHashStats::default(),
-            block_id: RwLock::new(None),
+            block_id: RwLock::new(fields.block_id),
             bank_hash_stats: AtomicBankHashStats::new(&fields.bank_hash_stats),
             epoch_rewards_calculation_cache: Arc::new(Mutex::new(HashMap::default())),
             block_component_processor: RwLock::new(BlockComponentProcessor::default()),

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -120,6 +120,7 @@ mod tests {
             let mut bank_fields = bank2.get_fields_to_serialize();
             let versioned_epoch_stakes = mem::take(&mut bank_fields.versioned_epoch_stakes);
             let accounts_lt_hash = Some(bank_fields.accounts_lt_hash.clone().into());
+            let block_id = bank2.block_id();
             serde_snapshot::serialize_bank_snapshot_into(
                 &mut writer,
                 bank_fields,
@@ -131,6 +132,7 @@ mod tests {
                     obsolete_epoch_accounts_hash: None,
                     versioned_epoch_stakes,
                     accounts_lt_hash,
+                    block_id,
                 },
                 accounts_db.write_version.load(Ordering::Acquire),
             )
@@ -401,6 +403,7 @@ mod tests {
 
             let mut bank_fields = bank.get_fields_to_serialize();
             let versioned_epoch_stakes = std::mem::take(&mut bank_fields.versioned_epoch_stakes);
+            let block_id = bank.block_id();
             serde_snapshot::serialize_bank_snapshot_with(
                 serializer,
                 bank_fields,
@@ -414,6 +417,7 @@ mod tests {
                     obsolete_epoch_accounts_hash: Some(Hash::new_unique()),
                     versioned_epoch_stakes,
                     accounts_lt_hash: Some(AccountsLtHash(LtHash::identity()).into()),
+                    block_id,
                 },
                 u64::default(), // obsolete, formerly write_version
             )

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "dev-context-only-utils")]
-use solana_hash::Hash;
 use {
     crate::{
         bank::{Bank, BankFieldsToSerialize, BankHashStats, BankSlotDelta},
@@ -7,6 +5,7 @@ use {
     },
     solana_accounts_db::accounts_db::AccountStorageEntry,
     solana_clock::Slot,
+    solana_hash::Hash,
     std::{
         sync::{atomic::Ordering, Arc},
         time::Instant,
@@ -27,6 +26,7 @@ pub struct SnapshotPackage {
     pub bank_fields_to_serialize: BankFieldsToSerialize,
     pub bank_hash_stats: BankHashStats,
     pub write_version: u64,
+    pub block_id: Option<Hash>,
 
     /// The instant this snapshot package was sent to the queue.
     /// Used to track how long snapshot packages wait before handling.
@@ -64,6 +64,7 @@ impl SnapshotPackage {
                 .accounts_db
                 .write_version
                 .load(Ordering::Acquire),
+            block_id: bank.block_id(),
             enqueued: Instant::now(),
         }
     }
@@ -84,6 +85,7 @@ impl SnapshotPackage {
             bank_fields_to_serialize: BankFieldsToSerialize::default_for_tests(),
             bank_hash_stats: BankHashStats::default(),
             write_version: u64::default(),
+            block_id: None,
             enqueued: Instant::now(),
         }
     }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -789,6 +789,7 @@ pub fn serialize_and_archive_snapshot_package(
         bank_fields_to_serialize,
         bank_hash_stats,
         write_version,
+        block_id,
         enqueued: _,
     } = snapshot_package;
 
@@ -800,6 +801,7 @@ pub fn serialize_and_archive_snapshot_package(
         bank_fields_to_serialize,
         bank_hash_stats,
         write_version,
+        block_id,
         should_flush_and_hard_link_storages,
     )?;
 
@@ -860,6 +862,7 @@ fn serialize_snapshot(
     mut bank_fields: BankFieldsToSerialize,
     bank_hash_stats: BankHashStats,
     write_version: u64,
+    block_id: Option<Hash>,
     should_flush_and_hard_link_storages: bool,
 ) -> Result<BankSnapshotInfo> {
     let slot = bank_fields.slot;
@@ -915,6 +918,7 @@ fn serialize_snapshot(
                 obsolete_epoch_accounts_hash: None,
                 versioned_epoch_stakes,
                 accounts_lt_hash: Some(bank_fields.accounts_lt_hash.clone().into()),
+                block_id,
             };
             serde_snapshot::serialize_bank_snapshot_into(
                 stream,

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -110,16 +110,9 @@ impl StandardBroadcastRun {
             })
         };
 
-        let parent_block_id = bank.parent_block_id().unwrap_or_else(|| {
-            // Once SIMD-0333 is active, we can just hard unwrap here.
-            error!(
-                "Parent block id missing for slot {} parent {}",
-                bank.slot(),
-                bank.parent_slot()
-            );
-            process_stats.err_unknown_parent_block_id += 1;
-            Hash::default()
-        });
+        let parent_block_id = bank
+            .parent_block_id()
+            .expect("Parent block ID must be present in snapshots after SIMD-0333");
 
         self.slot = bank.slot();
         self.parent = bank.parent_slot();

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -226,8 +226,12 @@ impl ConsensusPoolService {
                     .genesis_block()
                     .expect("Alpenglow is enabled");
                 let root_bank = ctx.sharable_banks.root();
-                // can expect once we have block id in snapshots (SIMD-0333)
-                let root_block = (root_bank.slot(), root_bank.block_id().unwrap_or_default());
+                let root_block = (
+                    root_bank.slot(),
+                    root_bank
+                        .block_id()
+                        .expect("block_id must be present in snapshots"),
+                );
                 let kick_off_block @ (kick_off_slot, _) = genesis_block.max(root_block);
                 let start_slot = kick_off_slot.checked_add(1).unwrap();
 


### PR DESCRIPTION
 #### Problem

  Block IDs were not being persisted in snapshots, requiring unsafe fallback to Hash::default() when block_id was 
  missing after snapshot restoration.

  #### Summary of Changes

  - Add block_id field to snapshot serialization/deserialization structures
  - Update ledger-tool to populate block_id for artificially created banks
  - Remove unsafe Hash::default() fallbacks, replace with explicit expects

  Fixes #634