### PR TITLE
refactor: `SlotStakeCounters` should not derive `Default`

### DIFF
--- a/votor/src/consensus_pool/slot_stake_counters.rs
+++ b/votor/src/consensus_pool/slot_stake_counters.rs
@@ -13,8 +13,8 @@ use {
     std::{collections::BTreeMap, num::NonZeroU64},
 };
 
-#[derive(Debug, Default)]
-pub(crate) struct SlotStakeCounters {
+#[derive(Debug)]
+pub(super) struct SlotStakeCounters {
     my_first_vote: Option<Vote>,
     total_stake: Stake,
     skip_total: Stake,
@@ -26,14 +26,20 @@ pub(crate) struct SlotStakeCounters {
 }
 
 impl SlotStakeCounters {
-    pub fn new(total_stake: Stake) -> Self {
+    pub(super) fn new(total_stake: Stake) -> Self {
         Self {
             total_stake,
-            ..Default::default()
+            my_first_vote: None,
+            skip_total: 0,
+            notarize_total: 0,
+            notarize_entry_total: BTreeMap::default(),
+            top_notarized_stake: 0,
+            safe_to_notar_sent: vec![],
+            safe_to_skip_sent: false,
         }
     }
 
-    pub fn add_vote(
+    pub(super) fn add_vote(
         &mut self,
         vote: &Vote,
         entry_stake: Stake,


### PR DESCRIPTION
#### Problem

- Nobody is using the `Default` implementation of `SlotStateCounters`
- The default implementation will set `SlotStateCounters::total_stake` to 0 and then later on that will cause a divide by 0 panic.

#### Summary of Changes

- Removes the `Default` implementation
- Also reduces the visibility of the struct and methods to what is necessary.
