### PR TITLE
feat: introduces `NonZeroStake`

### DIFF
--- a/votor/src/lib.rs
+++ b/votor/src/lib.rs
@@ -10,6 +10,7 @@ mod event_handler;
 pub mod root_utils;
 mod staked_validators_cache;
 mod timer_manager;
+pub(crate) mod types;
 pub mod vote_history;
 pub mod vote_history_storage;
 pub mod voting_service;

--- a/votor/src/types.rs
+++ b/votor/src/types.rs
@@ -1,0 +1,1 @@
+pub(crate) mod non_zero_stake;

--- a/votor/src/types/non_zero_stake.rs
+++ b/votor/src/types/non_zero_stake.rs
@@ -1,0 +1,34 @@
+use {crate::common::Stake, std::num::NonZeroU64};
+
+/// A struct to represent stake that is guaranteed to not be 0.
+#[derive(Clone, Copy)]
+pub(crate) struct NonZeroStake(NonZeroU64);
+
+impl NonZeroStake {
+    /// Constructs a new instance of [`NonZeroStake`].
+    pub(crate) fn try_new(stake: Stake) -> Option<Self> {
+        NonZeroU64::new(stake).map(Self)
+    }
+
+    /// Returns the [`Stake`].
+    pub(crate) fn get(&self) -> Stake {
+        self.0.get()
+    }
+}
+
+impl From<NonZeroStake> for NonZeroU64 {
+    fn from(stake: NonZeroStake) -> Self {
+        stake.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_constructor() {
+        assert!(NonZeroStake::try_new(0).is_none());
+        assert_eq!(NonZeroStake::try_new(1).unwrap().get(), 1);
+    }
+}


### PR DESCRIPTION
#### Problem

We have a bunch of code that either implicitly (divides by 0) or explicitly (using `unwrap`, etc.) assumes that stake cannot be zero.


#### Summary of Changes

Introduces a new type: `NonZeroStake` that is guaranteed to not be 0.  And uses it in a bunch of places allowing us to remove a bunch of panics and unwraps.