### PR TITLE
nit: removes duplicate function: `get_signed_data`

### DIFF
--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -1768,7 +1768,7 @@ mod test {
                 shred::layout::get_chained_merkle_root(shred),
                 chained_merkle_root
             );
-            let data = shred::layout::get_signed_data(shred).unwrap();
+            let data = shred::layout::get_merkle_root(shred).unwrap();
             assert_eq!(data, merkle_root);
             assert!(signature.verify(pubkey.as_ref(), data.as_ref()));
         }

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -64,7 +64,7 @@ pub fn verify_shred_cpu(
         return false;
     };
     trace!("signature {signature}");
-    let Some(data) = shred::layout::get_signed_data(shred) else {
+    let Some(data) = shred::layout::get_merkle_root(shred) else {
         return false;
     };
 
@@ -355,7 +355,7 @@ pub fn verify_shreds_gpu(
 fn sign_shred_cpu(keypair: &Keypair, packet: &mut PacketRefMut) {
     let sig = shred::layout::get_signature_range();
     let msg = shred::layout::get_shred(packet.as_ref())
-        .and_then(shred::layout::get_signed_data)
+        .and_then(shred::layout::get_merkle_root)
         .unwrap();
     assert!(
         packet.meta().size >= sig.end,
@@ -783,7 +783,7 @@ mod tests {
             let slot = shred::layout::get_slot(shred).unwrap();
             let signature = shred::layout::get_signature(shred).unwrap();
             let pubkey = keypairs[&slot].pubkey();
-            let data = shred::layout::get_signed_data(shred).unwrap();
+            let data = shred::layout::get_merkle_root(shred).unwrap();
             assert!(signature.verify(pubkey.as_ref(), data.as_ref()));
         }
         shreds


### PR DESCRIPTION
This is a backport of https://github.com/anza-xyz/agave/pull/9494

`get_signed_data` is a duplicate of `get_merkle_root` so removes the first function.