### PR TITLE
blockstore: DMR use correct slot meta column

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -896,8 +896,7 @@ impl Blockstore {
         block_location: BlockLocation,
     ) -> Option<Hash> {
         let slot_meta = self
-            .meta_cf
-            .get(slot)
+            .meta_from_location(slot, block_location)
             .expect("Blockstore operations must succeed")?;
 
         if !slot_meta.is_full() {


### PR DESCRIPTION
#### Problem
When trying to compute the DMR out of a different column (not `BlockLocation::Original`) I noticed that the slot meta check would sometimes fail. Turns out we were always checking the original slot meta 🤦 

#### Summary of Changes
Use `meta_from_location` to check the correct slot meta column