### PR TITLE
Introduces `Bank::epoch_stakes_from_slot()`

### DIFF
--- a/core/src/bls_sigverify/bls_sigverifier.rs
+++ b/core/src/bls_sigverify/bls_sigverifier.rs
@@ -50,10 +50,7 @@ use {
 //            Revisit this to figure out the best way to handle this.
 
 fn get_key_to_rank_map(bank: &Bank, slot: Slot) -> Option<(&Arc<BLSPubkeyToRankMap>, u64)> {
-    let stakes = bank.epoch_stakes_map();
-    let epoch = bank.epoch_schedule().get_epoch(slot);
-    stakes
-        .get(&epoch)
+    bank.epoch_stakes_from_slot(slot)
         .map(|stake| (stake.bls_pubkey_to_rank_map(), stake.total_stake()))
 }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5063,6 +5063,11 @@ impl Bank {
         self.epoch_stakes.get(&epoch)
     }
 
+    pub fn epoch_stakes_from_slot(&self, slot: Slot) -> Option<&VersionedEpochStakes> {
+        let epoch = self.epoch_schedule().get_epoch(slot);
+        self.epoch_stakes(epoch)
+    }
+
     pub fn epoch_stakes_map(&self) -> &HashMap<Epoch, VersionedEpochStakes> {
         &self.epoch_stakes
     }

--- a/runtime/src/block_component_processor.rs
+++ b/runtime/src/block_component_processor.rs
@@ -205,10 +205,8 @@ impl BlockComponentProcessor {
         cert: &Certificate,
     ) -> Result<(), BlockComponentProcessorError> {
         let slot = cert.cert_type.slot();
-        let epoch = bank.epoch_schedule().get_epoch(slot);
         let epoch_stakes = bank
-            .epoch_stakes_map()
-            .get(&epoch)
+            .epoch_stakes_from_slot(slot)
             .ok_or(BlockComponentProcessorError::GenesisCertificateFailedVerification)?;
         let key_to_rank_map = epoch_stakes.bls_pubkey_to_rank_map();
         let total_stake = epoch_stakes.total_stake();

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -330,14 +330,8 @@ impl ConsensusPoolService {
         votor_events: &mut Vec<VotorEvent>,
         commitment_sender: &Sender<CommitmentAggregationData>,
     ) -> Result<(Option<Slot>, Vec<Arc<Certificate>>), AddVoteError> {
-        let (new_finalized_slot, new_certificates_to_send) = consensus_pool.add_message(
-            root_bank.epoch_schedule(),
-            root_bank.epoch_stakes_map(),
-            root_bank.slot(),
-            my_vote_pubkey,
-            message,
-            votor_events,
-        )?;
+        let (new_finalized_slot, new_certificates_to_send) =
+            consensus_pool.add_message(root_bank, my_vote_pubkey, message, votor_events)?;
         let Some(new_finalized_slot) = new_finalized_slot else {
             return Ok((None, new_certificates_to_send));
         };


### PR DESCRIPTION
#### Problem

Based on discussion in https://github.com/anza-xyz/alpenglow/pull/660/changes#r2676614988, we have a lot of places with similar duplicate code of looking up the epoch stakes and rank map from the bank.


#### Summary of Changes

This PR introduces `Bank::epoch_stakes_from_slot()` and uses it in different places allowing us to eliminate quite a bit of duplicate code.
