### PR TITLE
rewards: fix unused import to fix CI

### DIFF
--- a/runtime/src/validated_reward_certificate.rs
+++ b/runtime/src/validated_reward_certificate.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{bank::Bank, epoch_stakes::BLSPubkeyToRankMap},
+    crate::bank::Bank,
     agave_bls_cert_verify::cert_verify::{verify_base2, Error as BlsCertVerifyError},
     solana_bls_signatures::BlsError,
     solana_clock::Slot,


### PR DESCRIPTION
#### Problem
Looks like #664 broke master:
```
error: unused import: `epoch_stakes::BLSPubkeyToRankMap`
 --> runtime/src/validated_reward_certificate.rs:2:25
  |
2 |     crate::{bank::Bank, epoch_stakes::BLSPubkeyToRankMap},
  |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `-D unused-imports` implied by `-D warnings`
  = help: to override `-D warnings` add `#[allow(unused_imports)]`
```
CI seemed to have passed on #664, might have been an issue where the branch was outdated.

#### Summary of Changes
Remove the unused import