### PR TITLE
repair_handler: add tests and bug fixes

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,6 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
 dev-context-only-utils = [
+    "solana-ledger/dev-context-only-utils",
     "solana-perf/dev-context-only-utils",
     "solana-runtime/dev-context-only-utils",
     "solana-streamer/dev-context-only-utils",

--- a/core/src/repair/repair_handler.rs
+++ b/core/src/repair/repair_handler.rs
@@ -15,7 +15,7 @@ use {
     solana_ledger::{
         ancestor_iterator::{AncestorIterator, AncestorIteratorWithHash},
         blockstore::Blockstore,
-        shred::{ErasureSetId, Nonce},
+        shred::{ErasureSetId, Nonce, DATA_SHREDS_PER_FEC_BLOCK},
     },
     solana_perf::packet::{Packet, PacketBatch, PacketBatchRecycler, PinnedPacketBatch},
     solana_pubkey::Pubkey,
@@ -250,13 +250,13 @@ pub trait RepairHandler {
         let fec_set_root = self
             .blockstore()
             .merkle_root_meta_from_location(ErasureSetId::new(slot, fec_set_index), location)
-            .expect("Unable to fetch merkle root meta")
-            .expect("Slot is full, MerkleRootMeta must exist")
+            .expect("Unable to fetch merkle root meta")?
             .merkle_root()
             .expect("Legacy shreds are gone, merkle root must exist");
+        let proof_index = fec_set_index.checked_div(DATA_SHREDS_PER_FEC_BLOCK as u32)?;
         let fec_set_proof = double_merkle_meta
             .proofs
-            .get(usize::try_from(fec_set_index).ok()?)?
+            .get(usize::try_from(proof_index).ok()?)?
             .clone();
 
         let response = BlockIdRepairResponse::FecSetRoot {
@@ -299,5 +299,285 @@ impl RepairHandlerType {
             self.to_handler(blockstore),
             migration_status,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        rand::Rng,
+        solana_entry::entry::create_ticks,
+        solana_keypair::Keypair,
+        solana_ledger::{
+            blockstore_meta::{BlockLocation, ParentMeta},
+            get_tmp_ledger_path_auto_delete,
+            shred::{ProcessShredsStats, ReedSolomonCache, Shred, Shredder},
+        },
+        solana_perf::packet::PacketBatchRecycler,
+        std::net::{IpAddr, Ipv4Addr, SocketAddr},
+    };
+
+    /// Creates shreds for a slot with both data and coding shreds
+    fn setup_erasure_shreds(
+        slot: Slot,
+        parent_slot: Slot,
+        num_entries: u64,
+    ) -> (Vec<Shred>, Vec<Shred>) {
+        let entries = create_ticks(num_entries, 0, Hash::default());
+        let leader_keypair = Arc::new(Keypair::new());
+        let shredder = Shredder::new(slot, parent_slot, 0, 0).unwrap();
+        let chained_merkle_root = Some(Hash::new_from_array(rand::thread_rng().gen()));
+        let (data_shreds, coding_shreds) = shredder.entries_to_merkle_shreds_for_tests(
+            &leader_keypair,
+            &entries,
+            true, // is_last_in_slot
+            chained_merkle_root,
+            0, // next_shred_index
+            0, // next_code_index
+            &ReedSolomonCache::default(),
+            &mut ProcessShredsStats::default(),
+        );
+
+        (data_shreds, coding_shreds)
+    }
+
+    /// Sets up a blockstore with a complete slot and all necessary metadata
+    fn setup_blockstore_with_complete_slot(
+        slot: Slot,
+        parent_slot: Slot,
+        num_entries: u64,
+    ) -> (Arc<Blockstore>, Hash, Vec<Hash>) {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
+
+        // First, insert the parent slot so the child slot can be marked full
+        let grandparent_slot = parent_slot.saturating_sub(1);
+        let (parent_data_shreds, parent_coding_shreds) =
+            setup_erasure_shreds(parent_slot, grandparent_slot, 10);
+        blockstore
+            .insert_shreds(
+                parent_data_shreds
+                    .into_iter()
+                    .chain(parent_coding_shreds)
+                    .collect::<Vec<_>>(),
+                None,
+                true,
+            )
+            .unwrap();
+
+        // Now create the target slot
+        let (data_shreds, coding_shreds) = setup_erasure_shreds(slot, parent_slot, num_entries);
+
+        // Collect merkle roots for each FEC set
+        let mut fec_set_roots = Vec::new();
+        for shred in data_shreds.iter() {
+            if shred.index() % (DATA_SHREDS_PER_FEC_BLOCK as u32) == 0 {
+                fec_set_roots.push(shred.merkle_root().unwrap());
+            }
+        }
+
+        // Create and insert ParentMeta BEFORE inserting shreds so that
+        // DoubleMerkleMeta can be computed when the slot becomes full
+        let parent_block_id = Hash::new_unique();
+        let parent_meta = ParentMeta {
+            parent_slot,
+            parent_block_id,
+            replay_fec_set_index: 0,
+        };
+        blockstore
+            .put_parent_meta(slot, BlockLocation::Original, &parent_meta)
+            .unwrap();
+
+        // Verify ParentMeta was stored
+        let stored_parent_meta = blockstore
+            .get_parent_meta(slot, BlockLocation::Original)
+            .expect("get_parent_meta should succeed")
+            .expect("ParentMeta should exist after put");
+        assert_eq!(
+            stored_parent_meta.parent_slot, parent_slot,
+            "Stored ParentMeta should match"
+        );
+
+        // Insert shreds - DoubleMerkleMeta will be computed atomically when slot becomes full
+        blockstore
+            .insert_shreds(
+                data_shreds
+                    .into_iter()
+                    .chain(coding_shreds)
+                    .collect::<Vec<_>>(),
+                None,
+                true, // is_trusted
+            )
+            .unwrap();
+
+        // Verify the slot is full
+        let slot_meta = blockstore.meta(slot).unwrap().unwrap();
+        assert!(
+            slot_meta.is_full(),
+            "Slot should be full after inserting all shreds"
+        );
+
+        // Get the double merkle root (computed during shred insertion when slot became full)
+        let block_id = blockstore
+            .get_double_merkle_root(slot, BlockLocation::Original)
+            .expect("DoubleMerkleMeta should exist for full slot with ParentMeta");
+
+        (blockstore, block_id, fec_set_roots)
+    }
+
+    #[test]
+    fn test_run_fec_set_root() {
+        let slot = 1000;
+        let parent_slot = 999;
+        // Use many entries to ensure multiple FEC sets (each FEC set has 32 data shreds)
+        let num_entries = 2000;
+
+        let (blockstore, block_id, fec_set_roots) =
+            setup_blockstore_with_complete_slot(slot, parent_slot, num_entries);
+
+        let handler = StandardRepairHandler::new(blockstore.clone());
+        let recycler = PacketBatchRecycler::default();
+        let from_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080);
+        let nonce = 12345;
+
+        // Verify we have multiple FEC sets
+        assert!(
+            fec_set_roots.len() >= 2,
+            "Should have at least 2 FEC sets for this test, got {}",
+            fec_set_roots.len()
+        );
+
+        // Test each FEC set using the actual fec_set_index (0, 32, 64, ...)
+        for (i, expected_root) in fec_set_roots.iter().enumerate() {
+            let fec_set_index = (i * DATA_SHREDS_PER_FEC_BLOCK) as u32;
+
+            let result = handler.run_fec_set_root(
+                &recycler,
+                &from_addr,
+                slot,
+                block_id,
+                fec_set_index,
+                nonce,
+            );
+
+            assert!(
+                result.is_some(),
+                "run_fec_set_root should succeed for fec_set_index {fec_set_index}"
+            );
+
+            // Deserialize the response and verify
+            let packet_batch = result.unwrap();
+            assert_eq!(packet_batch.len(), 1);
+
+            let packet = packet_batch.iter().next().unwrap();
+            let (response, response_nonce): (BlockIdRepairResponse, Nonce) =
+                bincode::deserialize(packet.data(..packet.meta().size).unwrap()).unwrap();
+
+            assert_eq!(response_nonce, nonce);
+            match response {
+                BlockIdRepairResponse::FecSetRoot {
+                    fec_set_root,
+                    fec_set_proof,
+                } => {
+                    assert_eq!(
+                        fec_set_root, *expected_root,
+                        "FEC set root should match for index {fec_set_index}"
+                    );
+                    assert!(
+                        !fec_set_proof.is_empty(),
+                        "FEC set proof should not be empty"
+                    );
+                }
+                _ => panic!("Expected FecSetRoot response"),
+            }
+        }
+
+        // Test with invalid block_id returns None
+        let invalid_block_id = Hash::new_unique();
+        let result =
+            handler.run_fec_set_root(&recycler, &from_addr, slot, invalid_block_id, 0, nonce);
+        assert!(result.is_none(), "Should return None for invalid block_id");
+
+        // Test with out-of-bounds fec_set_index returns None
+        let invalid_fec_set_index = (fec_set_roots.len() * DATA_SHREDS_PER_FEC_BLOCK) as u32;
+        let result = handler.run_fec_set_root(
+            &recycler,
+            &from_addr,
+            slot,
+            block_id,
+            invalid_fec_set_index,
+            nonce,
+        );
+        assert!(
+            result.is_none(),
+            "Should return None for out-of-bounds fec_set_index"
+        );
+    }
+
+    #[test]
+    fn test_run_parent_fec_set_count() {
+        let slot = 1000;
+        let parent_slot = 999;
+        let num_entries = 2000;
+
+        let (blockstore, block_id, fec_set_roots) =
+            setup_blockstore_with_complete_slot(slot, parent_slot, num_entries);
+
+        let handler = StandardRepairHandler::new(blockstore.clone());
+        let recycler = PacketBatchRecycler::default();
+        let from_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080);
+        let nonce = 12345;
+
+        let result = handler.run_parent_fec_set_count(&recycler, &from_addr, slot, block_id, nonce);
+
+        assert!(result.is_some(), "run_parent_fec_set_count should succeed");
+
+        // Deserialize and verify the response
+        let packet_batch = result.unwrap();
+        assert_eq!(packet_batch.len(), 1);
+
+        let packet = packet_batch.iter().next().unwrap();
+        let (response, response_nonce): (BlockIdRepairResponse, Nonce) =
+            bincode::deserialize(packet.data(..packet.meta().size).unwrap()).unwrap();
+
+        assert_eq!(response_nonce, nonce);
+        match response {
+            BlockIdRepairResponse::ParentFecSetCount {
+                fec_set_count,
+                parent_info: (p_slot, p_block_id),
+                parent_proof,
+            } => {
+                assert_eq!(
+                    fec_set_count,
+                    fec_set_roots.len(),
+                    "FEC set count should match"
+                );
+                assert_eq!(p_slot, parent_slot, "Parent slot should match");
+
+                // Verify parent_block_id matches what we set
+                let parent_meta = blockstore
+                    .get_parent_meta(slot, BlockLocation::Original)
+                    .unwrap()
+                    .unwrap();
+                assert_eq!(
+                    p_block_id, parent_meta.parent_block_id,
+                    "Parent block ID should match"
+                );
+
+                assert!(!parent_proof.is_empty(), "Parent proof should not be empty");
+            }
+            _ => panic!("Expected ParentFecSetCount response"),
+        }
+
+        // Test with invalid block_id returns None
+        let invalid_block_id = Hash::new_unique();
+        let result =
+            handler.run_parent_fec_set_count(&recycler, &from_addr, slot, invalid_block_id, nonce);
+        assert!(result.is_none(), "Should return None for invalid block_id");
+
+        // Test with non-existent slot returns None
+        let result = handler.run_parent_fec_set_count(&recycler, &from_addr, 9999, block_id, nonce);
+        assert!(result.is_none(), "Should return None for non-existent slot");
     }
 }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -658,6 +658,18 @@ impl Blockstore {
         self.parent_meta_cf.get((slot, location))
     }
 
+    /// Sets the ParentMeta for the specified slot and location.
+    /// Only available for testing.
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn put_parent_meta(
+        &self,
+        slot: Slot,
+        location: BlockLocation,
+        parent_meta: &ParentMeta,
+    ) -> Result<()> {
+        self.parent_meta_cf.put((slot, location), parent_meta)
+    }
+
     /// Returns true if the specified slot is full.
     pub fn is_full(&self, slot: Slot) -> bool {
         if let Ok(Some(meta)) = self.meta_cf.get(slot) {


### PR DESCRIPTION
- `fec_set_index` is in shred space, so we need to divide by 32 before accessing the proof
- `fec_set_index` on the request is unverified, do not panic if it's out of range

Added tests