### PR TITLE
blockid: move DMR computation to shred insert

### DIFF
--- a/ledger/src/shred/merkle_tree.rs
+++ b/ledger/src/shred/merkle_tree.rs
@@ -20,7 +20,7 @@ pub(crate) const MERKLE_HASH_PREFIX_NODE: &[u8] = b"\x01SOLANA_MERKLE_SHREDS_NOD
 pub type MerkleProofEntry = [u8; 20];
 
 /// A struct to track a given Merkle tree.
-pub(crate) struct MerkleTree {
+pub struct MerkleTree {
     /// List of all the nodes in the tree.
     /// The constructor ensures that this is not empty.
     /// The last node in the list is the root of the tree.
@@ -34,7 +34,7 @@ impl MerkleTree {
     ///
     /// [`Error::EmptyIterator`] if the function is called with an empty iterator.
     /// [`Error`] if any of the elements in the iterator contains an [`Error`].
-    pub(crate) fn try_new(
+    pub fn try_new(
         shreds: impl ExactSizeIterator<Item = Result<Hash, Error>>,
     ) -> Result<MerkleTree, Error> {
         if shreds.len() == 0 {
@@ -61,7 +61,7 @@ impl MerkleTree {
     }
 
     /// Returns a reference to the root of the tree.
-    pub(crate) fn root(&self) -> &Hash {
+    pub fn root(&self) -> &Hash {
         // constructor ensures that the tree contains at least one node so this unwrap() should be safe.
         self.nodes.last().unwrap()
     }


### PR DESCRIPTION
#### Problem
Currently the DoubleMerkleMeta is only computed and inserted once the bank has finished replay (or in the leader case finished broadcast).
This can cause problems in repair as we use this blockstore column to check if we have the block or we otherwise need to repair it.

#### Summary of Changes
Instead we move this computation up to shred insert. Namely once the block is full (all shreds are inserted) we compute the double merkle root & proofs. Perhaps as an optimization we can defer computing the proofs until we actually need them (when responding to repair requests) in the future.

We do this atomically in the write batch. This guarantees the invariant that any alpenglow block that is fully ingested will have this column populated. 