### PR TITLE
Make `StatusCache` "work" with block_id or block_hash

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4541,7 +4541,7 @@ impl Bank {
 
     pub fn get_signature_status_slot(&self, signature: &Signature) -> Option<(Slot, Result<()>)> {
         let rcache = self.status_cache.read().unwrap();
-        rcache.get_status_any_blockhash(signature, &self.ancestors)
+        rcache.get_status_any_hash(signature, &self.ancestors)
     }
 
     pub fn get_signature_status(&self, signature: &Signature) -> Option<Result<()>> {


### PR DESCRIPTION
#### Problem

As per #486, we need to use block_id when alpenglow is enabled.  `StatusCache` is a fairly generic object that stores various types of hash maps and does not care if the `Hash` key being used is a block_hash or block_id.



#### Summary of Changes

This PR refactors it a bit to use the general term `hash` instead of `blockhash`.
