### PR TITLE
nit: improves documentation

### DIFF
--- a/votor-messages/src/consensus_message.rs
+++ b/votor-messages/src/consensus_message.rs
@@ -10,7 +10,7 @@ use {
 /// The seed used to derive the BLS keypair
 pub const BLS_KEYPAIR_DERIVE_SEED: &[u8; 9] = b"alpenglow";
 
-/// Block, a (slot, hash) tuple
+/// Block, a (slot, block_id) tuple
 pub type Block = (Slot, Hash);
 
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION

Existing documentation is not descriptive.  I believe the Hash here is the block id, so updating the comment.
