### PR TITLE
wip: register new block ids

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2838,10 +2838,13 @@ impl ReplayStage {
                     .unwrap()
                     .highest_super_majority_root(),
             );
+            // XXX
+            let block_id = Hash::new_unique();
             Self::check_and_handle_new_root(
                 &identity_keypair.pubkey(),
                 bank.parent_slot(),
                 new_root,
+                &block_id,
                 bank_forks,
                 progress,
                 blockstore,
@@ -4617,6 +4620,7 @@ impl ReplayStage {
         my_pubkey: &Pubkey,
         parent_slot: Slot,
         new_root: Slot,
+        block_id: &Hash,
         bank_forks: &RwLock<BankForks>,
         progress: &mut ProgressMap,
         blockstore: &Blockstore,
@@ -4633,6 +4637,7 @@ impl ReplayStage {
         root_utils::check_and_handle_new_root(
             parent_slot,
             new_root,
+            block_id,
             snapshot_controller,
             highest_super_majority_root,
             bank_notification_sender,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2941,7 +2941,11 @@ impl Bank {
     /// Register a new recent blockhash in the bank's recent blockhash queue. Called when a bank
     /// reaches its max tick height. Can be called by tests to get new blockhashes for transaction
     /// processing without advancing to a new bank slot.
-    fn register_recent_blockhash(&self, blockhash: &Hash, scheduler: &InstalledSchedulerRwLock) {
+    pub fn register_recent_blockhash(
+        &self,
+        blockhash: &Hash,
+        scheduler: &InstalledSchedulerRwLock,
+    ) {
         // This is needed because recent_blockhash updates necessitate synchronizations for
         // consistent tx check_age handling.
         BankWithScheduler::wait_for_paused_scheduler(self, scheduler);

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -754,7 +754,7 @@ impl EventHandler {
     ) -> Result<(), SetRootError> {
         let bank_forks_r = ctx.bank_forks.read().unwrap();
         let old_root = bank_forks_r.root();
-        let Some(new_root) = finalized_blocks
+        let Some((new_root, block_id)) = finalized_blocks
             .iter()
             .filter_map(|&(slot, block_id)| {
                 let bank = bank_forks_r.get(slot)?;
@@ -762,7 +762,7 @@ impl EventHandler {
                     && vctx.vote_history.voted(slot)
                     && bank.is_frozen()
                     && bank.block_id().is_some_and(|bid| bid == block_id))
-                .then_some(slot)
+                .then_some((slot, block_id))
             })
             .max()
         else {
@@ -773,6 +773,7 @@ impl EventHandler {
         root_utils::set_root(
             my_pubkey,
             new_root,
+            &block_id,
             ctx,
             vctx,
             rctx,

--- a/votor/src/root_utils.rs
+++ b/votor/src/root_utils.rs
@@ -36,6 +36,7 @@ pub(crate) struct RootContext {
 pub(crate) fn set_root(
     my_pubkey: &Pubkey,
     new_root: Slot,
+    block_id: &Hash,
     ctx: &SharedContext,
     vctx: &mut VotingContext,
     rctx: &RootContext,
@@ -52,6 +53,7 @@ pub(crate) fn set_root(
     check_and_handle_new_root(
         new_root,
         new_root,
+        block_id,
         rctx.snapshot_controller.as_deref(),
         Some(new_root),
         &rctx.bank_notification_sender,
@@ -108,6 +110,7 @@ pub(crate) fn set_root(
 pub fn check_and_handle_new_root<CB>(
     parent_slot: Slot,
     new_root: Slot,
+    block_id: &Hash,
     snapshot_controller: Option<&SnapshotController>,
     highest_super_majority_root: Option<Slot>,
     bank_notification_sender: &Option<BankNotificationSenderConfig>,
@@ -128,6 +131,7 @@ where
         .unwrap()
         .get(new_root)
         .expect("Root bank doesn't exist");
+    root_bank.register_recent_blockhash(block_id, &BankWithScheduler::no_scheduler_available());
     let mut rooted_banks = root_bank.parents();
     let oldest_parent = rooted_banks.last().map(|last| last.parent_slot());
     rooted_banks.push(root_bank.clone());


### PR DESCRIPTION
This is a proposal to address #486, on how we could use block ids in various places instead of block hashes with Alpenglow.  