### PR TITLE
Improvements to calculating epoch inflation rewards

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -959,10 +959,15 @@ impl Default for BankTestConfig {
 }
 
 #[derive(Debug)]
-struct PrevEpochInflationRewards {
-    validator_rewards: u64,
-    prev_epoch_duration_in_years: f64,
+/// Data returned from [`calculate_epoch_inflation_rewards`].
+struct EpochInflationRewards {
+    /// Amount of rewards a validator should get if it voted in every slot in the epoch and its stake is equal to the network capitalization i.e. the total supply.
+    validator_rewards_lamports: u64,
+    /// How long a single epoch lasts in years.
+    epoch_duration_in_years: f64,
+    /// The current inflation rate for the validators.
     validator_rate: f64,
+    /// The current inflation rate for the foundation.
     foundation_rate: f64,
 }
 
@@ -1389,6 +1394,7 @@ impl Bank {
             if parent.epoch() < new.epoch() {
                 new.process_new_epoch(
                     parent.epoch(),
+                    parent.capitalization(),
                     parent.slot(),
                     parent.block_height(),
                     reward_calc_tracer,
@@ -1636,6 +1642,7 @@ impl Bank {
         &mut self,
         parent_epoch: Epoch,
         parent_slot: Slot,
+        parent_capitalization: u64,
         parent_height: u64,
         reward_calc_tracer: Option<impl RewardCalcTracer>,
     ) {
@@ -1671,6 +1678,7 @@ impl Bank {
                 reward_calc_tracer,
                 &thread_pool,
                 parent_epoch,
+                parent_capitalization,
                 parent_slot,
                 parent_height,
                 &mut rewards_metrics,
@@ -2346,11 +2354,11 @@ impl Bank {
         });
     }
 
-    pub fn epoch_duration_in_years(&self, prev_epoch: Epoch) -> f64 {
+    pub fn epoch_duration_in_years(&self, epoch: Epoch) -> f64 {
         // period: time that has passed as a fraction of a year, basically the length of
         //  an epoch as a fraction of a year
         //  calculated as: slots_elapsed / (slots / year)
-        self.epoch_schedule().get_slots_in_epoch(prev_epoch) as f64 / self.slots_per_year
+        self.epoch_schedule().get_slots_in_epoch(epoch) as f64 / self.slots_per_year
     }
 
     // Calculates the starting-slot for inflation from the activation slot.
@@ -2391,11 +2399,12 @@ impl Bank {
         num_slots as f64 / self.slots_per_year
     }
 
-    fn calculate_previous_epoch_inflation_rewards(
+    /// For given [`capitalization`] (total_supply in lamports) and [`epoch`], performs various inflation related calculations.
+    fn calculate_epoch_inflation_rewards(
         &self,
-        prev_epoch_capitalization: u64,
-        prev_epoch: Epoch,
-    ) -> PrevEpochInflationRewards {
+        capitalization: u64,
+        epoch: Epoch,
+    ) -> EpochInflationRewards {
         let slot_in_year = self.slot_in_year_for_inflation();
         let (validator_rate, foundation_rate) = {
             let inflation = self.inflation.read().unwrap();
@@ -2405,14 +2414,13 @@ impl Bank {
             )
         };
 
-        let prev_epoch_duration_in_years = self.epoch_duration_in_years(prev_epoch);
-        let validator_rewards = (validator_rate
-            * prev_epoch_capitalization as f64
-            * prev_epoch_duration_in_years) as u64;
+        let epoch_duration_in_years = self.epoch_duration_in_years(epoch);
+        let validator_rewards_lamports =
+            (validator_rate * capitalization as f64 * epoch_duration_in_years) as u64;
 
-        PrevEpochInflationRewards {
-            validator_rewards,
-            prev_epoch_duration_in_years,
+        EpochInflationRewards {
+            validator_rewards_lamports,
+            epoch_duration_in_years,
             validator_rate,
             foundation_rate,
         }

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -248,7 +248,6 @@ pub(super) struct PartitionedRewardsCalculation {
     pub(super) validator_rate: f64,
     pub(super) foundation_rate: f64,
     pub(super) prev_epoch_duration_in_years: f64,
-    pub(super) capitalization: u64,
     point_value: PointValue,
 }
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -819,21 +819,22 @@ where
         - bank2_sysvar_delta();
 
     // this assumes that no new builtins or precompiles were activated in bank1 or bank2
-    let PrevEpochInflationRewards {
-        validator_rewards, ..
-    } = bank2.calculate_previous_epoch_inflation_rewards(bank0.capitalization(), bank0.epoch());
+    let EpochInflationRewards {
+        validator_rewards_lamports,
+        ..
+    } = bank2.calculate_epoch_inflation_rewards(bank0.capitalization(), bank0.epoch());
 
     // verify the stake and vote accounts are the right size
     assert!(
         ((bank2.get_balance(&stake_id) - stake_account.lamports() + bank2.get_balance(&vote_id)
             - vote_account.lamports()) as f64
-            - validator_rewards as f64)
+            - validator_rewards_lamports as f64)
             .abs()
             < 1.0
     );
 
     // verify the rewards are the right size
-    assert!((validator_rewards as f64 - paid_rewards as f64).abs() < 1.0); // rounding, truncating
+    assert!((validator_rewards_lamports as f64 - paid_rewards as f64).abs() < 1.0); // rounding, truncating
 
     // verify validator rewards show up in rewards vectors
     assert_eq!(
@@ -842,7 +843,7 @@ where
             stake_id,
             RewardInfo {
                 reward_type: RewardType::Staking,
-                lamports: validator_rewards as i64,
+                lamports: validator_rewards_lamports as i64,
                 post_balance: bank2.get_balance(&stake_id),
                 commission: Some(0),
             }


### PR DESCRIPTION
#### Problem and summary

- `calculate_rewards_for_partitioning()` assumes that it will be called at the start of the epoch before PER has started.  In particular, it is using `self.capitalization()` to perform the inflation calculations which can change once PER has started.  This makes this function a bit fragile.
  - The PR changes this function to also accept the capitalization to break this assumption.

- `epoch_duration_in_years(prev_epoch)`: `prev_epoch` here is poorly named.  This function doesn't care which epoch it is called with and it will calculate the duration for that epoch.
  - renames `prev_epoch` to `epoch`

- Similarly `calculate_previous_epoch_inflation_rewards()` is poorly named.  It doesn't care which epoch / capitalization it is called for and it will perform the calculations.
  - renames `calculate_previous_epoch_inflation_rewards` to `calculate_epoch_inflation_rewards` and the return struct to `EpochInflationRewards` and also some fields in the in the struct as well.
