### PR TITLE
Fix realpath compatibility on macOS in the CI helper

### DIFF
--- a/ci/_
+++ b/ci/_
@@ -5,7 +5,7 @@
 # |source| me
 #
 
-base_dir=$(realpath --strip "$(dirname "$0")/..")
+base_dir=$(realpath "$(dirname "$0")/..")
 
 _() {
   if [[ $(pwd) = $base_dir ]]; then


### PR DESCRIPTION
#### Problem
The `ci/_` script currently uses `realpath --strip`. The `--strip` flag is a GNU extension and is not supported by the default BSD-based realpath utility found on macOS. This causes CI scripts to fail immediately when run locally on macOS with an "illegal option -- -" error, hindering local development and testing.

#### Summary of Changes
Removed the `--strip` flag from the realpath command in `ci/_`.

#### Benefit
This change makes the CI helper script portable across both Linux (GNU) and macOS (BSD) environments. Developers on macOS can now run CI scripts locally without encountering syntax errors or needing to install GNU coreutils.
