### PR TITLE
Bump `solana-bls-signatures` to `3.0.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7389,9 +7389,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bls-signatures"
-version = "1.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c75573697bbb148afa8209aa3ce228ca0754584c9a8a91e818db0f706ae4fb"
+checksum = "e21cad136370a83c91bbe9348c69a510222d8d70144154ca37edff59df789661"
 dependencies = [
  "base64 0.22.1",
  "blst",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -396,7 +396,7 @@ solana-big-mod-exp = "3.0.0"
 solana-bincode = "3.0.0"
 solana-blake3-hasher = "3.0.0"
 solana-bloom = { path = "bloom", version = "=3.1.0" }
-solana-bls-signatures = { version = "1.0.0", features = ["serde"] }
+solana-bls-signatures = { version = "3.0.0", features = ["serde"] }
 solana-bls12-381 = { path = "curves/bls12-381", version = "=3.1.0" }
 solana-bn254 = "3.0.0"
 solana-borsh = "3.0.0"

--- a/clap-utils/src/input_parsers.rs
+++ b/clap-utils/src/input_parsers.rs
@@ -433,8 +433,8 @@ mod tests {
 
     #[test]
     fn test_bls_pubkeys_of() {
-        let bls_pubkey1: BLSPubkey = BLSKeypair::new().public;
-        let bls_pubkey2: BLSPubkey = BLSKeypair::new().public;
+        let bls_pubkey1: BLSPubkey = BLSKeypair::new().public.into();
+        let bls_pubkey2: BLSPubkey = BLSKeypair::new().public.into();
         let matches = app().get_matches_from(vec![
             "test",
             "--multiple",

--- a/core/src/bls_sigverify/bls_sigverifier.rs
+++ b/core/src/bls_sigverify/bls_sigverifier.rs
@@ -398,7 +398,7 @@ impl BLSSigVerifier {
                     let payload_slice = distinct_payloads[0].as_slice();
                     aggregate_pubkeys[0]
                         .verify_signature(&aggregate_signature, payload_slice)
-                        .unwrap_or(false)
+                        .is_ok()
                 } else {
                     let payload_slices: Vec<&[u8]> =
                         distinct_payloads.iter().map(|p| p.as_slice()).collect();
@@ -408,10 +408,10 @@ impl BLSSigVerifier {
 
                     SignatureProjective::par_verify_distinct_aggregated(
                         &aggregate_pubkeys_affine,
-                        &aggregate_signature.into(),
+                        &aggregate_signature,
                         &payload_slices,
                     )
-                    .unwrap_or(false)
+                    .is_ok()
                 }
             } else {
                 false
@@ -441,7 +441,7 @@ impl BLSSigVerifier {
                 if vote_to_verify
                     .bls_pubkey
                     .verify_signature(&vote_to_verify.vote_message.signature, payload.as_slice())
-                    .unwrap_or(false)
+                    .is_ok()
                 {
                     true
                 } else {

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -1337,7 +1337,7 @@ mod tests {
 
         let mut genesis_config = GenesisConfig::default();
 
-        let bls_pubkey: BLSPubkey = BLSKeypair::new().public;
+        let bls_pubkey: BLSPubkey = BLSKeypair::new().public.into();
         let validator_accounts = vec![
             StakedValidatorAccountInfo {
                 identity_account: solana_pubkey::new_rand().to_string(),

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -531,7 +531,7 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
         ("bls_pubkey", matches) => {
             let keypair = get_keypair_from_matches(matches, config, &mut wallet_manager)?;
             let bls_keypair = BLSKeypair::derive_from_signer(&keypair, BLS_KEYPAIR_DERIVE_SEED)?;
-            let bls_pubkey: BLSPubkey = bls_keypair.public;
+            let bls_pubkey: BLSPubkey = bls_keypair.public.into();
 
             if matches.try_contains_id("outfile")? {
                 let outfile = matches.get_one::<String>("outfile").unwrap();

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -247,7 +247,6 @@ impl VersionedEpochStakes {
 pub(crate) mod tests {
     use {
         super::*,
-        crate::genesis_utils::bls_pubkey_to_compressed_bytes,
         solana_account::AccountSharedData,
         solana_bls_signatures::keypair::Keypair as BLSKeypair,
         solana_vote::vote_account::VoteAccount,
@@ -282,7 +281,7 @@ pub(crate) mod tests {
                                 &node_id,
                                 &authorized_voter,
                                 &node_id,
-                                Some(bls_pubkey_to_compressed_bytes(&BLSKeypair::new().public)),
+                                Some(BLSKeypair::new().public.to_bytes_compressed()),
                                 0,
                                 100,
                             )

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -154,7 +154,7 @@ pub fn create_genesis_config_with_vote_accounts_and_cluster_type(
         &validator_pubkey,
         &voting_keypairs[0].borrow().vote_keypair.pubkey(),
         &voting_keypairs[0].borrow().stake_keypair.pubkey(),
-        Some(&voting_keypairs[0].borrow().bls_keypair.public),
+        Some(&voting_keypairs[0].borrow().bls_keypair.public.into()),
         stakes[0],
         VALIDATOR_LAMPORTS,
         FeeRateGovernor::new(0, 0), // most tests can't handle transaction fees
@@ -184,7 +184,7 @@ pub fn create_genesis_config_with_vote_accounts_and_cluster_type(
                 &node_pubkey,
                 &vote_pubkey,
                 &vote_pubkey,
-                Some(bls_pubkey_to_compressed_bytes(&bls_pubkey)),
+                Some(bls_pubkey.to_bytes_compressed()),
                 0,
                 *stake,
             )
@@ -281,7 +281,7 @@ pub fn create_genesis_config_with_leader_with_mint_keypair(
 
     let bls_keypair =
         BLSKeypair::derive_from_signer(&voting_keypair, BLS_KEYPAIR_DERIVE_SEED).unwrap();
-    let bls_pubkey: BLSPubkey = bls_keypair.public;
+    let bls_pubkey: BLSPubkey = bls_keypair.public.into();
     let genesis_config = create_genesis_config_with_leader_ex(
         mint_lamports,
         &mint_keypair.pubkey(),

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -531,7 +531,6 @@ fn refresh_vote_accounts(
 pub(crate) mod tests {
     use {
         super::*,
-        crate::genesis_utils::bls_pubkey_to_compressed_bytes,
         rayon::ThreadPoolBuilder,
         solana_account::WritableAccount,
         solana_bls_signatures::keypair::Keypair as BLSKeypair,
@@ -556,7 +555,7 @@ pub(crate) mod tests {
                 &solana_pubkey::new_rand(),
                 &vote_pubkey,
                 &vote_pubkey,
-                Some(bls_pubkey_to_compressed_bytes(&bls_keypair.public)),
+                Some(bls_keypair.public.to_bytes_compressed()),
                 0,
                 1,
             )

--- a/runtime/src/validated_reward_certificate.rs
+++ b/runtime/src/validated_reward_certificate.rs
@@ -149,7 +149,7 @@ mod tests {
         },
         bitvec::vec::BitVec,
         solana_bls_signatures::{
-            Keypair as BlsKeypair, Signature as BLSSignature,
+            Keypair as BlsKeypair, Pubkey as BLSPubkey, Signature as BLSSignature,
             SignatureCompressed as BlsSignatureCompressed, SignatureProjective,
         },
         solana_hash::Hash,
@@ -197,7 +197,7 @@ mod tests {
             .collect::<Vec<_>>();
         let keypair_map = validator_keypairs
             .iter()
-            .map(|k| (k.bls_keypair.public, k.bls_keypair.clone()))
+            .map(|k| (BLSPubkey::from(k.bls_keypair.public), k.bls_keypair.clone()))
             .collect::<HashMap<_, _>>();
         let genesis = create_genesis_config_with_alpenglow_vote_accounts(
             1_000_000_000,

--- a/vote/src/vote_account.rs
+++ b/vote/src/vote_account.rs
@@ -212,8 +212,7 @@ impl VoteAccount {
 
     #[cfg(feature = "dev-context-only-utils")]
     pub fn new_random_alpenglow() -> VoteAccount {
-        let bls_pubkey_compressed: BLSPubkeyCompressed =
-            BLSKeypair::new().public.try_into().unwrap();
+        let bls_pubkey_compressed: BLSPubkeyCompressed = BLSKeypair::new().public.into();
         let bls_pubkey_compressed_buffer = bincode::serialize(&bls_pubkey_compressed).unwrap();
         let vote_state = VoteStateV4 {
             node_pubkey: Pubkey::new_unique(),
@@ -587,8 +586,7 @@ mod tests {
             commission: rng.gen(),
         };
         let vote_state_versions = if is_alpenglow {
-            let bls_pubkey_compressed: BLSPubkeyCompressed =
-                BLSKeypair::new().public.try_into().unwrap();
+            let bls_pubkey_compressed: BLSPubkeyCompressed = BLSKeypair::new().public.into();
             let bls_pubkey_compressed_buffer = bincode::serialize(&bls_pubkey_compressed).unwrap();
             VoteStateVersions::new_v4(VoteStateV4 {
                 node_pubkey: vote_init.node_pubkey,

--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -2238,7 +2238,7 @@ mod tests {
         let bls_keypair =
             BLSKeypair::derive_from_signer(validator_vote_keypair, BLS_KEYPAIR_DERIVE_SEED)
                 .unwrap();
-        let bls_pubkey: BLSPubkey = bls_keypair.public;
+        let bls_pubkey: BLSPubkey = bls_keypair.public.into();
 
         let signed_message = bincode::serialize(&vote).unwrap();
 

--- a/votor/src/consensus_pool/certificate_builder.rs
+++ b/votor/src/consensus_pool/certificate_builder.rs
@@ -520,7 +520,7 @@ mod tests {
             aggregate_pubkey.verify_signature(&cert.signature, &serialized_vote);
 
         assert!(
-            verification_result.unwrap_or(false),
+            verification_result.is_ok(),
             "BLS aggregate signature verification failed for base2 encoded certificate"
         );
     }

--- a/votor/src/consensus_rewards/entry.rs
+++ b/votor/src/consensus_rewards/entry.rs
@@ -120,7 +120,7 @@ impl Entry {
 mod tests {
     use {
         super::*,
-        solana_bls_signatures::Keypair as BlsKeypair,
+        solana_bls_signatures::{Keypair as BlsKeypair, Pubkey as BlsPubkey},
         solana_epoch_schedule::EpochSchedule,
         solana_hash::Hash,
         solana_pubkey::Pubkey,
@@ -161,7 +161,7 @@ mod tests {
             .collect::<Vec<_>>();
         let keypair_map = validator_keypairs
             .iter()
-            .map(|k| (k.bls_keypair.public, k.bls_keypair.clone()))
+            .map(|k| (BlsPubkey::from(k.bls_keypair.public), k.bls_keypair.clone()))
             .collect::<HashMap<_, _>>();
         let mut genesis_config = create_genesis_config_with_alpenglow_vote_accounts(
             1_000_000_000,

--- a/votor/src/voting_utils.rs
+++ b/votor/src/voting_utils.rs
@@ -217,7 +217,7 @@ pub fn generate_vote_tx(
 
     let bls_keypair = get_or_insert_bls_keypair(derived_bls_keypairs, &authorized_voter_keypair)
         .unwrap_or_else(|e| panic!("Failed to derive my own BLS keypair: {e:?}"));
-    let my_bls_pubkey: BLSPubkey = bls_keypair.public;
+    let my_bls_pubkey: BLSPubkey = bls_keypair.public.into();
     if my_bls_pubkey != bls_pubkey_in_vote_account {
         panic!(
             "Vote account bls_pubkey mismatch: {bls_pubkey_in_vote_account:?} (expected: \


### PR DESCRIPTION
#### Problem

`solana-bls-signatures` in agave was upgraded in v3 (https://github.com/anza-xyz/agave/pull/9967).

The main change in API
- signature verification functions now return `Result<(), Err>` instead of `Result<bool, Err>`
- (BLS) `Keypair` now holds (BLS) `PubkeyAffine` instead of (BLS) `Pubkey`, so when we want to extract `Pubkey`, we need to add an extra `.into()`.

#### Summary of Changes

Upgrading to v3 in alpenglow.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
