### PR TITLE
backport: pr feedback from migration upstream #10063

### DIFF
--- a/core/src/admin_rpc_post_init.rs
+++ b/core/src/admin_rpc_post_init.rs
@@ -29,8 +29,10 @@ pub enum KeyUpdaterType {
     Forward,
     /// For the RPC service
     RpcService,
-    /// Tpu alpenglow key updater
-    TpuAlpenglow,
+    /// BLS all-to-all streamer key updater
+    Bls,
+    /// BLS all-to-all connection cache key updater
+    BlsConnectionCache,
 }
 
 /// Responsible for managing the updaters for identity key change

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -373,7 +373,7 @@ impl ClusterInfoVoteListener {
                 Ok(confirmed_slots) => {
                     let confirmed_slots = confirmed_slots
                         .into_iter()
-                        .filter(|(slot, _)| {
+                        .filter(|(slot, _hash)| {
                             migration_status.should_report_commitment_or_root(*slot)
                         })
                         .collect();

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -173,6 +173,9 @@ pub(crate) struct ComputedBankState {
     pub voted_stakes: VotedStakes,
     pub total_stake: Stake,
     pub fork_stake: Stake,
+
+    /// For Alpenglow migration - a block in `N` is super OC when there is at least
+    /// 82% of stake voting for `N` in `N + 1`
     pub parent_is_super_oc: bool,
     // Tree of intervals of lockouts of the form [slot, slot + slot.lockout],
     // keyed by end of the range
@@ -456,8 +459,7 @@ impl Tower {
                     true,
                 );
 
-                // For migration - a block is super OC there are 82% of votes in the direct child
-                // on the very next slot
+                // For migration - a block is super OC there are 82% of votes for slot N in N + 1
                 if last_landed_voted_slot == parent_slot {
                     super_oc_stake += voted_stake;
                 }
@@ -507,6 +509,7 @@ impl Tower {
             total_stake += voted_stake;
         }
 
+        debug_assert!(total_stake > 0);
         let parent_is_super_oc = bank_slot == parent_slot + 1
             && Fraction::new(super_oc_stake, NonZeroU64::new(total_stake).unwrap())
                 > GENESIS_VOTE_THRESHOLD;

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1099,10 +1099,18 @@ pub mod formalize_loaded_transaction_data_size {
 }
 
 pub mod alpenglow {
-    use {solana_keypair::Keypair, std::sync::LazyLock};
+    #[cfg(feature = "dev-context-only-utils")]
+    use {
+        solana_keypair::{Keypair, Signer},
+        std::sync::LazyLock,
+    };
 
+    // Used to activate alpenglow in local-cluster tests without exposing the actual feature's private key
+    #[cfg(feature = "dev-context-only-utils")]
     pub static TEST_KEYPAIR: LazyLock<Keypair> = LazyLock::new(|| {
-        Keypair::from_base58_string("2Vzd6oTWU4RtM5UmsSyBH3tAhPSi1sKqMeMC8bF1jzHHLBMRhEWtrfmBV4EmwQbGSwkunk5Wy67kXNAL1ZL1xQhR")
+        let keypair = Keypair::from_base58_string("2Vzd6oTWU4RtM5UmsSyBH3tAhPSi1sKqMeMC8bF1jzHHLBMRhEWtrfmBV4EmwQbGSwkunk5Wy67kXNAL1ZL1xQhR");
+        assert_eq!(keypair.pubkey(), super::alpenglow::id());
+        keypair
     });
 
     #[cfg(not(feature = "dev-context-only-utils"))]

--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -385,13 +385,52 @@ pub fn check_min_slot_is_rooted(
     }
 }
 
+fn check_for_new_slots_with_commitment(
+    num_new_slots: usize,
+    contact_infos: &[ContactInfo],
+    connection_cache: &Arc<ConnectionCache>,
+    test_name: &str,
+    commitment: CommitmentConfig,
+) {
+    let mut slots = vec![HashSet::new(); contact_infos.len()];
+    let mut done = false;
+    let mut last_print = Instant::now();
+    let loop_start = Instant::now();
+    let loop_timeout = Duration::from_secs(180);
+    let mut num_slots_map = HashMap::new();
+    while !done {
+        assert!(loop_start.elapsed() < loop_timeout);
+
+        for (i, ingress_node) in contact_infos.iter().enumerate() {
+            let client = new_tpu_quic_client(ingress_node, connection_cache.clone()).unwrap();
+            let slot = client
+                .rpc_client()
+                .get_slot_with_commitment(commitment)
+                .unwrap_or(0);
+            slots[i].insert(slot);
+            num_slots_map.insert(*ingress_node.pubkey(), slots[i].len());
+            let num_slots = slots.iter().map(|r| r.len()).min().unwrap();
+            done = num_slots >= num_new_slots;
+            if done || last_print.elapsed().as_secs() > 3 {
+                info!(
+                    "{test_name} waiting for {num_new_slots} new {} slots .. observed: \
+                     {num_slots_map:?}",
+                    commitment.commitment,
+                );
+                last_print = Instant::now();
+            }
+        }
+        sleep(Duration::from_millis(clock::DEFAULT_MS_PER_SLOT / 2));
+    }
+}
+
 pub fn check_for_new_roots(
     num_new_roots: usize,
     contact_infos: &[ContactInfo],
     connection_cache: &Arc<ConnectionCache>,
     test_name: &str,
 ) {
-    check_for_new_commitment_slots(
+    check_for_new_slots_with_commitment(
         num_new_roots,
         contact_infos,
         connection_cache,
@@ -400,16 +439,13 @@ pub fn check_for_new_roots(
     );
 }
 
-/// For alpenglow, CommitmentConfig::processed() refers to the current voting loop slot,
-/// so this is more accurate for determining that each node is voting when stake distribution is
-/// uneven
 pub fn check_for_new_processed(
     num_new_processed: usize,
     contact_infos: &[ContactInfo],
     connection_cache: &Arc<ConnectionCache>,
     test_name: &str,
 ) {
-    check_for_new_commitment_slots(
+    check_for_new_slots_with_commitment(
         num_new_processed,
         contact_infos,
         connection_cache,
@@ -418,6 +454,8 @@ pub fn check_for_new_processed(
     );
 }
 
+/// Start a QUIC streamer to listen for votes and certificates.
+/// Returns a cancellation token, the server thread handle, and a receiver for packet batches.
 pub fn start_quic_streamer_to_listen_for_votes_and_certs(
     vote_listener_socket: std::net::UdpSocket,
     validator_keys: &[Arc<Keypair>],
@@ -453,44 +491,6 @@ pub fn start_quic_streamer_to_listen_for_votes_and_certs(
     )
     .unwrap();
     (cancel, quic_server_thread, receiver)
-}
-
-fn check_for_new_commitment_slots(
-    num_new_slots: usize,
-    contact_infos: &[ContactInfo],
-    connection_cache: &Arc<ConnectionCache>,
-    test_name: &str,
-    commitment: CommitmentConfig,
-) {
-    let mut slots = vec![HashSet::new(); contact_infos.len()];
-    let mut done = false;
-    let mut last_print = Instant::now();
-    let loop_start = Instant::now();
-    let loop_timeout = Duration::from_secs(180);
-    let mut num_slots_map = HashMap::new();
-    while !done {
-        assert!(loop_start.elapsed() < loop_timeout);
-
-        for (i, ingress_node) in contact_infos.iter().enumerate() {
-            let client = new_tpu_quic_client(ingress_node, connection_cache.clone()).unwrap();
-            let root_slot = client
-                .rpc_client()
-                .get_slot_with_commitment(commitment)
-                .unwrap_or(0);
-            slots[i].insert(root_slot);
-            num_slots_map.insert(*ingress_node.pubkey(), slots[i].len());
-            let num_slots = slots.iter().map(|r| r.len()).min().unwrap();
-            done = num_slots >= num_new_slots;
-            if done || last_print.elapsed().as_secs() > 3 {
-                info!(
-                    "{} waiting for {} new {:?} slots.. observed: {:?}",
-                    test_name, num_new_slots, commitment.commitment, num_slots_map
-                );
-                last_print = Instant::now();
-            }
-        }
-        sleep(Duration::from_millis(clock::DEFAULT_MS_PER_SLOT / 2));
-    }
 }
 
 pub fn check_no_new_roots(

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -163,12 +163,11 @@ fn test_alpenglow_nodes_basic(num_nodes: usize, num_offline_nodes: usize) {
     let validator_keys = (0..num_nodes)
         .map(|i| (Arc::new(keypair_from_seed(&[i as u8; 32]).unwrap()), true))
         .collect::<Vec<_>>();
+    let mut validator_config = ValidatorConfig::default_for_test();
+    validator_config.wait_for_supermajority = Some(0);
 
     let mut config = ClusterConfig {
-        validator_configs: make_identical_validator_configs(
-            &ValidatorConfig::default_for_test(),
-            num_nodes,
-        ),
+        validator_configs: make_identical_validator_configs(&validator_config, num_nodes),
         validator_keys: Some(validator_keys.clone()),
         node_stakes: vec![DEFAULT_NODE_STAKE; num_nodes],
         ticks_per_slot: 8,
@@ -212,28 +211,21 @@ fn test_alpenglow_nodes_basic(num_nodes: usize, num_offline_nodes: usize) {
 
 #[test]
 #[serial]
-fn test_1_node_alpenglow() {
+fn test_alpenglow_1() {
     const NUM_NODES: usize = 1;
     test_alpenglow_nodes_basic(NUM_NODES, 0);
 }
 
 #[test]
 #[serial]
-fn test_2_nodes_alpenglow() {
-    const NUM_NODES: usize = 2;
-    test_alpenglow_nodes_basic(NUM_NODES, 0);
-}
-
-#[test]
-#[serial]
-fn test_4_nodes_alpenglow() {
+fn test_alpenglow_4() {
     const NUM_NODES: usize = 4;
     test_alpenglow_nodes_basic(NUM_NODES, 0);
 }
 
 #[test]
 #[serial]
-fn test_4_nodes_with_1_offline_alpenglow() {
+fn test_alpenglow_4_1_offline() {
     const NUM_NODES: usize = 4;
     const NUM_OFFLINE: usize = 1;
     test_alpenglow_nodes_basic(NUM_NODES, NUM_OFFLINE);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -216,7 +216,9 @@ pub const SECONDS_PER_YEAR: f64 = 365.25 * 24.0 * 60.0 * 60.0;
 
 pub const MAX_LEADER_SCHEDULE_STAKES: Epoch = 5;
 
-const MAX_ALPENGLOW_VOTE_ACCOUNTS: usize = 2000;
+/// This will be guaranteed through the VAT rules,
+/// only the top 2000 validators by stake will be present in vote account structures.
+pub const MAX_ALPENGLOW_VOTE_ACCOUNTS: usize = 2000;
 
 // Minimum balance for an identity account to be considered for Alpenglow VAT.
 #[cfg(not(feature = "dev-context-only-utils"))]

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -603,7 +603,7 @@ impl<T> From<tokio::sync::mpsc::error::SendError<T>> for Error {
 pub mod test {
     use {
         super::*,
-        crossbeam_channel::unbounded,
+        crossbeam_channel::{bounded, unbounded},
         rand::Rng,
         solana_entry::{entry::create_ticks, entry_marker::EntryMarker},
         solana_gossip::{cluster_info::ClusterInfo, node::Node},
@@ -776,7 +776,8 @@ pub mod test {
         let bank_forks = BankForks::new_rw_arc(bank);
         let bank = bank_forks.read().unwrap().root_bank();
 
-        let (votor_event_sender, _) = unbounded();
+        // Create votor event channel for test
+        let (votor_event_sender, _votor_event_receiver) = bounded(100);
 
         // Start up the broadcast stage
         let broadcast_service = BroadcastStage::new(

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -1561,7 +1561,8 @@ mod tests {
                     KeyUpdaterType::TpuVote,
                     KeyUpdaterType::Forward,
                     KeyUpdaterType::RpcService,
-                    KeyUpdaterType::TpuAlpenglow,
+                    KeyUpdaterType::Bls,
+                    KeyUpdaterType::BlsConnectionCache,
                 ])
             );
             let mut io = MetaIoHandler::default();

--- a/votor/src/consensus_metrics.rs
+++ b/votor/src/consensus_metrics.rs
@@ -16,6 +16,17 @@ use {
     },
 };
 
+/// Even at 10 events per slot, this supports 1000 slots in flight
+/// With 2000 active validators, we can't have more than:
+/// - 1 Notarize vote
+/// - 3 Notarize-fallback votes
+/// - 1 Skip-fallback vote
+/// - 1 Finalize vote
+///
+/// Per validator, resulting in 12k vote events.
+/// We overprovision this channel at 15k total events.
+pub const MAX_IN_FLIGHT_CONSENSUS_EVENTS: usize = 15_000;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ConsensusMetricsEvent {
     /// A vote was received from the node with `id`.


### PR DESCRIPTION
#### Problem
https://github.com/anza-xyz/agave/pull/10063 upstreamed turning on votor in agave.
There were some changes made based on pr feedback
Backport these changes to minimize the 2 way divergence between the codebases.

#### Summary of Changes
The changes are mostly cosmetic, apart from hooking up the connection cache to the key notifier.

Note: upstream has moved on to replace the quic streamer with the simple qos server. Since we don't have that here, i've left the quic setup unchanged.