### PR TITLE
audit: ignore RUSTSEC-2026-0009

### DIFF
--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -59,6 +59,16 @@ cargo_audit_ignores=(
   # URL:       https://rustsec.org/advisories/RUSTSEC-2024-0376
   # Solution:  Upgrade to >=0.12.3
   --ignore RUSTSEC-2024-0376
+
+  #   Crate:     time
+  # Version:   0.3.9
+  # Title:     Denial of Service via Stack Exhaustion
+  # Date:      2026-02-05
+  # ID:        RUSTSEC-2026-0009
+  # URL:       https://rustsec.org/advisories/RUSTSEC-2026-0009
+  # Severity:  6.8 (medium)
+  # Solution:  Upgrade to >=0.3.47
+  --ignore RUSTSEC-2026-0009
 )
 scripts/cargo-for-all-lock-files.sh audit "${cargo_audit_ignores[@]}" | $dep_tree_filter
 # we want the `cargo audit` exit code, not `$dep_tree_filter`'s


### PR DESCRIPTION
#### Problem
time crate needs to be updated for recent sec advisory but is not trivial to do in alpenglow

#### Summary of Changes
Ignore for now we'll upstream soon and it will be fixed on agave

