### PR TITLE
flaky: ignore test_proactive_connection_close_detection

### DIFF
--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -753,6 +753,7 @@ async fn test_update_identity() {
 // Test that connection close events are detected immediately via
 // connection.closed() monitoring, not only when send operations fail.
 #[tokio::test]
+#[ignore]
 async fn test_proactive_connection_close_detection() {
     let SpawnTestServerResult {
         join_handle: server_handle,


### PR DESCRIPTION
#### Problem
This test is quite flaky and we don't use this crate in alpenglow

#### Summary of Changes
Ignore for now can monitor if it gives us problems when upstreaming