### PR TITLE
block_id_repair: only accept data shreds

### DIFF
--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -44,7 +44,7 @@ use {
         shred::{
             self,
             merkle_tree::{self, SIZE_OF_MERKLE_PROOF_ENTRY},
-            Nonce, ShredFetchStats, DATA_SHREDS_PER_FEC_BLOCK, MAX_FEC_SETS_PER_SLOT,
+            Nonce, ShredFetchStats, ShredType, DATA_SHREDS_PER_FEC_BLOCK, MAX_FEC_SETS_PER_SLOT,
             SIZE_OF_NONCE,
         },
     },
@@ -185,6 +185,7 @@ impl RequestResponse for ShredRepairType {
                 ..
             } => {
                 shred_slot == *slot
+                    && matches!(shred::layout::get_shred_type(shred), Ok(ShredType::Data))
                     && shred::layout::get_index(shred) == Some(*index)
                     && get_merkle_root(shred) == Some(*fec_set_merkle_root)
             }

--- a/ledger/src/shred/wire.rs
+++ b/ledger/src/shred/wire.rs
@@ -80,7 +80,7 @@ pub(super) fn get_shred_variant(shred: &[u8]) -> Result<ShredVariant, Error> {
 }
 
 #[inline]
-pub(super) fn get_shred_type(shred: &[u8]) -> Result<ShredType, Error> {
+pub fn get_shred_type(shred: &[u8]) -> Result<ShredType, Error> {
     get_shred_variant(shred).map(ShredType::from)
 }
 


### PR DESCRIPTION
#### Problem
As part of alpenglow repair, we request a specific slot , shred index w/ an expected merkle root for a block id.
The acceptance criteria was too lenient allowing for a coding shred to be received as a response, even though honest nodes will only send data shreds.

This causes problems downstream, as the alternate blockstore columns only expects data shreds.

#### Summary of Changes
Tighten the filter
