### PR TITLE
fix audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6281,7 +6281,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.6",
+ "rustls-webpki 0.103.10",
  "subtle",
  "zeroize",
 ]
@@ -6331,7 +6331,7 @@ dependencies = [
  "rustls 0.23.34",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.6",
+ "rustls-webpki 0.103.10",
  "security-framework 3.2.0",
  "security-framework-sys",
  "webpki-root-certs",
@@ -6356,9 +6356,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.6"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -12634,9 +12634,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",

--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -69,6 +69,17 @@ cargo_audit_ignores=(
   # Severity:  6.8 (medium)
   # Solution:  Upgrade to >=0.3.47
   --ignore RUSTSEC-2026-0009
+  
+  # Crate:     rustls-webpki
+  # Version:   0.101.7
+  # Title:     CRLs not considered authorative by Distribution Point due to faulty matching logic
+  # Date:      2026-03-20
+  # ID:        RUSTSEC-2026-0049
+  # URL:       https://rustsec.org/advisories/RUSTSEC-2026-0049
+  # Solution:  Upgrade to >=0.103.10
+  # Dependency tree:
+  # rustls-webpki 0.101.7
+  --ignore RUSTSEC-2026-0049
 )
 scripts/cargo-for-all-lock-files.sh audit "${cargo_audit_ignores[@]}" | $dep_tree_filter
 # we want the `cargo audit` exit code, not `$dep_tree_filter`'s


### PR DESCRIPTION
#### Problem
CI is broken

#### Summary of Changes
upgrade tar and rustls-webpki 0.103.6 and ignore rustls-webpki 0.101.7 audit (blocked behind rpc pubsub which is pinned to v3.1 in this repo)
