### PR TITLE
Backports removal of `EpochInflationRewards`

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -969,20 +969,6 @@ impl Default for BankTestConfig {
     }
 }
 
-/// Data returned from [`Bank::calculate_epoch_inflation_rewards()`].
-pub(crate) struct EpochInflationRewards {
-    /// Amount of rewards a validator should get if it voted in every slot in
-    /// the epoch and its stake is equal to the network capitalization i.e.
-    /// the total supply.
-    pub(crate) validator_rewards_lamports: u64,
-    /// How long a single epoch lasts in years.
-    pub(crate) epoch_duration_in_years: f64,
-    /// The current inflation rate for the validators.
-    pub(crate) validator_rate: f64,
-    /// The current inflation rate for the foundation.
-    pub(crate) foundation_rate: f64,
-}
-
 #[derive(Debug, Default, PartialEq)]
 pub struct ProcessedTransactionCounts {
     pub processed_transactions_count: u64,
@@ -2426,31 +2412,17 @@ impl Bank {
         num_slots as f64 / self.slots_per_year
     }
 
-    /// For a given [`capitalization`] (total_supply in lamports) and [`epoch`], calculates various inflation related info.
+    /// For a given `capitalization` (total_supply in lamports) and `epoch`, returns the
+    /// `epoch inflation rewards` in lamports.
     pub(crate) fn calculate_epoch_inflation_rewards(
         &self,
         capitalization: u64,
         epoch: Epoch,
-    ) -> EpochInflationRewards {
+    ) -> u64 {
         let slot_in_year = self.slot_in_year_for_inflation();
-        let (validator_rate, foundation_rate) = {
-            let inflation = self.inflation.read().unwrap();
-            (
-                (*inflation).validator(slot_in_year),
-                (*inflation).foundation(slot_in_year),
-            )
-        };
-
+        let validator_rate = self.inflation.read().unwrap().validator(slot_in_year);
         let epoch_duration_in_years = self.epoch_duration_in_years(epoch);
-        let validator_rewards_lamports =
-            (validator_rate * capitalization as f64 * epoch_duration_in_years) as u64;
-
-        EpochInflationRewards {
-            validator_rewards_lamports,
-            epoch_duration_in_years,
-            validator_rate,
-            foundation_rate,
-        }
+        (validator_rate * capitalization as f64 * epoch_duration_in_years) as u64
     }
 
     fn filter_stake_delegations<'a>(

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -8,8 +8,8 @@ use {
     },
     crate::{
         bank::{
-            null_tracer, EpochInflationRewards, RewardCalcTracer, RewardCalculationEvent,
-            RewardsMetrics, VoteReward, VoteRewards,
+            null_tracer, RewardCalcTracer, RewardCalculationEvent, RewardsMetrics, VoteReward,
+            VoteRewards,
         },
         inflation_rewards::{
             points::{calculate_points, PointValue},
@@ -192,9 +192,6 @@ impl Bank {
         let PartitionedRewardsCalculation {
             vote_account_rewards,
             stake_rewards,
-            validator_rate,
-            foundation_rate,
-            prev_epoch_duration_in_years,
             capitalization,
             point_value,
         } = rewards_calculation.as_ref();
@@ -236,13 +233,6 @@ impl Bank {
             "epoch_rewards",
             ("slot", self.slot, i64),
             ("epoch", prev_epoch, i64),
-            ("validator_rate", *validator_rate, f64),
-            ("foundation_rate", *foundation_rate, f64),
-            (
-                "epoch_duration_in_years",
-                *prev_epoch_duration_in_years,
-                f64
-            ),
             ("validator_rewards", total_vote_rewards, i64),
             ("active_stake", active_stake, i64),
             ("pre_capitalization", *capitalization, i64),
@@ -285,12 +275,8 @@ impl Bank {
         metrics: &mut RewardsMetrics,
     ) -> PartitionedRewardsCalculation {
         let capitalization = self.capitalization();
-        let EpochInflationRewards {
-            validator_rewards_lamports,
-            epoch_duration_in_years,
-            validator_rate,
-            foundation_rate,
-        } = self.calculate_epoch_inflation_rewards(capitalization, prev_epoch);
+        let validator_rewards_lamports =
+            self.calculate_epoch_inflation_rewards(capitalization, prev_epoch);
 
         let CalculateValidatorRewardsResult {
             vote_rewards_accounts: vote_account_rewards,
@@ -314,9 +300,6 @@ impl Bank {
         PartitionedRewardsCalculation {
             vote_account_rewards,
             stake_rewards,
-            validator_rate,
-            foundation_rate,
-            prev_epoch_duration_in_years: epoch_duration_in_years,
             capitalization,
             point_value,
         }

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -243,12 +243,9 @@ pub(super) struct EpochRewardCalculateParamInfo<'a> {
 /// side effects.
 #[derive(Debug)]
 pub(super) struct PartitionedRewardsCalculation {
-    pub(super) vote_account_rewards: VoteRewardsAccounts,
-    pub(super) stake_rewards: StakeRewardCalculation,
-    pub(super) validator_rate: f64,
-    pub(super) foundation_rate: f64,
-    pub(super) prev_epoch_duration_in_years: f64,
-    pub(super) capitalization: u64,
+    vote_account_rewards: VoteRewardsAccounts,
+    stake_rewards: StakeRewardCalculation,
+    capitalization: u64,
     point_value: PointValue,
 }
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -820,10 +820,8 @@ where
         - EpochInflationAccountState::rent_needed_for_account(&bank2);
 
     // this assumes that no new builtins or precompiles were activated in bank1 or bank2
-    let EpochInflationRewards {
-        validator_rewards_lamports,
-        ..
-    } = bank2.calculate_epoch_inflation_rewards(bank0.capitalization(), bank0.epoch());
+    let validator_rewards_lamports =
+        bank2.calculate_epoch_inflation_rewards(bank0.capitalization(), bank0.epoch());
 
     // verify the stake and vote accounts are the right size
     assert!(

--- a/runtime/src/block_component_processor/vote_reward.rs
+++ b/runtime/src/block_component_processor/vote_reward.rs
@@ -346,7 +346,6 @@ mod tests {
     use {
         super::*,
         crate::{
-            bank::EpochInflationRewards,
             genesis_utils::{
                 create_genesis_config_with_alpenglow_vote_accounts, ValidatorVoteKeypairs,
             },
@@ -410,10 +409,8 @@ mod tests {
         let circulating_supply = 566_000_000 * LAMPORTS_PER_SOL;
 
         let bank = Bank::new_for_tests(&GenesisConfig::default());
-        let EpochInflationRewards {
-            validator_rewards_lamports,
-            ..
-        } = bank.calculate_epoch_inflation_rewards(circulating_supply, 1);
+        let validator_rewards_lamports =
+            bank.calculate_epoch_inflation_rewards(circulating_supply, 1);
 
         let epoch_state = EpochInflationState {
             slots_per_epoch: bank.epoch_schedule.slots_per_epoch,
@@ -455,13 +452,8 @@ mod tests {
         total_stake: u64,
         stake_voted: u64,
     ) -> u64 {
-        let EpochInflationRewards {
-            validator_rewards_lamports: epoch_inflation,
-            epoch_duration_in_years: _,
-            validator_rate: _,
-            foundation_rate: _,
-        } = bank.calculate_epoch_inflation_rewards(prev_bank.capitalization(), prev_bank.epoch());
-
+        let epoch_inflation =
+            bank.calculate_epoch_inflation_rewards(prev_bank.capitalization(), prev_bank.epoch());
         let numerator = epoch_inflation as u128 * stake_voted as u128;
         let denominator = bank.epoch_schedule.slots_per_epoch as u128 * total_stake as u128;
         let reward: u64 = (numerator / denominator).try_into().unwrap();

--- a/runtime/src/block_component_processor/vote_reward/epoch_inflation_account_state.rs
+++ b/runtime/src/block_component_processor/vote_reward/epoch_inflation_account_state.rs
@@ -1,5 +1,5 @@
 use {
-    crate::bank::{Bank, EpochInflationRewards},
+    crate::bank::Bank,
     solana_account::{Account, AccountSharedData},
     solana_clock::Epoch,
     solana_genesis_config::GenesisConfig,
@@ -39,17 +39,12 @@ impl EpochInflationState {
         prev_epoch_capitalization: u64,
         additional_validator_rewards: u64,
     ) -> Self {
-        let EpochInflationRewards {
-            validator_rewards_lamports,
-            epoch_duration_in_years: _,
-            validator_rate: _,
-            foundation_rate: _,
-        } = bank.calculate_epoch_inflation_rewards(
+        let max_possible_validator_reward = bank.calculate_epoch_inflation_rewards(
             prev_epoch_capitalization + additional_validator_rewards,
             prev_epoch,
         );
         EpochInflationState {
-            max_possible_validator_reward: validator_rewards_lamports,
+            max_possible_validator_reward,
             slots_per_epoch: bank.epoch_schedule.slots_per_epoch,
             epoch: bank.epoch(),
         }


### PR DESCRIPTION
I want to back port changes to the vote reward account state and need this PR first.