### PR TITLE
drop ag-blocking label as consensus-team is the main one

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ repository_
 
 The link below lists issues found during Alpenglow's development and review. They can point you to areas worth investigating:
 
-[Alpenglow related issues on Agave](https://github.com/anza-xyz/agave/issues?q=is%3Aissue+label%3Ablocking-ag+label%3Aconsensus-team)
+[Alpenglow related issues on Agave](https://github.com/anza-xyz/agave/issues?q=is%3Aissue+label%3Aconsensus-team)
 
 ## Get notified
 


### PR DESCRIPTION
Requiring both labels was too narrow and hid some interesting issues, so this drops `blocking-ag` and keeps just `consensus-team` for known issues section
